### PR TITLE
Added top right title when using the function plotyplot

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -744,6 +744,13 @@ class Visdom(object):
             # numpy arrays to Python lists and several other edge cases.
             figure_dict = json.loads(
                 json.dumps(figure, cls=plotly.utils.PlotlyJSONEncoder))
+
+            # If opts title is not added, the title is not added to the top right of the window.
+            # We add the paramater to opts manually if it exists.
+            opts = dict()
+            if 'title' in figure_dict['layout']:
+                opts['title'] = figure_dict['layout']['title']
+
             return self._send({
                 'data': figure_dict['data'],
                 'layout': figure_dict['layout'],


### PR DESCRIPTION
Added title when using the function plotyplot

## Description
Manually add the layout['title'] to opts.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When plotlyplot is used the title doesn't appear in top right corner of window. This solves the issue.
Otherwise the filtering doesn't work.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, experiments you ran to see how -->
<!--- your change affects existing areas of the code and their behaviors, etc. -->
<!--- One method of testing is to run the `demo.py` script from the examples -->
<!--- both on your branch and a clean branch and ensure that none of the functionality -->
<!--- appears different. Be sure to install from source when testing. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
