### PR TITLE
add flag to make server accessible only from localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ The following options can be provided to the server:
 7. `-enable_login` : Flag to setup authentication for the sever, requiring a username and password to login.
 8. `-force_new_cookie` : Flag to reset the secure cookie used by the server, invalidating current login cookies.
 Requires `-enable_login`.
+9. `-bind_local` : Flag to make the server accessible only from localhost.
 
 When `-enable_login` flag is provided, the server asks user to input credentials using terminal prompt. Alternatively,
 you can setup `VISDOM_USE_ENV_CREDENTIALS` env variable, and then provide your username and password via

--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -1772,12 +1772,15 @@ def download_scripts(proxies=None, install_dir=None):
 def start_server(port=DEFAULT_PORT, hostname=DEFAULT_HOSTNAME,
                  base_url=DEFAULT_BASE_URL, env_path=DEFAULT_ENV_PATH,
                  readonly=False, print_func=None, user_credential=None,
-                 use_frontend_client_polling=False):
+                 use_frontend_client_polling=False, bind_local=False):
     print("It's Alive!")
     app = Application(port=port, base_url=base_url, env_path=env_path,
                       readonly=readonly, user_credential=user_credential,
                       use_frontend_client_polling=use_frontend_client_polling)
-    app.listen(port, max_buffer_size=1024 ** 3)
+    if bind_local:
+        app.listen(port, max_buffer_size=1024 ** 3, address='127.0.0.1')
+    else:
+        app.listen(port, max_buffer_size=1024 ** 3)
     logging.info("Application Started")
 
     if "HOSTNAME" in os.environ and hostname == DEFAULT_HOSTNAME:
@@ -1824,6 +1827,10 @@ def main(print_func=None):
                         action='store_true',
                         help='Have the frontend communicate via polling '
                              'rather than over websockets.')
+    parser.add_argument('-bind_local', default=False,
+                        action='store_true',
+                        help='Make server only accessible only from '
+                             'localhost.')
     FLAGS = parser.parse_args()
 
     # Process base_url
@@ -1899,7 +1906,8 @@ def main(print_func=None):
     start_server(port=FLAGS.port, hostname=FLAGS.hostname, base_url=base_url,
                  env_path=FLAGS.env_path, readonly=FLAGS.readonly,
                  print_func=print_func, user_credential=user_credential,
-                 use_frontend_client_polling=FLAGS.use_frontend_client_polling)
+                 use_frontend_client_polling=FLAGS.use_frontend_client_polling,
+                 bind_local=FLAGS.bind_local)
 
 
 def download_scripts_and_run():


### PR DESCRIPTION
## Description
In this PR, I added a flag to the server CLI allowing to bind to localhost, i.e. `127.0.0.1`, denying external requests.

## Motivation and Context
In several situations, it might be sensible to have the server only accessible from localhost instead of the whole network, especially when one does not control the firewall of a machine. Granularly regulated external access is still feasible via SSH port forwarding.
Enabling the new option does not have an impact on the overall ease-of-use in many use cases but significantly reduces the potential attack surface.

## How Has This Been Tested?
This PR has been tested by locally running `server.py` in both configurations and by checking that the command line arguments parser still works correctly.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
