### PR TITLE
Solved issue #749

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,21 @@ The following `opts` are supported:
 - Tensor of size `N x 3`: Red, Green and Blue intensities per data point. 0,0,0 = black, 255,255,255 = white
 - Tensor of size `K` and `K x 3`: Instead of having a unique color per data point, the same color is shared for all points of a particular label.
 
+#### vis.sunburst
+This function draws a sunburst chart. It takes two inputs: `parents` and `labels` array.
+values from `parents` array is used as parents object, like it define above which sector 
+should the this sector shown. values from `labels` array is used to define sector's label 
+or you can say name. keep in mind that lenght of array `parents` and `labels` should be 
+equal. There is a third array that you can pass to which is `value`, it is use to show 
+a value on hovering over a sector, it is optional argument, but if you are passing it then
+keep in mind lenght of `values` should be equal to `parents` or `labels`.
+
+Following `opts` are currently supported:
+- `opts.font_size`    : define font size of label (`int`)
+- `opts.font_color`    : define font color of label (`string`)
+- `opts.opacity`    : define opacity of chart (`float`)
+- `opts.line_width`    : define distance between two sectors and sector to its parents (`int`)
+
 
 #### vis.line
 This function draws a line plot. It takes as input an `N` or `NxM` tensor

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -2130,31 +2130,41 @@ class Visdom(object):
 
 
     @pytorch_wrap
-    def sunburst(self, X,parents,labels, win=None, env=None, opts=None):
+    def sunburst(self, labels, parents, values=None, win=None, env=None, opts=None):
         opts = {} if opts is None else opts
         _title2str(opts)
         _assert_opts(opts)
-        
+
         font_size=opts.get("size")
         font_color=opts.get("font_color")
         opacity=opts.get("opacity")
         line_width=opts.get("marker_width")
 
-        X = np.squeeze(X)
-        assert X.ndim == 1, 'X should be one-dimensional'
-        assert np.all(np.greater_equal(X, 0)), \
-            'X cannot contain negative values'
-
-
-        data = [{
-            'values': X.tolist(),
-            'labels': labels.tolist(),
-            "parents":parents.tolist(),
-            "outsidetextfont":{"size":font_size,"color":font_color},
-            "leaf":{"opacity":opacity},
-            "marker":{"line":{"width":line_width}},
-            'type': 'sunburst',
-        }]
+        assert len(parents.tolist())==len(labels.tolist()), "length of parents and labels should be equal"
+        
+        if(values!=None):
+            values = np.squeeze(values)
+            assert values.ndim == 1, 'values should be one-dimensional'
+            assert len(parents.tolist())==len(values.tolist()), "length of values should be equal to lenght of labels and parents"
+            data = [{
+                'values': values.tolist(),
+                'labels': labels.tolist(),
+                "parents":parents.tolist(),
+                "outsidetextfont":{"size":font_size,"color":font_color},
+                "leaf":{"opacity":opacity},
+                "marker":{"line":{"width":line_width}},
+                'type': 'sunburst',
+            }]
+        
+        else:
+            data = [{
+                'labels': labels.tolist(),
+                "parents":parents.tolist(),
+                "outsidetextfont":{"size":font_size,"color":font_color},
+                "leaf":{"opacity":opacity},
+                "marker":{"line":{"width":line_width}},
+                'type': 'sunburst',
+            }]            
         return self._send({
             'data': data,
             'win': win,

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -405,7 +405,8 @@ class Visdom(object):
             'base_url should not end with / as it is appended automatically'
 
         self.ipv6 = ipv6
-        self.env = env              # default env
+        self.env = env      
+        self.env_list={f'{env}'}      # default env
         self.send = send
         self.event_handlers = {}  # Haven't registered any events
         self.socket_alive = False
@@ -664,8 +665,13 @@ class Visdom(object):
         created with a random name. If `create=False`, `win=None` indicates the
         operation should be applied to all windows.
         """
+
         if msg.get('eid', None) is None:
             msg['eid'] = self.env
+            self.env_list.add(self.env)
+
+        if msg.get('eid', None) is not None:
+            self.env_list.add(msg['eid'])
 
         # TODO investigate send use cases, then deprecate
         if not self.send:
@@ -796,7 +802,7 @@ class Visdom(object):
         This function returns a list of all of the env names that are currently
         in the server.
         """
-        return json.loads(self._send({}, endpoint='env_state', quiet=True))
+        return list(self.env_list)
 
     def win_exists(self, win, env=None):
         """

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -2142,29 +2142,22 @@ class Visdom(object):
 
         assert len(parents.tolist())==len(labels.tolist()), "length of parents and labels should be equal"
         
-        if(values!=None):
+        data_dict=[{
+                'labels': labels.tolist(),
+                "parents":parents.tolist(),
+                "outsidetextfont":{"size":font_size,"color":font_color},
+                "leaf":{"opacity":opacity},
+                "marker":{"line":{"width":line_width}},
+                'type': 'sunburst',
+                }]
+        if values is not None:
             values = np.squeeze(values)
             assert values.ndim == 1, 'values should be one-dimensional'
             assert len(parents.tolist())==len(values.tolist()), "length of values should be equal to lenght of labels and parents"
-            data = [{
-                'values': values.tolist(),
-                'labels': labels.tolist(),
-                "parents":parents.tolist(),
-                "outsidetextfont":{"size":font_size,"color":font_color},
-                "leaf":{"opacity":opacity},
-                "marker":{"line":{"width":line_width}},
-                'type': 'sunburst',
-            }]
-        
-        else:
-            data = [{
-                'labels': labels.tolist(),
-                "parents":parents.tolist(),
-                "outsidetextfont":{"size":font_size,"color":font_color},
-                "leaf":{"opacity":opacity},
-                "marker":{"line":{"width":line_width}},
-                'type': 'sunburst',
-            }]            
+
+            data_dict[0]['values']=values.tolist()
+
+        data=data_dict          
         return self._send({
             'data': data,
             'win': win,

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -2128,6 +2128,42 @@ class Visdom(object):
 
         return self.scatter(X=data, Y=labels, opts=opts, win=win, env=env)
 
+
+    @pytorch_wrap
+    def sunburst(self, X,parents,labels, win=None, env=None, opts=None):
+        opts = {} if opts is None else opts
+        _title2str(opts)
+        _assert_opts(opts)
+        
+        font_size=opts.get("size")
+        font_color=opts.get("font_color")
+        opacity=opts.get("opacity")
+        line_width=opts.get("marker_width")
+
+        X = np.squeeze(X)
+        assert X.ndim == 1, 'X should be one-dimensional'
+        assert np.all(np.greater_equal(X, 0)), \
+            'X cannot contain negative values'
+
+
+        data = [{
+            'values': X.tolist(),
+            'labels': labels.tolist(),
+            "parents":parents.tolist(),
+            "outsidetextfont":{"size":font_size,"color":font_color},
+            "leaf":{"opacity":opacity},
+            "marker":{"line":{"width":line_width}},
+            'type': 'sunburst',
+        }]
+        return self._send({
+            'data': data,
+            'win': win,
+            'eid': env,
+            'layout': _opts2layout(opts),
+            'opts': opts,
+        })
+
+
     @pytorch_wrap
     def pie(self, X, win=None, env=None, opts=None):
         """


### PR DESCRIPTION
I simply look into server.py gather_envs function and found out that this function is exactly what is needed to be added so I created a copy of that function in __init__.py and return a list from that function.
## Description
I added a function called get_all_env, which is similar to server.py's gather_envs functions, it simply return the name of all envs in list format. In get_all_env function I returned a sorted list which return name of all env.
## Motivation and Context
It solves issue #749 

## How Has This Been Tested?
I simply create a script that was reproducing issue(that script is told in issue I mentioned) :
`from visdom import Visdom

#  instantiate the window class 
```
vis = Visdom(offline=True, log_to_filename="./log.visdom")
print(vis.get_env_list())`

```
And output for this:
`
{'env list': "['main', 'main12', 'main13', 'main15', 'main2', 'main3', 'main6', 'myown']"}
`
