### PR TITLE
Tried again to solve issue #749

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -665,7 +665,6 @@ class Visdom(object):
         created with a random name. If `create=False`, `win=None` indicates the
         operation should be applied to all windows.
         """
-
         if msg.get('eid', None) is None:
             msg['eid'] = self.env
             self.env_list.add(self.env)
@@ -798,17 +797,14 @@ class Visdom(object):
         }, endpoint='win_exists', quiet=True)
 
     def get_env_list(self):
-
         """
         This function returns a list of all of the env names that are currently
         in the server.
         """
         if self.offline:        
             return list(self.env_list)
-
         else:
             return json.loads(self._send({}, endpoint='env_state', quiet=True))
-
 
     def win_exists(self, win, env=None):
         """
@@ -1502,13 +1498,10 @@ class Visdom(object):
             if update == 'append':
                 if win is None:
                     update = None
-
                 elif not self.offline:
-
                     exists = self.win_exists(win, env)
                     if exists is False:
                         update = None
-
             # case when X is 1 dimensional and corresponding values on y-axis
             # are passed in parameter Y
             if name:

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -405,7 +405,8 @@ class Visdom(object):
             'base_url should not end with / as it is appended automatically'
 
         self.ipv6 = ipv6
-        self.env = env              # default env
+        self.env = env      
+        self.env_list={f'{env}'}      # default env
         self.send = send
         self.event_handlers = {}  # Haven't registered any events
         self.socket_alive = False
@@ -664,8 +665,13 @@ class Visdom(object):
         created with a random name. If `create=False`, `win=None` indicates the
         operation should be applied to all windows.
         """
+
         if msg.get('eid', None) is None:
             msg['eid'] = self.env
+            self.env_list.add(self.env)
+
+        if msg.get('eid', None) is not None:
+            self.env_list.add(msg['eid'])
 
         # TODO investigate send use cases, then deprecate
         if not self.send:
@@ -792,11 +798,17 @@ class Visdom(object):
         }, endpoint='win_exists', quiet=True)
 
     def get_env_list(self):
+
         """
         This function returns a list of all of the env names that are currently
         in the server.
         """
-        return json.loads(self._send({}, endpoint='env_state', quiet=True))
+        if self.offline:        
+            return list(self.env_list)
+
+        else:
+            return json.loads(self._send({}, endpoint='env_state', quiet=True))
+
 
     def win_exists(self, win, env=None):
         """
@@ -1444,8 +1456,7 @@ class Visdom(object):
         return self._send(data_to_send, endpoint='update')
 
     @pytorch_wrap
-    def scatter(self, X, Y=None, win=None, env=None, opts=None, update=None,
-                name=None):
+    def scatter(self, X, Y=None, win=None, env=None, opts=None, update=None,name=None):
         """
         This function draws a 2D or 3D scatter plot. It takes in an `Nx2` or
         `Nx3` tensor `X` that specifies the locations of the `N` points in the
@@ -1491,7 +1502,9 @@ class Visdom(object):
             if update == 'append':
                 if win is None:
                     update = None
+
                 elif not self.offline:
+
                     exists = self.win_exists(win, env)
                     if exists is False:
                         update = None


### PR DESCRIPTION
I simply get some help and get guidance from @JackUrb and work on this.
## Description
I append the set of env_list on every time _send() is creating a env and by default `main` env is added to set.
## Motivation and Context
It solves issue #749 

## How Has This Been Tested?
I simply create a script that was reproducing issue(that script is told in issue I mentioned) :
`from visdom import Visdom

#  instantiate the window class 
```
vis = Visdom(offline=True, log_to_filename="./log.visdom")
print(vis.get_env_list())`

```
And output for this:
`
['main']
`
