### PR TITLE
Added missing -eager_data_loading flag to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ The following options can be provided to the server:
 8. `-force_new_cookie` : Flag to reset the secure cookie used by the server, invalidating current login cookies.
 Requires `-enable_login`.
 9. `-bind_local` : Flag to make the server accessible only from localhost.
+10. `-eager_data_loading` : By default visdom loads environments lazily upon user request. Setting this flag lets visdom pre-fetch all environments upon startup.
 
 When `-enable_login` flag is provided, the server asks user to input credentials using terminal prompt. Alternatively,
 you can setup `VISDOM_USE_ENV_CREDENTIALS` env variable, and then provide your username and password via


### PR DESCRIPTION
## Description
Just a short follow-up to #832, where I've overlooked one place in the documentation that lists all cli flags.
In this PR I've added the missing `-eager_data_loading` flag to README.md.

## Types of changes
- [x] Documentation adaption
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
