### PR TITLE
Apply webpack best Practice for better Development

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "prettier": "1.19.1",
     "react-select": "^2.4.4",
     "webpack": "^4.41.0",
-    "webpack-cli": "^3.3.9"
+    "webpack-cli": "^3.3.9",
+    "webpack-merge": "^5.8.0"
   },
   "scripts": {
     "dev": "webpack --watch --progress --colors",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,8 @@
     "webpack-merge": "^5.8.0"
   },
   "scripts": {
-    "dev": "webpack --watch --progress --colors",
-    "build": "webpack -p",
-    "buckbuild": "$_ ./node_modules/webpack/bin/webpack.js -p",
+    "dev": "webpack --watch --progress --colors --config webpack.dev.js",
+    "build": "webpack -p --config webpack.prod.js",
     "lint": "eslint js/."
   },
   "dependencies": {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2017-present, The Visdom Authors
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+var webpack = require('webpack');
+var path = require('path');
+
+module.exports = {
+  entry: ['./js/main.js'],
+  output: {
+    path: path.join(__dirname, './'),
+    filename: 'py/visdom/static/js/main.js',
+  },
+  node: {
+    net: 'empty',
+    dns: 'empty',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /(node_modules|bower_components)/,
+        loader: 'babel-loader',
+        options: {
+          presets: ['es2015', 'react'],
+          plugins: ['transform-class-properties'],
+        },
+      },
+      {
+        test: /\.css$/,
+        loaders: ['style-loader', 'css-loader'],
+      },
+    ],
+  },
+  plugins: [new webpack.BannerPlugin('@generated')],
+};

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2017-present, The Visdom Authors
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+const { merge } = require('webpack-merge');
+const common = require('./webpack.common.js');
+
+module.exports = merge(common, {
+  mode: 'development',
+  devtool: 'inline-source-map',
+  devServer: {
+    static: './dist',
+  },
+});

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -12,4 +12,5 @@ const common = require('./webpack.common.js');
 
 module.exports = merge(common, {
   mode: 'production',
+  devtool: 'source-map',
 });

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright 2017-present, The Visdom Authors
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+const { merge } = require('webpack-merge');
+const common = require('./webpack.common.js');
+
+module.exports = merge(common, {
+  mode: 'production',
+});


### PR DESCRIPTION
## Motivation & Description
The current `webpack.config.js` does not enable source maps by default, making it rather hard to debug the JavaScript code.
I took this opportunity to enable source maps by also applying the [current "best practice" for webpack](https://webpack.js.org/guides/production/).

**Note**:
I have removed the `npm buckbuild` script from `package.json` as it appears nowhere else in the project and is just an alias for `npm build`

## How Has This Been Tested?
I used it already for debugging. Functionality-wise it should not alter anything besides source maps in the browser.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
  -> Technically the binary differs due to source maps added. I was unsure if I shall also commit the new compiled file.
 
**PS**: In case you are interested in a release-bot that also compiles the files accordingly after merging a PR, I can offer some simple github actions/workflows that could tackle that.
