### PR TITLE
Fix Bugs in UI due to update of Multilevel-Arrays

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -375,6 +375,9 @@ class App extends React.Component {
       if (newPane.height)
         currLayout.h = Math.ceil(this.p2h(newPane.height + 14));
       if (newPane.content && newPane.content.caption) currLayout.h += 1;
+      this.state.consistent_pane_copy[newPane.id] = JSON.parse(
+        JSON.stringify(newPane)
+      ); //Deep Copy
     }
   };
 


### PR DESCRIPTION
## Description
This PR solves a pretty nasty bug related to unintentional interlocked/shared internal data structures occurring in the UI during updates of already existing windows.

## Motivation and Context
I've encountered this bug during working on #834. As far as I can tell, this bug appears only due to multi-level arrays not being deep-copied upon ui-update requests.




## How Has This Been Tested?
Consider the following code snippet that creates and updates 4 `vis.heatmap` plots.
```python
w, h = 3, 3
def init_test():
    return viz.heatmap(
        X=np.outer(np.arange(1, w), np.arange(1, h)),
        opts=dict(
            colormap='Electric',
        )
    )

# test 1 (top left)
win = init_test()
viz.heatmap(
    X=np.outer(np.arange(w, w+1), np.arange(1, h)),
    win=win,
    update='appendRow',
    opts=dict(
        colormap='Electric',
    )
)

# test 2 (top right)
win = init_test()
viz.heatmap(
    X=np.outer(np.arange(w, w+1), np.arange(1, h)),
    win=win,
    update='appendRow',
    opts=dict(
        colormap='Electric',
    )
)
viz.heatmap(
    X=np.outer(np.arange(1, w+1), np.arange(h, h+1)),
    win=win,
    update='appendColumn',
    opts=dict(
        colormap='Electric',
        xmin=0,
        xmax=10
    )
)

# test3 (bottom left)
win = init_test()
viz.heatmap(
    X=np.outer(np.arange(1, w), np.arange(h, h+1)),
    win=win,
    update='appendColumn',
    opts=dict(
        colormap='Electric',
    )
)

# test4 (bottom right)
win = init_test()
viz.heatmap(
    X=np.outer(np.arange(1, w), np.arange(h, h+1)),
    win=win,
    update='appendColumn',
    opts=dict(
        colormap='Electric',
    )
)
viz.heatmap(
    X=np.outer(np.arange(w, w+1), np.arange(1, h+1)),
    win=win,
    update='appendRow',
    opts=dict(
        colormap='Electric',
        xmin=0,
        xmax=10
    )
)
```

Its result of the second plot (**test 2**, shown in the top right corner of the following image) adds an additional row. (Inspecting the incoming commands reveals), that the *server* indeed sends the right window & diff objects. The error is solely due to the update structure inside the *client*.)
![Screenshot 2022-03-02 at 19-37-25 visdom](https://user-images.githubusercontent.com/19650074/156426522-cdff3846-44fb-409a-b6dd-c9ff23b10aca.png)


With the change introduced in this PR, the bug disappears:
![Screenshot 2022-03-02 at 19-24-06 visdom](https://user-images.githubusercontent.com/19650074/156426914-a24be863-69cc-43c3-849d-7aaeb4d1fa5c.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] For JavaScript changes, I have re-generated the minified JavaScript code.
