### PR TITLE
Fix Relative Env Path Errors

### DIFF
--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -86,10 +86,9 @@ def get_rand_id():
 def ensure_dir_exists(path):
     """Make sure the parent dir exists for path so we can write a file."""
     try:
-        os.makedirs(os.path.dirname(path))
+        os.makedirs(os.path.dirname(os.path.abspath(path)))
     except OSError as e1:
         assert e1.errno == 17  # errno.EEXIST
-        pass
 
 
 def get_path(filename):


### PR DESCRIPTION
## Description
Just a small one, fixing #568 & thus enabling to start the visdom server locally, i.e. by using
```sh
visdom -env_path .
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
