### PR TITLE
update .gitignore to match current static file downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,9 @@ setup.cfg
 py/visdom/static/fonts/
 py/visdom/static/css/
 py/visdom/static/js/*.min.js
-py/visdom/static/js/mathjax-MathJax.js
+py/visdom/static/js/*.js
+py/visdom/static/js/*.js.map
+py/visdom/static/js/mathjax/
 py/visdom/static/js/sjcl.js
 py/visdom/static/version.built
 __pycache__/


### PR DESCRIPTION
## Description
This tiny PR updates the `.gitignore` file to include all downloaded files.

## Motivation and Context
Visdom downloads most of the static files during initialization of the server.
Currently, this introduces new files unknown to git.
```
> git status
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	py/visdom/static/js/d3-selection-multi.v1.js
	py/visdom/static/js/layout-bin-packer.js.map
	py/visdom/static/js/mathjax/
	py/visdom/static/js/saveSvgAsPng.js
```

## How Has This Been Tested?
- Nuke git working tree
- Start visdom server & shut down when it shows `It's Alive`
- run `git status`


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
