### PR TITLE
Custom Machine- & Project-specific Styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,6 +755,15 @@ This function takes the contents of a visdom log and replays them to the current
 Arguments:
 - `log_filename`: log file to replay the contents of.
 
+## Customizing Visdom
+The user config directory for visdom is
+- `~/.config/visdom` for Linux
+- `~/Library/Preferences/visdom` for OSX
+- `%APPDATA%/visdom` for Windows
+
+By placing a `style.css` in you user config directory, visdom will serve the customized css file along with the default style-file.
+In addition, it is also possible to create a project-specific file; just place the file `style.css` in your `env_path`.
+
 ## License
 visdom is Apache 2.0 licensed, as found in the LICENSE file.
 

--- a/py/visdom/static/index.html
+++ b/py/visdom/static/index.html
@@ -62,6 +62,7 @@ LICENSE file in the root directory of this source tree.
     </script>
     <script src={{ static_url("js/main.js") }}></script>
     <link rel="stylesheet" href={{ static_url("css/style.css") }}>
+    <link rel="stylesheet" href={{ static_url("../user/style.css") }}>
     <!-- Added Script for NetworkPane -->
     <link rel="stylesheet" href={{ static_url("css/network.css") }}>
 


### PR DESCRIPTION
## Description
This PR adds the possibility to style visdom on a per-user or per-project fashion.

**In more detail**:
- the style files are loaded during the server initialization to keep load-times low
- for windows & osx the phat changes to their platform-specific config paths

## Motivation and Context
In my case, I use visdom on multiple machines, sometimes even in multiple `env_paths` at the same time.
Specifying visually seperating the machines & projects can help to find more quickly what I was looking for.

## How Has This Been Tested?
- create user specific css `~/.config/visdom/style.css` & adapt
- create env-path specific `style.css` & adapt

## Screenshots (if appropriate):
![2022-03-08-090919_1618x792_scrot](https://user-images.githubusercontent.com/19650074/157194021-ae32be6e-dda6-483b-9626-057a7d367c66.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
