### PR TITLE
Action to build js files automatically

### DIFF
--- a/.github/workflows/update-js-build-files.yml
+++ b/.github/workflows/update-js-build-files.yml
@@ -1,0 +1,29 @@
+name: Update Static JS Files
+
+on:
+  push:
+    paths:
+        - 'js/**'
+
+jobs:
+  update-static-js-files:
+    runs-on: ubuntu-latest
+    name: "Update Static JS-Files"
+    steps:
+      - uses: actions/checkout@v3
+        # > if the push needs to trigger other workflows, use a repo scoped Personal Acces Token
+        # see: https://stackoverflow.com/questions/57921401/push-to-origin-from-github-action/58393457#58393457
+        # with:
+        #   token: ${{ secrets.PAT }}
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - run: npm install
+      - run: npm run build
+      - run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git add -f py/visdom/static/js/main.js py/visdom/static/js/main.js.map
+          git commit -m "update static/js files"
+          git push
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,9 +94,15 @@ We actively welcome your pull requests.
 8. If you haven't already, complete the Contributor License Agreement ("CLA").
 
 ## Contributing to the UI
-The UI is built with [React](https://facebook.github.io/react/). This means that `js/` needs to be compiled. This can be done with `yarn` or `npm`.
-To clarify an inconsistency, Panes in the UI are the containers for the
+The UI is built with [React](https://facebook.github.io/react/). For testing,
+this means that `js/` needs to be compiled. This can be done with `yarn` or
+`npm`. To clarify an inconsistency, Panes in the UI are the containers for the
 'windows' referred to by the Python and Lua APIs.
+For the Pull-Request, please let the Github-Action "Update Static JS Files" compile
+the file to ensure a consistent build. The Github-Action is triggered for
+changed JS files on any branch that you create. It automatically builds and
+then commits the resulting `main.js` and `main.js.map` files to the respective
+branch.
 
 #### yarn
 You can find instructions for install `yarn` [here](https://yarnpkg.com/lang/en/docs/install/).

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -29,4 +29,3 @@
 - [ ] My code follows the code style of this project.
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
-- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.


### PR DESCRIPTION
## Description
This PR moves the requirement to commit build files from the contributor to a dedicated github action.

## Motivation and Context
The goal of this PR is to ensure consistency across builds on the one hand, and to increase security of the deployment on the other hand.

## How Has This Been Tested?
See the action result in [my own test branch](https://github.com/da-h/visdom/actions/runs/2014654689)

## Notes
The new action triggers on any pushes of the `js/**` files. Alternatively, it would be reasonable to either
- trigger on pushes onto `master` only
- trigger on closing of merge requests (I see no direct possibility to trigger on "merged" merge requests)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] For JavaScript changes, I have re-generated the minified JavaScript code.
