### PR TITLE
Fix demo.py by correcting an argument-assert of vis.heatmap

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -1746,7 +1746,7 @@ class Visdom(object):
         - `opts.nancolor`: if not None, color for plotting nan
                            (`string`; default = `None`)
         """
-        validUpdateValues = [None, 'reset', 'remove', 'appendRow', 'appendColumn', 'prependRow', 'prependColumn']
+        validUpdateValues = [None, 'replace', 'remove', 'appendRow', 'appendColumn', 'prependRow', 'prependColumn']
         assert update in validUpdateValues,\
                 "update needs to take one of the following values: %s" % ", ".join(\
                 "'%s'" % str(s) if s is not None else "None" for s in validUpdateValues)


### PR DESCRIPTION
## Description
This is just a small bugfix in `demo.py`.

In #834, i have added the `update` flag for histograms. However, I also introduced an error in `demo.py`, because I have added a wrong argument check right before pushing the feature. :facepalm: 
This PR solves the issue by replacing the check for `"reset"` with the correct value `"replace"`.

*A side note*: this (`replace`) is also specified in the documentation and matches the naming in `vis.line`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
