### PR TITLE
Let update-js-build-files push only to master

### DIFF
--- a/.github/workflows/update-js-build-files.yml
+++ b/.github/workflows/update-js-build-files.yml
@@ -4,6 +4,8 @@ on:
   push:
     paths:
         - 'js/**'
+    branches:
+        - master
 
 jobs:
   update-static-js-files:


### PR DESCRIPTION
## Description
This PR improves the visibility of the (cypress) tests in pull-requests. (See discussion in #849)

## Motivation and Context
The goal is show the PR-creator & the reviewer directly if and which tests passed or failed. Currently, the result is a bit hidden due to additional commits of the `update-js-build-files.yml` workflow. The proposed solution is to build and commit the js-files only on the master, branch, i.e. when a PR has been already merged.

## How Has This Been Tested?
I've created a short [test-PR](https://github.com/da-h/visdom/pull/8) in my fork.
The tests directly started, and the resulting visualization of the tests is shown below:
![image](https://user-images.githubusercontent.com/19650074/166523160-5506cded-b5ad-4b7b-8163-264b46f34ae8.png)

Then, I've pressed the "merge pull request"-button and after that, another workflow started to push the new js-build-files onto master:
![image](https://user-images.githubusercontent.com/19650074/166523289-8c7727e5-83a0-4fe5-8a2a-eacfc39beafe.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My code follows the code style of this project.
   No code changes.
- [ ] My change requires a change to the documentation.
   No change of functionality.
- [ ] I have updated the documentation accordingly.
 