### PR TITLE
Add 'change-properties' Cypress Test

### DIFF
--- a/cypress/integration/screenshots.init.js
+++ b/cypress/integration/screenshots.init.js
@@ -46,7 +46,8 @@ describe(`Take compare-view screenshots`, () => {
 })
 
 
-describe(`Take line smoothing screenshot`, () => {
+describe(`Take screenshot for PlotPane functions`, () => {
+
   it('Screenshot for Line Smoothing', () => {
       var run = "line_smoothing"
       var env1 = run + "_1_" + Cypress._.random(0, 1e6)
@@ -63,6 +64,36 @@ describe(`Take line smoothing screenshot`, () => {
             range.dispatchEvent(new Event('input', { value: 0, bubbles: true })); // now dispatch the event
           })
        cy
+        .get('.content').first()
+        .screenshot(run, {overwrite: true})
+  })
+
+  it('Screenshot for Property Change (using Line Plot)', () => {
+      cy.run("plot_line_basic")
+      cy.get('button[title="properties"]').click()
+
+      // change some settings
+      const change = (key, val) => cy.get('td.table-properties-name').contains(key).siblings('td.table-properties-value').find('input').clear().type(val);
+
+      // plot settings
+      change('name', 'a line')
+      change('type', 'bar')
+      change('opacity', '0.75')
+      change('marker.line.width', '5')
+      change('marker.line.color', '#0FF')
+
+      // layout settings
+      change('margin.l', '10')
+      change('margin.r', '10')
+      change('margin.b', '10')
+      change('margin.t', '10')
+      change('xaxis.type', 'log')
+
+      // apply settings
+      cy.get('button[title="properties"]').click()
+
+      const run = "change-properties"
+      cy
         .get('.content').first()
         .screenshot(run, {overwrite: true})
   })

--- a/cypress/integration/screenshots.js
+++ b/cypress/integration/screenshots.js
@@ -65,7 +65,8 @@ describe(`Compare with compare-view screenshots`, () => {
 
 
 
-describe(`Compare with privious line smoothing screenshot`, () => {
+describe(`Compare screenshots for plotpane functions`, () => {
+
   it('Compare screenshot for Line Smoothing', () => {
       var run = "line_smoothing"
       var env1 = run + "_1_" + Cypress._.random(0, 1e6)
@@ -92,5 +93,43 @@ describe(`Compare with privious line smoothing screenshot`, () => {
         .screenshot(run, {overwrite: true})
       cy.task('numDifferentPixels', {src1: img1_src, src2: img2_src, diffsrc: diff_src, threshold: threshold}).should('equal', 0)
   })
+
+  it('Compare screenshot for Property Change (using Line Plot)', () => {
+      cy.run("plot_line_basic")
+      cy.get('button[title="properties"]').click()
+
+      // change some settings
+      const change = (key, val) => cy.get('td.table-properties-name').contains(key).siblings('td.table-properties-value').find('input').clear().type(val);
+
+      // plot settings
+      change('name', 'a line')
+      change('type', 'bar')
+      change('opacity', '0.75')
+      change('marker.line.width', '5')
+      change('marker.line.color', '#0FF')
+
+      // layout settings
+      change('margin.l', '10')
+      change('margin.r', '10')
+      change('margin.b', '10')
+      change('margin.t', '10')
+      change('xaxis.type', 'log')
+
+      // apply settings
+      cy.get('button[title="properties"]').click()
+
+      const run = "change-properties"
+      const diff_src = Cypress.config("screenshotsFolder") + "/" + "screenshots.diff.js" + "/" + run + ".png";
+      const img1_src = Cypress.config("screenshotsFolder") + "_init/" + "screenshots.init.js" + "/" + run + ".png";
+      const img2_src = Cypress.config("screenshotsFolder") + "/" + Cypress.spec.name + "/" + run + ".png";
+      const threshold = thresholds[run] || 0;
+
+      cy
+        .get('.content').first()
+        .screenshot(run, {overwrite: true})
+      cy.task('numDifferentPixels', {src1: img1_src, src2: img2_src, diffsrc: diff_src, threshold: threshold}).should('equal', 0)
+  })
+
 })
+
 


### PR DESCRIPTION
## Description
This PR adds a simple cypress test that tests the function to change any property used in any `PlotPane`. (I.e. the function from #837).

## Motivation and Context
During the rewrite of most react components using the hook based react-api, I did encounter unexpected changes in this function, thus the suggestion to add a test for this.

Note:
This PR will fail, as the test does not exist on the `master` branch, yet. (#854 solves this).

## How Has This Been Tested?
I've tested this PR already [on my own fork](https://github.com/da-h/visdom/pull/9), including also #854 .

## Screenshots:
The test uses the `plot_line_basic` example:
![plot_line_basic](https://user-images.githubusercontent.com/19650074/166729131-ed164499-838f-42d0-8999-e35d7ba03fb7.png)

and changes some properties, resulting in:
![change-properties](https://user-images.githubusercontent.com/19650074/166729079-cc482f82-8c82-4196-9a0e-825de1a1a863.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
      Added a new visual regression test
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
  