### PR TITLE
Enable PRs That Change Cypress Visual Regression Tests

### DIFF
--- a/.github/workflows/process-changes.yml
+++ b/.github/workflows/process-changes.yml
@@ -49,9 +49,20 @@ jobs:
 
       - name: "Checkout Repository"
         uses: actions/checkout@v3
+
+      - name: "Save current Head-Ref as PR-branch"
+        shell: bash
+        run: |
+          git checkout -B PR-HEAD
+
       - uses: ./.github/actions/prepare
         with:
           usebasebranch: true
+
+      - name: "Checkout Tests from Head-Ref"
+        shell: bash
+        run: |
+          git checkout PR-HEAD -- ./cypress
 
       - name: Cypress test:init
         uses: cypress-io/github-action@v2


### PR DESCRIPTION
## Description
This PR fixes a small issue with the current cypress testing workflow related to PRs that modify these tests.

## Motivation and Context
The visual regression tests in `cypress/integration/screenshot.js` take screenshots of the state *before* the code changes of any PR. In case a new test is added in such a PR, this procedure will always result in a failed test, as on the base branch the new test cases are not present yet.

The solution is simply to take the screenshots on the base branch, but using the new test setup.

Note: Certainly, this procedure can fail in case a breaking API-change occurs in the cypress-package and a PR includes an `npm update` that includes this API-change. However, this should happen much less often than new tests being created.

## How Has This Been Tested?
I tested the change using the PR #853 [in my fork](https://github.com/da-h/visdom/pull/9).


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
      No code changed.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
