### PR TITLE
Cypress Click-Event Hotfix

### DIFF
--- a/cypress/integration/screenshots.init.js
+++ b/cypress/integration/screenshots.init.js
@@ -65,7 +65,7 @@ describe(`Take screenshot for PlotPane functions`, () => {
       seed: 43,
     });
     cy.open_env(env1);
-    cy.get('button[title="smooth lines"]').click();
+    cy.get('button[title="smooth lines"]').click({ multiple: true }); // should be single element, concurrency (?) has triggered error here
     cy.get('input[type="range"]').then(($range) => {
       const range = $range[0]; // get the DOM node
       const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
@@ -80,7 +80,7 @@ describe(`Take screenshot for PlotPane functions`, () => {
 
   it('Screenshot for Property Change (using Line Plot)', () => {
     cy.run('plot_line_basic');
-    cy.get('button[title="properties"]').click();
+    cy.get('button[title="properties"]').click({ multiple: true }); // should be single element, concurrency (?) has triggered error here
 
     // change some settings
     const change = (key, val) =>
@@ -107,7 +107,7 @@ describe(`Take screenshot for PlotPane functions`, () => {
     change('xaxis.type', 'log');
 
     // apply settings
-    cy.get('button[title="properties"]').click();
+    cy.get('button[title="properties"]').click({ multiple: true }); // should be single element, concurrency (?) has triggered error here
 
     const run = 'change-properties';
     cy.get('.content').first().screenshot(run, { overwrite: true });

--- a/cypress/integration/screenshots.init.js
+++ b/cypress/integration/screenshots.init.js
@@ -1,100 +1,115 @@
 before(() => {
-  cy.visit('/')
-})
+  cy.visit('/');
+});
 
-import { all_screenshots, all_compareviews } from '../support/screenshots.config.js'
+import {
+  all_screenshots,
+  all_compareviews,
+} from '../support/screenshots.config.js';
 
 describe(`Take plot screenshots`, () => {
-  all_screenshots.forEach( (run) => {
+  all_screenshots.forEach((run) => {
     it(`Screenshot for ${run}`, () => {
-        cy.run(run)
+      cy.run(run);
 
-        // ImagePane requires an additional rerender for the image to adjust to the Pane size correctly
-        if (run.startsWith("image_"))
-            cy.wait(300)
+      // ImagePane requires an additional rerender for the image to adjust to the Pane size correctly
+      if (run.startsWith('image_')) cy.wait(300);
 
-        cy
-          .get('.content')
-          .screenshot(run, {overwrite: true})
-    })
-  })
-})
-
+      cy.get('.content').screenshot(run, { overwrite: true });
+    });
+  });
+});
 
 describe(`Take compare-view screenshots`, () => {
-  all_compareviews.forEach( (run) => {
+  all_compareviews.forEach((run) => {
     it(`Screenshot for ${run}`, () => {
+      var num_runs = 3;
 
-        var num_runs = 3;
+      var envs = [];
+      for (var i = 0; i < num_runs; i++) {
+        var env = run + '_' + i + '_' + Cypress._.random(0, 1e6);
+        cy.run(run, {
+          env: env,
+          open: false,
+          seed: 42 + i,
+          args: [run],
+          asyncrun: i != num_runs - 1,
+        });
+        envs.push(env);
+      }
+      cy.close_envs();
+      for (var i = 0; i < num_runs; i++) {
+        cy.open_env(envs[i]);
+      }
 
-        var envs = []
-        for (var i=0; i<num_runs; i++) {
-            var env = run + "_" + i + "_" + Cypress._.random(0, 1e6);
-            cy.run(run, {env:env, open: false, seed:42+i, args: [run], asyncrun: i != num_runs - 1})
-            envs.push(env);
-        }
-        cy.close_envs();
-        for (var i=0; i<num_runs; i++) {
-            cy.open_env(envs[i]);
-        }
-
-        cy
-          .get('.content').first()
-          .screenshot("compare_"+run, {overwrite: true})
-    })
-  })
-})
-
+      cy.get('.content')
+        .first()
+        .screenshot('compare_' + run, { overwrite: true });
+    });
+  });
+});
 
 describe(`Take screenshot for PlotPane functions`, () => {
-
   it('Screenshot for Line Smoothing', () => {
-      var run = "line_smoothing"
-      var env1 = run + "_1_" + Cypress._.random(0, 1e6)
-      var env2 = run + "_2_" + Cypress._.random(0, 1e6)
-      cy.run('plot_line_basic', {env: env1, args: ["'Line smoothing'", 100], open:false})
-      cy.run('plot_line_basic', {env: env2, args: ["'Line smoothing'", 100], seed:43})
-      cy.open_env(env1);
-      cy.get('button[title="smooth lines"]').click()
-      cy.get('input[type="range"]')
-          .then(($range) => {
-            const range = $range[0]; // get the DOM node
-            const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
-            nativeInputValueSetter.call(range, 100); // set the value manually
-            range.dispatchEvent(new Event('input', { value: 0, bubbles: true })); // now dispatch the event
-          })
-       cy
-        .get('.content').first()
-        .screenshot(run, {overwrite: true})
-  })
+    var run = 'line_smoothing';
+    var env1 = run + '_1_' + Cypress._.random(0, 1e6);
+    var env2 = run + '_2_' + Cypress._.random(0, 1e6);
+    cy.run('plot_line_basic', {
+      env: env1,
+      args: ["'Line smoothing'", 100],
+      open: false,
+    });
+    cy.run('plot_line_basic', {
+      env: env2,
+      args: ["'Line smoothing'", 100],
+      seed: 43,
+    });
+    cy.open_env(env1);
+    cy.get('button[title="smooth lines"]').click();
+    cy.get('input[type="range"]').then(($range) => {
+      const range = $range[0]; // get the DOM node
+      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value'
+      ).set;
+      nativeInputValueSetter.call(range, 100); // set the value manually
+      range.dispatchEvent(new Event('input', { value: 0, bubbles: true })); // now dispatch the event
+    });
+    cy.get('.content').first().screenshot(run, { overwrite: true });
+  });
 
   it('Screenshot for Property Change (using Line Plot)', () => {
-      cy.run("plot_line_basic")
-      cy.get('button[title="properties"]').click()
+    cy.run('plot_line_basic');
+    cy.get('button[title="properties"]').click();
 
-      // change some settings
-      const change = (key, val) => cy.get('td.table-properties-name').contains(key).siblings('td.table-properties-value').find('input').clear().type(val);
-
-      // plot settings
-      change('name', 'a line')
-      change('type', 'bar')
-      change('opacity', '0.75')
-      change('marker.line.width', '5')
-      change('marker.line.color', '#0FF')
-
-      // layout settings
-      change('margin.l', '10')
-      change('margin.r', '10')
-      change('margin.b', '10')
-      change('margin.t', '10')
-      change('xaxis.type', 'log')
-
-      // apply settings
-      cy.get('button[title="properties"]').click()
-
-      const run = "change-properties"
+    // change some settings
+    const change = (key, val) =>
       cy
-        .get('.content').first()
-        .screenshot(run, {overwrite: true})
-  })
-})
+        .get('td.table-properties-name')
+        .contains(key)
+        .siblings('td.table-properties-value')
+        .find('input')
+        .clear()
+        .type(val);
+
+    // plot settings
+    change('name', 'a line');
+    change('type', 'bar');
+    change('opacity', '0.75');
+    change('marker.line.width', '5');
+    change('marker.line.color', '#0FF');
+
+    // layout settings
+    change('margin.l', '10');
+    change('margin.r', '10');
+    change('margin.b', '10');
+    change('margin.t', '10');
+    change('xaxis.type', 'log');
+
+    // apply settings
+    cy.get('button[title="properties"]').click();
+
+    const run = 'change-properties';
+    cy.get('.content').first().screenshot(run, { overwrite: true });
+  });
+});

--- a/cypress/integration/screenshots.js
+++ b/cypress/integration/screenshots.js
@@ -133,7 +133,7 @@ describe(`Compare screenshots for plotpane functions`, () => {
       seed: 43,
     });
     cy.open_env(env1);
-    cy.get('button[title="smooth lines"]').click();
+    cy.get('button[title="smooth lines"]').click({ multiple: true }); // should be single element, concurrency (?) has triggered error here
     cy.get('input[type="range"]').then(($range) => {
       const range = $range[0]; // get the DOM node
       const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
@@ -178,7 +178,7 @@ describe(`Compare screenshots for plotpane functions`, () => {
 
   it('Compare screenshot for Property Change (using Line Plot)', () => {
     cy.run('plot_line_basic');
-    cy.get('button[title="properties"]').click();
+    cy.get('button[title="properties"]').click({ multiple: true }); // should be single element, concurrency (?) has triggered error here
 
     // change some settings
     const change = (key, val) =>
@@ -205,7 +205,7 @@ describe(`Compare screenshots for plotpane functions`, () => {
     change('xaxis.type', 'log');
 
     // apply settings
-    cy.get('button[title="properties"]').click();
+    cy.get('button[title="properties"]').click({ multiple: true }); // should be single element, concurrency (?) has triggered error here
 
     const run = 'change-properties';
     const diff_src =

--- a/cypress/integration/screenshots.js
+++ b/cypress/integration/screenshots.js
@@ -1,135 +1,242 @@
 before(() => {
-  cy.visit('/')
-})
+  cy.visit('/');
+});
 
-import { all_screenshots, all_compareviews } from '../support/screenshots.config.js'
+import {
+  all_screenshots,
+  all_compareviews,
+} from '../support/screenshots.config.js';
 
 const thresholds = {
-    // the internal video player may already start by showing animated loading sign
-    misc_video_tensor: 0.1,
-    misc_video_download: 0.1,
-}
+  // the internal video player may already start by showing animated loading sign
+  misc_video_tensor: 0.1,
+  misc_video_download: 0.1,
+};
 
 describe(`Compare with previous plot screenshots`, () => {
-  all_screenshots.forEach( (run) => {
+  all_screenshots.forEach((run) => {
     it(`Compare screenshot of ${run}`, () => {
-        cy.run(run)
+      cy.run(run);
 
-        const diff_src = Cypress.config("screenshotsFolder") + "/" + "screenshots.diff.js" + "/" + run + ".png";
-        const img1_src = Cypress.config("screenshotsFolder") + "_init/" + "screenshots.init.js" + "/" + run + ".png";
-        const img2_src = Cypress.config("screenshotsFolder") + "/" + Cypress.spec.name + "/" + run + ".png";
-        const threshold = thresholds[run] || 0;
+      const diff_src =
+        Cypress.config('screenshotsFolder') +
+        '/' +
+        'screenshots.diff.js' +
+        '/' +
+        run +
+        '.png';
+      const img1_src =
+        Cypress.config('screenshotsFolder') +
+        '_init/' +
+        'screenshots.init.js' +
+        '/' +
+        run +
+        '.png';
+      const img2_src =
+        Cypress.config('screenshotsFolder') +
+        '/' +
+        Cypress.spec.name +
+        '/' +
+        run +
+        '.png';
+      const threshold = thresholds[run] || 0;
 
-        // ImagePane requires an additional rerender for the image to adjust to the Pane size correctly
-        if (run.startsWith("image_"))
-            cy.wait(300)
+      // ImagePane requires an additional rerender for the image to adjust to the Pane size correctly
+      if (run.startsWith('image_')) cy.wait(300);
 
-        cy
-          .get('.content').first()
-          .screenshot(run, {overwrite: true})
-        cy.task('numDifferentPixels', {src1: img1_src, src2: img2_src, diffsrc: diff_src, threshold: threshold}).should('equal', 0)
-    })
-  })
-})
+      cy.get('.content').first().screenshot(run, { overwrite: true });
+      cy.task('numDifferentPixels', {
+        src1: img1_src,
+        src2: img2_src,
+        diffsrc: diff_src,
+        threshold: threshold,
+      }).should('equal', 0);
+    });
+  });
+});
 
 describe(`Compare with compare-view screenshots`, () => {
-  all_compareviews.forEach( (run) => {
+  all_compareviews.forEach((run) => {
     it(`Compare screenshot for ${run}`, () => {
+      var num_runs = 3;
 
-        var num_runs = 3;
+      var envs = [];
+      for (var i = 0; i < num_runs; i++) {
+        var env = run + '_' + i + '_' + Cypress._.random(0, 1e6);
+        cy.run(run, {
+          env: env,
+          open: false,
+          seed: 42 + i,
+          args: [run],
+          asyncrun: i != num_runs - 1,
+        });
+        envs.push(env);
+      }
+      cy.close_envs();
+      for (var i = 0; i < num_runs; i++) {
+        cy.open_env(envs[i]);
+      }
 
-        var envs = []
-        for (var i=0; i<num_runs; i++) {
-            var env = run + "_" + i + "_" + Cypress._.random(0, 1e6);
-            cy.run(run, {env:env, open: false, seed:42+i, args: [run], asyncrun: i != num_runs - 1})
-            envs.push(env);
-        }
-        cy.close_envs();
-        for (var i=0; i<num_runs; i++) {
-            cy.open_env(envs[i]);
-        }
+      cy.get('.content')
+        .first()
+        .screenshot('compare_' + run, { overwrite: true });
 
-        cy
-          .get('.content').first()
-          .screenshot("compare_"+run, {overwrite: true})
+      const diff_src =
+        Cypress.config('screenshotsFolder') +
+        '/' +
+        'screenshots.diff.js' +
+        '/' +
+        'compare_' +
+        run +
+        '.png';
+      const img1_src =
+        Cypress.config('screenshotsFolder') +
+        '_init/' +
+        'screenshots.init.js' +
+        '/' +
+        'compare_' +
+        run +
+        '.png';
+      const img2_src =
+        Cypress.config('screenshotsFolder') +
+        '/' +
+        Cypress.spec.name +
+        '/' +
+        'compare_' +
+        run +
+        '.png';
+      const threshold = thresholds[run] || 0;
 
-        const diff_src = Cypress.config("screenshotsFolder") + "/" + "screenshots.diff.js" + "/" + "compare_"+run + ".png";
-        const img1_src = Cypress.config("screenshotsFolder") + "_init/" + "screenshots.init.js" + "/" + "compare_"+run + ".png";
-        const img2_src = Cypress.config("screenshotsFolder") + "/" + Cypress.spec.name + "/" + "compare_"+run + ".png";
-        const threshold = thresholds[run] || 0;
-
-        cy.task('numDifferentPixels', {src1: img1_src, src2: img2_src, diffsrc: diff_src, threshold: threshold}).should('equal', 0)
-    })
-  })
-})
-
-
+      cy.task('numDifferentPixels', {
+        src1: img1_src,
+        src2: img2_src,
+        diffsrc: diff_src,
+        threshold: threshold,
+      }).should('equal', 0);
+    });
+  });
+});
 
 describe(`Compare screenshots for plotpane functions`, () => {
-
   it('Compare screenshot for Line Smoothing', () => {
-      var run = "line_smoothing"
-      var env1 = run + "_1_" + Cypress._.random(0, 1e6)
-      var env2 = run + "_2_" + Cypress._.random(0, 1e6)
-      cy.run('plot_line_basic', {env: env1, args: ["'Line smoothing'", 100], open:false})
-      cy.run('plot_line_basic', {env: env2, args: ["'Line smoothing'", 100], seed:43})
-      cy.open_env(env1);
-      cy.get('button[title="smooth lines"]').click()
-      cy.get('input[type="range"]')
-          .then(($range) => {
-            const range = $range[0]; // get the DOM node
-            const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
-            nativeInputValueSetter.call(range, 100); // set the value manually
-            range.dispatchEvent(new Event('input', { value: 0, bubbles: true })); // now dispatch the event
-          })
+    var run = 'line_smoothing';
+    var env1 = run + '_1_' + Cypress._.random(0, 1e6);
+    var env2 = run + '_2_' + Cypress._.random(0, 1e6);
+    cy.run('plot_line_basic', {
+      env: env1,
+      args: ["'Line smoothing'", 100],
+      open: false,
+    });
+    cy.run('plot_line_basic', {
+      env: env2,
+      args: ["'Line smoothing'", 100],
+      seed: 43,
+    });
+    cy.open_env(env1);
+    cy.get('button[title="smooth lines"]').click();
+    cy.get('input[type="range"]').then(($range) => {
+      const range = $range[0]; // get the DOM node
+      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value'
+      ).set;
+      nativeInputValueSetter.call(range, 100); // set the value manually
+      range.dispatchEvent(new Event('input', { value: 0, bubbles: true })); // now dispatch the event
+    });
 
-      const diff_src = Cypress.config("screenshotsFolder") + "/" + "screenshots.diff.js" + "/" + run + ".png";
-      const img1_src = Cypress.config("screenshotsFolder") + "_init/" + "screenshots.init.js" + "/" + run + ".png";
-      const img2_src = Cypress.config("screenshotsFolder") + "/" + Cypress.spec.name + "/" + run + ".png";
-      const threshold = thresholds[run] || 0;
+    const diff_src =
+      Cypress.config('screenshotsFolder') +
+      '/' +
+      'screenshots.diff.js' +
+      '/' +
+      run +
+      '.png';
+    const img1_src =
+      Cypress.config('screenshotsFolder') +
+      '_init/' +
+      'screenshots.init.js' +
+      '/' +
+      run +
+      '.png';
+    const img2_src =
+      Cypress.config('screenshotsFolder') +
+      '/' +
+      Cypress.spec.name +
+      '/' +
+      run +
+      '.png';
+    const threshold = thresholds[run] || 0;
 
-      cy
-        .get('.content').first()
-        .screenshot(run, {overwrite: true})
-      cy.task('numDifferentPixels', {src1: img1_src, src2: img2_src, diffsrc: diff_src, threshold: threshold}).should('equal', 0)
-  })
+    cy.get('.content').first().screenshot(run, { overwrite: true });
+    cy.task('numDifferentPixels', {
+      src1: img1_src,
+      src2: img2_src,
+      diffsrc: diff_src,
+      threshold: threshold,
+    }).should('equal', 0);
+  });
 
   it('Compare screenshot for Property Change (using Line Plot)', () => {
-      cy.run("plot_line_basic")
-      cy.get('button[title="properties"]').click()
+    cy.run('plot_line_basic');
+    cy.get('button[title="properties"]').click();
 
-      // change some settings
-      const change = (key, val) => cy.get('td.table-properties-name').contains(key).siblings('td.table-properties-value').find('input').clear().type(val);
-
-      // plot settings
-      change('name', 'a line')
-      change('type', 'bar')
-      change('opacity', '0.75')
-      change('marker.line.width', '5')
-      change('marker.line.color', '#0FF')
-
-      // layout settings
-      change('margin.l', '10')
-      change('margin.r', '10')
-      change('margin.b', '10')
-      change('margin.t', '10')
-      change('xaxis.type', 'log')
-
-      // apply settings
-      cy.get('button[title="properties"]').click()
-
-      const run = "change-properties"
-      const diff_src = Cypress.config("screenshotsFolder") + "/" + "screenshots.diff.js" + "/" + run + ".png";
-      const img1_src = Cypress.config("screenshotsFolder") + "_init/" + "screenshots.init.js" + "/" + run + ".png";
-      const img2_src = Cypress.config("screenshotsFolder") + "/" + Cypress.spec.name + "/" + run + ".png";
-      const threshold = thresholds[run] || 0;
-
+    // change some settings
+    const change = (key, val) =>
       cy
-        .get('.content').first()
-        .screenshot(run, {overwrite: true})
-      cy.task('numDifferentPixels', {src1: img1_src, src2: img2_src, diffsrc: diff_src, threshold: threshold}).should('equal', 0)
-  })
+        .get('td.table-properties-name')
+        .contains(key)
+        .siblings('td.table-properties-value')
+        .find('input')
+        .clear()
+        .type(val);
 
-})
+    // plot settings
+    change('name', 'a line');
+    change('type', 'bar');
+    change('opacity', '0.75');
+    change('marker.line.width', '5');
+    change('marker.line.color', '#0FF');
 
+    // layout settings
+    change('margin.l', '10');
+    change('margin.r', '10');
+    change('margin.b', '10');
+    change('margin.t', '10');
+    change('xaxis.type', 'log');
 
+    // apply settings
+    cy.get('button[title="properties"]').click();
+
+    const run = 'change-properties';
+    const diff_src =
+      Cypress.config('screenshotsFolder') +
+      '/' +
+      'screenshots.diff.js' +
+      '/' +
+      run +
+      '.png';
+    const img1_src =
+      Cypress.config('screenshotsFolder') +
+      '_init/' +
+      'screenshots.init.js' +
+      '/' +
+      run +
+      '.png';
+    const img2_src =
+      Cypress.config('screenshotsFolder') +
+      '/' +
+      Cypress.spec.name +
+      '/' +
+      run +
+      '.png';
+    const threshold = thresholds[run] || 0;
+
+    cy.get('.content').first().screenshot(run, { overwrite: true });
+    cy.task('numDifferentPixels', {
+      src1: img1_src,
+      src2: img2_src,
+      diffsrc: diff_src,
+      threshold: threshold,
+    }).should('equal', 0);
+  });
+});


### PR DESCRIPTION
Fixes cypress test fails (possibly triggered) due to reappearing windows during re-rendering.

## Description
In the recent MR #856, the initialization of the cypress tests failed unexpectedly.  (See [these error logs](https://github.com/fossasia/visdom/actions/runs/3054697717/jobs/4926953999).  

The test prepares screenshot on the `master` branch, which has been passing successfully in a previous PR test run. I am honestly a bit unsure why this happened, and, I cannot reproduce the error, yet.  

My guess is that during re-rendering due to a change in the react state, cypress has registered the replaced/recreated window as a new object and thus registered two windows instead of only one.
The error message suggests adding a `multiple: True` flag in case multiple clicks should be performed.
I see no problem in enabling this in case such a coincidence happens again, thus this PR.

**Note**:
Also, the auto-formatter has applied some changes to the tests, which I have committed as well.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
