### PR TITLE
Bugfix for job visual-regression-test-init (Reverts quickfix #863)

### DIFF
--- a/.github/workflows/process-changes.yml
+++ b/.github/workflows/process-changes.yml
@@ -58,6 +58,7 @@ jobs:
       - uses: ./.github/actions/prepare
         with:
           usebasebranch: true
+          loadprbuild: false
 
       - name: "Checkout Tests from Head-Ref"
         shell: bash

--- a/cypress/integration/screenshots.init.js
+++ b/cypress/integration/screenshots.init.js
@@ -65,7 +65,7 @@ describe(`Take screenshot for PlotPane functions`, () => {
       seed: 43,
     });
     cy.open_env(env1);
-    cy.get('button[title="smooth lines"]').click({ multiple: true }); // should be single element, concurrency (?) has triggered error here
+    cy.get('button[title="smooth lines"]').click();
     cy.get('input[type="range"]').then(($range) => {
       const range = $range[0]; // get the DOM node
       const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
@@ -80,7 +80,7 @@ describe(`Take screenshot for PlotPane functions`, () => {
 
   it('Screenshot for Property Change (using Line Plot)', () => {
     cy.run('plot_line_basic');
-    cy.get('button[title="properties"]').click({ multiple: true }); // should be single element, concurrency (?) has triggered error here
+    cy.get('button[title="properties"]').click();
 
     // change some settings
     const change = (key, val) =>
@@ -107,7 +107,7 @@ describe(`Take screenshot for PlotPane functions`, () => {
     change('xaxis.type', 'log');
 
     // apply settings
-    cy.get('button[title="properties"]').click({ multiple: true }); // should be single element, concurrency (?) has triggered error here
+    cy.get('button[title="properties"]').click();
 
     const run = 'change-properties';
     cy.get('.content').first().screenshot(run, { overwrite: true });

--- a/cypress/integration/screenshots.js
+++ b/cypress/integration/screenshots.js
@@ -133,7 +133,7 @@ describe(`Compare screenshots for plotpane functions`, () => {
       seed: 43,
     });
     cy.open_env(env1);
-    cy.get('button[title="smooth lines"]').click({ multiple: true }); // should be single element, concurrency (?) has triggered error here
+    cy.get('button[title="smooth lines"]').click();
     cy.get('input[type="range"]').then(($range) => {
       const range = $range[0]; // get the DOM node
       const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
@@ -178,7 +178,7 @@ describe(`Compare screenshots for plotpane functions`, () => {
 
   it('Compare screenshot for Property Change (using Line Plot)', () => {
     cy.run('plot_line_basic');
-    cy.get('button[title="properties"]').click({ multiple: true }); // should be single element, concurrency (?) has triggered error here
+    cy.get('button[title="properties"]').click();
 
     // change some settings
     const change = (key, val) =>
@@ -205,7 +205,7 @@ describe(`Compare screenshots for plotpane functions`, () => {
     change('xaxis.type', 'log');
 
     // apply settings
-    cy.get('button[title="properties"]').click({ multiple: true }); // should be single element, concurrency (?) has triggered error here
+    cy.get('button[title="properties"]').click();
 
     const run = 'change-properties';
     const diff_src =


### PR DESCRIPTION
This PR fixes the errors found in #856 that occurred in the initialization stage of the cypress visual regression tests.

## Description
These tests **should** in theory take screenshots on the master branch and compare to the changes done in the respective PR.
**In reality**, the test did use the built Javascript files of the PR instead and thus compared it to itself due to a missing flag (`loadprbuild: false`) in the github action.

## How Has This Been Tested?
I've done multiple tests on my fork. Using this change, the initialization did not fail anymore for the PR #856. (There are other errors however later in testing that I still need to fix, related to the changes there).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
