### PR TITLE
upgrade plotly js

### DIFF
--- a/py/visdom/server.py
+++ b/py/visdom/server.py
@@ -1828,7 +1828,11 @@ def download_scripts(proxies=None, install_dir=None):
             'react-modal.min.js',
         # here is another url in case the cdn breaks down again.
         # https://raw.githubusercontent.com/plotly/plotly.js/master/dist/plotly.min.js
-        'https://cdn.plot.ly/plotly-latest.min.js': 'plotly-plotly.min.js',
+
+        ## [shouldsee/visdom/package_version]:latest.min.js not pointing to latest.
+        ## see https://github.com/plotly/plotly.py/issues/3651
+        'https://cdn.plot.ly/plotly-2.11.1.min.js': 'plotly-plotly.min.js', 
+        
         # Stanford Javascript Crypto Library for Password Hashing
         '%ssjcl@1.0.7/sjcl.js' % b: 'sjcl.js',
         '%slayout-bin-packer@1.4.0/dist/layout-bin-packer.js.map' % b: 'layout-bin-packer.js.map',


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->


        ## [shouldsee/visdom/package_version]:latest.min.js not pointing to latest.
        ## see https://github.com/plotly/plotly.py/issues/3651



## Motivation and Context

old url points to v1.58.5 and was too old for modern plotly functions. no tests performed on this PR yet

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, experiments you ran to see how -->
<!--- your change affects existing areas of the code and their behaviors, etc. -->
<!--- One method of testing is to run the `demo.py` script from the examples -->
<!--- both on your branch and a clean branch and ensure that none of the functionality -->
<!--- appears different. Be sure to install from source when testing. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
