### PR TITLE
github-actions: adapt cypress test to new server code

### DIFF
--- a/.github/workflows/process-changes.yml
+++ b/.github/workflows/process-changes.yml
@@ -69,7 +69,7 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           install: false
-          start: python3 py/visdom/server -port 8098 -env_path /tmp
+          start: visdom -port 8098 -env_path /tmp
           wait-on: 'http://localhost:8098'
           spec: cypress/integration/*.init.js
 
@@ -96,7 +96,7 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           install: false
-          start: python3 py/visdom/server -port 8098 -env_path /tmp
+          start: visdom -port 8098 -env_path /tmp
           wait-on: 'http://localhost:8098'
           spec: cypress/integration/screenshots.js
 
@@ -118,7 +118,7 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           install: false
-          start: python3 py/visdom/server -port 8098 -env_path /tmp
+          start: visdom -port 8098 -env_path /tmp
           wait-on: 'http://localhost:8098'
           config: ignoreTestFiles=screenshots.*
 

--- a/.github/workflows/process-changes.yml
+++ b/.github/workflows/process-changes.yml
@@ -65,26 +65,8 @@ jobs:
         run: |
           git checkout PR-HEAD -- ./cypress
 
-      - name: Check file existence
-        id: check_files
-        run: |
-          if test "py/visdom/server.py"; then
-          echo '::set-output name=file_exists::true'
-          else
-          echo '::set-output name=file_exists::false'
-          fi
-
-      - name: Cypress test:init
-        if: steps.check_files.outputs.file_exists == 'true'
-        uses: cypress-io/github-action@v2
-        with:
-          install: false
-          start: python3 py/visdom/server.py -port 8098 -env_path /tmp
-          wait-on: 'http://localhost:8098'
-          spec: cypress/integration/*.init.js
       - name: Cypress test:init
         uses: cypress-io/github-action@v2
-        if: steps.check_files.outputs.file_exists != 'true'
         with:
           install: false
           start: python3 py/visdom/server -port 8098 -env_path /tmp


### PR DESCRIPTION
## Description
This PR adapts the cypress test workflow to the new server code (for future reference: #858).
Note that it removes the additional checks introduced in #858 (commit 1a34bb6b) to have the test work across the different versions for the server (before and after refactoring).

(The test failed here because of a missing argument for `test`. It should have been `if test -f "py/visdom/server.py"` instead of `if test "py/visdom/server.py"`. Nevertheless, the extra test-case here is not required anymore.)

## How Has This Been Tested?
Tested on my own fork, see [here](https://github.com/da-h/visdom/pull/25)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. 