### PR TITLE
Update GitHub actions & fixes deprecation warnings

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -14,7 +14,7 @@ runs:
   using: "composite"
   steps:
       - name: "Setup Node" 
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 

--- a/.github/workflows/process-changes.yml
+++ b/.github/workflows/process-changes.yml
@@ -39,7 +39,7 @@ jobs:
           git fetch origin $GITHUB_BASE_REF
           echo "Target branch : $GITHUB_BASE_REF"
           git diff --name-only origin/$GITHUB_BASE_REF --
-          echo '::set-output name=jsfileschanged::'$(git diff --name-only origin/$GITHUB_BASE_REF -- | grep '^js/*' | wc -l)
+          echo 'jsfileschanged='$(git diff --name-only origin/$GITHUB_BASE_REF -- | grep '^js/*' | wc -l) >> $GITHUB_OUTPUT
           echo 'Num js files changed='$(git diff --name-only origin/$GITHUB_BASE_REF -- | grep '^js/*' | wc -l)
 
       - name: "Build Project (PR version)"

--- a/.github/workflows/process-changes.yml
+++ b/.github/workflows/process-changes.yml
@@ -7,7 +7,7 @@ on: pull_request
 
 jobs:
   eslint_check:
-    name: Linter Check
+    name: "Linter Check"
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout Repository"
@@ -22,6 +22,7 @@ jobs:
       run: npm run lint
 
   install-and-build:
+    name: "Install and Build"
     runs-on: ubuntu-latest
     outputs:
       jsfileschanged: ${{ steps.checkout.outputs.jsfileschanged }}
@@ -58,6 +59,7 @@ jobs:
 
 
   visual-regression-test-init:
+    name: "Initialize Visual Regression Test"
     runs-on: ubuntu-latest
     needs: install-and-build
     steps:
@@ -95,6 +97,7 @@ jobs:
 
 
   visual-regression-test:
+    name: "Visual Regression Test"
     runs-on: ubuntu-latest
     needs: visual-regression-test-init
     steps:
@@ -122,6 +125,7 @@ jobs:
           path: cypress/screenshots
 
   funcitonal-test:
+    name: "Functional Test"
     runs-on: ubuntu-latest
     needs: install-and-build
     steps:

--- a/.github/workflows/process-changes.yml
+++ b/.github/workflows/process-changes.yml
@@ -13,7 +13,7 @@ jobs:
     - name: "Checkout Repository"
       uses: actions/checkout@v3
     - name: "Install Node"
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
           node-version: 16
     - name: "Install Dependencies"
@@ -81,14 +81,14 @@ jobs:
           git checkout PR-HEAD -- ./cypress
 
       - name: Cypress test:init
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v4
         with:
           install: false
           start: visdom -port 8098 -env_path /tmp
           wait-on: 'http://localhost:8098'
           spec: cypress/integration/*.init.js
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: cypress-init-screenshots
           path: cypress/screenshots_init
@@ -102,20 +102,20 @@ jobs:
         uses: actions/checkout@v3
       - uses: ./.github/actions/prepare
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: cypress-init-screenshots
           path: cypress/screenshots_init
 
       - name: Cypress test:visual
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v4
         with:
           install: false
           start: visdom -port 8098 -env_path /tmp
           wait-on: 'http://localhost:8098'
           spec: cypress/integration/screenshots.js
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-screenshots-visual
@@ -130,14 +130,14 @@ jobs:
       - uses: ./.github/actions/prepare
 
       - name: Cypress test
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v4
         with:
           install: false
           start: visdom -port 8098 -env_path /tmp
           wait-on: 'http://localhost:8098'
           config: ignoreTestFiles=screenshots.*
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-screenshots-functional

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -13,7 +13,7 @@ jobs:
     name: "Deploy to PyPI"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Get git-tags
         run: |
           git fetch --prune --unshallow --tags
@@ -38,7 +38,7 @@ jobs:
           release_name: "Release ${{ steps.version.outputs.TAG_NAME }}"
       - name: Set up Python
         if: ${{ steps.version.outputs.TAG_EXISTS == '0' }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
             python-version: '3.x'
       - name: Install dependencies

--- a/.github/workflows/update-js-build-files.yml
+++ b/.github/workflows/update-js-build-files.yml
@@ -17,7 +17,7 @@ jobs:
         # see: https://stackoverflow.com/questions/57921401/push-to-origin-from-github-action/58393457#58393457
         # with:
         #   token: ${{ secrets.PAT }}
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '16'
       - run: npm install


### PR DESCRIPTION

## Description
This PR updates the GitHub workflows to use the most recent APIs:
1. updating the official actions used in the workflows, i.e. upgrading `action/setup-node@v2` as much as possible
    Currently, the workflows were mostly running on old versions that show warnings regarding "Node 12" and "set-output".
    **In more detail, this PR updates:**
    - `actions/setup-node@v2` to `actions/setup-node@v3`
    - `actions/setup-python@v1` to `actions/setup-python@v4`
    - `actions/upload-artifact@v2` to `actions/upload-artifact@v3`
    - `actions/download-artifact@v2` to `actions/download-artifact@v3`
    - `actions/checkout@v2` to `actions/checkout@v3`
    - `cypress-io/github-action@2` to `/cypress-io/github-action@v4`
    The updates did not require new 
2. `::set-output` is deprecated and will [start to fail in June 2023](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
3. Minor: I have also added human-readable workflow names for all tests.

Note:
- The remaining warnings seem to be related to https://github.com/cypress-io/github-action/issues/613.
- I did not adapt the actions used in the workflow `assign-check` (`.github/workflows/issue-scripts.yml`) because I could not test it and **never versions of `actions/github-scripts` include breaking API-changes.**

## Motivation and Context
Current GitHub action-runs warn about the upcoming deprecation of old APIs in march 2023.

## How Has This Been Tested?
https://github.com/da-h/visdom/actions/runs/3299410803
(Includes JavaScript no-op changes to test also building & passing to next workflow jobs).

## Screenshots (if appropriate):
Additionally, the new actions do provide a direct overview over passing / failing tests in the GitHub-UI:
![image](https://user-images.githubusercontent.com/19650074/197254755-c063a67e-78b5-40ea-9289-0b7576fe624f.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)
- [x] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
