### PR TITLE
server: remove startup message ERROR:root:initializing

### DIFF
--- a/py/visdom/server/app.py
+++ b/py/visdom/server/app.py
@@ -208,7 +208,6 @@ class Application(tornado.web.Application):
 
         # initialize user style
         user_css = ""
-        logging.error("initializing")
         home_style_path = os.path.join(config_dir, "style.css")
         if os.path.exists(home_style_path):
             with open(home_style_path, "r") as f:


### PR DESCRIPTION

## Description
Removing the startup message `ERROR:root:initializing`.

## Motivation and Context
In #842, I've mistakenly left a debug-message in the PR.
This should be removed as some users think rightly that this should not show up if everything is ok.

## How Has This Been Tested?
Just running `visdom` now yields:
```
Checking for scripts.
It's Alive!
INFO:root:Application Started
INFO:root:Working directory: /home/dave/.visdom
You can navigate to http://localhost:8097
```

Previously, it said:
```
Checking for scripts.
It's Alive!
ERROR:root:initializing
INFO:root:Application Started
INFO:root:Working directory: /home/dave/.visdom
You can navigate to http://localhost:8097
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
