### PR TITLE
Cypress Tests for -use_frontend_client_polling variant of visdom

### DIFF
--- a/.github/workflows/process-changes.yml
+++ b/.github/workflows/process-changes.yml
@@ -137,7 +137,7 @@ jobs:
           path: cypress/screenshots
 
   funcitonal-test:
-    name: "Functional Test"
+    name: "Functional Test (Websocket)"
     runs-on: ubuntu-latest
     needs: install-and-build
     steps:
@@ -157,4 +157,27 @@ jobs:
         if: failure()
         with:
           name: cypress-screenshots-functional
+          path: cypress/screenshots
+
+  funcitonal-test-polling:
+    name: 'Functional Test (Polling)'
+    runs-on: ubuntu-latest
+    needs: install-and-build
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/prepare
+
+      - name: Cypress test
+        uses: cypress-io/github-action@v4
+        with:
+          install: false
+          start: visdom -port 8098 -env_path /tmp -use_frontend_client_polling
+          wait-on: 'http://localhost:8098'
+          config: ignoreTestFiles=screenshots.*
+
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: cypress-screenshots-functional-polling
           path: cypress/screenshots

--- a/cypress/integration/image.js
+++ b/cypress/integration/image.js
@@ -1,175 +1,194 @@
-
 before(() => {
-  cy.visit('/')
-})
+  cy.visit('/');
+});
 
-const path = require("path");
+const path = require('path');
+const win_selector = '.layout .react-grid-item';
+const container_selector = `${win_selector} .content > div`;
+const img_selector = `${container_selector} img`;
 
 describe('Image Pane', () => {
-
   it('image_basic', () => {
-      cy.run('image_basic')
-         .get('.layout .react-grid-item').first()
-         .find('img').should('have.length', 1)
-  })
+    cy.run('image_basic')
+      .get(win_selector)
+      .first()
+      .find('img')
+      .should('have.length', 1);
+  });
 
   it('Image Movement (Alt + Wheel or Drag)', () => {
+    // check default position
+    cy.get(container_selector)
+      .first()
+      .should('have.css', 'top', '0px')
+      .should('have.css', 'left', '0px');
 
-      // check default position
-      cy.get('.layout .react-grid-item .content > div').first()
-         .should('have.css', 'top', '0px')
-         .should('have.css', 'left', '0px')
+    // scroll a bit
+    cy.get(img_selector)
+      .first()
+      .trigger('wheel', {
+        altKey: true,
+        deltaY: 20,
+        deltaX: 30,
+        bubbles: true,
+      });
 
-      // scroll a bit
-      cy.get('.layout .react-grid-item').first()
-         .find('img')
-         .trigger("wheel", { altKey: true, deltaY: 20, deltaX: 30, bubbles: true})
+    // check new position
+    cy.get(container_selector)
+      .first()
+      .should('have.css', 'top', '-50px')
+      .should('have.css', 'left', '-50px');
 
-      // check new position
-      cy.get('.layout .react-grid-item .content > div').first()
-         .should('have.css', 'top', '-50px')
-         .should('have.css', 'left', '-50px')
+    // check drag and drop
+    cy.get(img_selector)
+      .first()
+      .trigger('mousemove', {
+        button: 0,
+        clientX: 120,
+        clientY: 300,
+      })
+      .trigger('dragover');
 
-      // check drag and drop
-      cy.get('.layout .react-grid-item .content > div').first()
-         .find('img')
-            .trigger('mousemove', {
-                 button: 0,
-                 clientX: 120,
-                 clientY: 300,
-            })
-            .trigger('dragover')
-
-      // check new position
-      cy.get('.layout .react-grid-item .content > div').first()
-         .should('have.css', 'top', '256px')
-         .should('have.css', 'left', '38px')
-
-
-  })
+    // check new position
+    cy.get(container_selector)
+      .first()
+      .should('have.css', 'top', '256px')
+      .should('have.css', 'left', '38px');
+  });
 
   it('Image Zoom (Ctrl + Wheel)', () => {
+    // scroll a bit
+    cy.get(img_selector)
+      .first()
+      .trigger('wheel', { ctrlKey: true, deltaY: 200, bubbles: true })
+      .trigger('wheel', { ctrlKey: true, deltaY: 200, bubbles: true })
+      .trigger('wheel', { ctrlKey: true, deltaY: 200, bubbles: true })
+      .trigger('wheel', { ctrlKey: true, deltaY: 200, bubbles: true })
+      .trigger('wheel', { ctrlKey: true, deltaY: 200, bubbles: true })
+      .should('have.attr', 'width', '157px')
+      .should('have.attr', 'height', '314px');
 
-      // scroll a bit
-      cy.get('.layout .react-grid-item').first()
-         .find('img')
-         .trigger("wheel", { ctrlKey: true, deltaY: 200, bubbles: true})
-         .trigger("wheel", { ctrlKey: true, deltaY: 200, bubbles: true})
-         .trigger("wheel", { ctrlKey: true, deltaY: 200, bubbles: true})
-         .trigger("wheel", { ctrlKey: true, deltaY: 200, bubbles: true})
-         .trigger("wheel", { ctrlKey: true, deltaY: 200, bubbles: true})
-         .should('have.attr', 'width', '157px')
-         .should('have.attr', 'height', '314px')
-
-      // check new position
-      cy.get('.layout .react-grid-item .content > div').first()
-         .should('have.css', 'top', '276.786px')
-         .should('have.css', 'left', '81.5211px')
-
-  })
-
+    // check new position
+    cy.get(container_selector)
+      .first()
+      .should('have.css', 'top', '276.786px')
+      .should('have.css', 'left', '81.5211px');
+  });
 
   it('Image Reset (Double-Click)', () => {
+    cy.get(img_selector)
+      .first()
+      .dblclick()
+      .should('have.attr', 'width', '257px')
+      .should('have.attr', 'height', '514px');
 
-      cy.get('.layout .react-grid-item').first()
-         .find('img')
-         .dblclick()
-         .should('have.attr', 'width', '257px')
-         .should('have.attr', 'height', '514px')
-
-      // check new position
-      cy.get('.layout .react-grid-item .content > div').first()
-         .should('have.css', 'top', '0px')
-         .should('have.css', 'left', '0px')
-
-
-  })
+    // check new position
+    cy.get(container_selector)
+      .first()
+      .should('have.css', 'top', '0px')
+      .should('have.css', 'left', '0px');
+  });
 
   it('image_basic download', () => {
-      cy.run('image_basic')
-          .get('.layout .react-grid-item').first()
-          .find('button[title="save"]').click()
-      const downloadsFolder = Cypress.config("downloadsFolder");
-      cy.readFile(path.join(downloadsFolder, "Random!.jpg")).should("exist");
-  })
+    cy.run('image_basic')
+      .get(img_selector)
+      .parents(win_selector)
+      .first()
+      .find('button[title="save"]')
+      .click();
+    const downloadsFolder = Cypress.config('downloadsFolder');
+    cy.readFile(path.join(downloadsFolder, 'Random!.jpg')).should('exist');
+  });
 
   it('image_save_jpeg', () => {
-      cy.run('image_save_jpeg')
-          .get('.layout .react-grid-item').first()
-          .find('button[title="save"]').click()
-      const downloadsFolder = Cypress.config("downloadsFolder");
-      cy.readFile(path.join(downloadsFolder, "Random image as jpg!.jpg")).should("exist");
-  })
+    cy.run('image_save_jpeg')
+      .get(img_selector)
+      .parents(win_selector)
+      .first()
+      .find('button[title="save"]')
+      .click();
+    const downloadsFolder = Cypress.config('downloadsFolder');
+    cy.readFile(path.join(downloadsFolder, 'Random image as jpg!.jpg')).should(
+      'exist'
+    );
+  });
 
   it('image_history', () => {
+    cy.run('image_history', { asyncrun: true });
 
-      cy.run('image_history', {asyncrun: true})
+    cy.get(img_selector)
+      .should('have.length', 1)
+      .then((src) => {
+        const src1 = src;
+        // image exists
+        cy.get('.layout .react-grid-item .widget input[type="range"]')
+          .first()
 
-      cy
-        .get('.layout .react-grid-item').first()
-        .find('img').should('have.length', 1)
-        .then((src) => {
-            const src1 = src;
-            // image exists
-            cy.get('.layout .react-grid-item .widget input[type="range"]').first()
+          // slider works
+          // (bugfix for not working simpler .invoke('val', '0').invoke('input'))
+          .then(($range) => {
+            const range = $range[0]; // get the DOM node
+            const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+              window.HTMLInputElement.prototype,
+              'value'
+            ).set;
+            nativeInputValueSetter.call(range, 0); // set the value manually
+            range.dispatchEvent(
+              new Event('input', { value: 0, bubbles: true })
+            ); // now dispatch the event
+          })
 
-              // slider works
-              // (bugfix for not working simpler .invoke('val', '0').invoke('input'))
-              .then(($range) => {
-                const range = $range[0]; // get the DOM node
-                const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
-                nativeInputValueSetter.call(range, 0); // set the value manually
-                range.dispatchEvent(new Event('input', { value: 0, bubbles: true })); // now dispatch the event
-              })
-
-              // shown image differs
-              .then((src2) => {
-                  cy.expect(src1).to.not.equal(src2)
-              })
-        })
-  })
+          // shown image differs
+          .then((src2) => {
+            cy.expect(src1).to.not.equal(src2);
+          });
+      });
+  });
 
   it('image_grid', () => {
-      cy.run('image_grid', {asyncrun: true})
-      cy.get(".window .content").first()
-        .find('img')
-        .should('have.length', 1)
-        .should('have.attr', 'width', '545px')
-        .should('have.attr', 'height', '205px')
-  })
+    cy.run('image_grid', { asyncrun: true });
+    cy.get(img_selector)
+      .should('have.length', 1)
+      .should('have.attr', 'width', '545px')
+      .should('have.attr', 'height', '205px');
+  });
 
   it('image_svg', () => {
-      cy.run('image_svg', {asyncrun: true})
-      cy.get(".window .content").first()
-        .find('ellipse')
-        .should('have.length', 1)
-        .should('have.attr', 'cx', 80)
-        .should('have.attr', 'cy', 80)
-        .should('have.attr', 'rx', 50)
-        .should('have.attr', 'ry', 30)
-  })
-
+    cy.run('image_svg', { asyncrun: true });
+    cy.get('.window .content')
+      .first()
+      .find('ellipse')
+      .should('have.length', 1)
+      .should('have.attr', 'cx', 80)
+      .should('have.attr', 'cy', 80)
+      .should('have.attr', 'rx', 50)
+      .should('have.attr', 'ry', 30);
+  });
 
   it('image_callback', () => {
-      cy.run('image_callback', {asyncrun: true})
-      cy.get('.layout .react-grid-item .content > div').first()
-         .click() // to focus the pane
-         .find('img')
-            .click(12, 34)
-            .click(45, 67)
-      cy.get('.layout .react-grid-item .content-text').first()
-        .contains("Coords:")
-        .contains("x: 12, y: 35;") // bug: y is off by 1
-        .contains("x: 45, y: 68;") // bug: y is off by 1
-  })
-
+    cy.run('image_callback', { asyncrun: true });
+    cy.get(img_selector)
+      .parents(win_selector)
+      .click() // to focus the pane
+      .find('img')
+      .click(12, 34)
+      .click(45, 67);
+    cy.get('.layout .react-grid-item .content-text')
+      .first()
+      .contains('Coords:')
+      .contains('x: 12, y: 35;') // bug: y is off by 1
+      .contains('x: 45, y: 68;'); // bug: y is off by 1
+  });
 
   it('image_callback2', () => {
-      cy.run('image_callback2', {asyncrun: true})
-      cy.get('.layout .react-grid-item .content > div').first()
-         .type('{rightArrow}'.repeat(3))
-         .type('{leftArrow}')
-         .find('img')
-         .should('have.attr', 'src', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAIAAADTED8xAAACvklEQVR4nO3TMQEAIAzAMMC/gblFxo4mCvr0zsyBqrcdAJsMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYC0D0ZzA8uAJ7iLAAAAAElFTkSuQmCC')
-  })
-})
+    cy.run('image_callback2', { asyncrun: true });
+    cy.get(img_selector)
+      .type('{rightArrow}'.repeat(3))
+      .type('{leftArrow}')
+      .should(
+        'have.attr',
+        'src',
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAIAAADTED8xAAACvklEQVR4nO3TMQEAIAzAMEDs/EtAxo4mCvr0zsyBqrcdAJsMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYA0A5BmANIMQJoBSDMAaQYgzQCkGYC0D5OxAzLzmPjyAAAAAElFTkSuQmCC'
+      );
+  });
+});

--- a/cypress/integration/modal.js
+++ b/cypress/integration/modal.js
@@ -94,10 +94,10 @@ describe('Test View Modal', () => {
     var env = 'view_modal_' + Cypress._.random(0, 1e6);
 
     // initialize any env
-    cy.run('text_basic', { env: env, open: false });
-    cy.run('image_basic', { env: env, open: false });
-    cy.run('plot_line_basic', { env: env, open: false });
-    cy.run('plot_bar_basic', { env: env });
+    cy.run('text_basic', { env: env }).wait(500);
+    cy.run('image_basic', { env: env, open: false }).wait(500);
+    cy.run('plot_line_basic', { env: env, open: false }).wait(500);
+    cy.run('plot_bar_basic', { env: env, open: false }).wait(500);
 
     // save the view at this point
     cy.get(viewbutton).click();

--- a/cypress/integration/text.js
+++ b/cypress/integration/text.js
@@ -1,41 +1,42 @@
 before(() => {
-  cy.visit('/')
-})
+  cy.visit('/');
+});
 
-const path = require("path");
+const path = require('path');
 
 describe('Text Pane', () => {
   it('text_basic', () => {
-      cy.run('text_basic')
-  })
-
-  it('text_update', () => {
-      cy.run('text_update')
-          .get('.layout .react-grid-item').first()
-          .contains('Hello World! More text should be here')
-          .contains('And here it is')
-  })
-
-  it('check download button', () => {
-      cy.run('text_update')
-          .get('.layout .react-grid-item').first()
-          .find('button[title="save"]').click()
-      const downloadsFolder = Cypress.config("downloadsFolder");
-      cy.readFile(path.join(downloadsFolder, "visdom_text.txt")).should("exist");
+    cy.run('text_basic');
   });
 
+  it('text_update', () => {
+    cy.run('text_update')
+      .get('.layout .react-grid-item')
+      .first()
+      .contains('Hello World! More text should be here')
+      .contains('And here it is');
+  });
+
+  it('check download button', () => {
+    cy.run('text_update')
+      .get('.layout .react-grid-item')
+      .first()
+      .find('button[title="save"]')
+      .click();
+    const downloadsFolder = Cypress.config('downloadsFolder');
+    cy.readFile(path.join(downloadsFolder, 'visdom_text.txt')).should('exist');
+  });
 
   it('text_callbacks', () => {
-      cy.run('text_callbacks', {asyncrun: true})
-      cy.get(".window .content").first()
-        .type("checking callback :({backspace})", {delay: 50}) // requiring a delay is a bug
-        .contains("checking callback :)")
-  })
+    cy.run('text_callbacks', { asyncrun: true });
+    cy.get('.window .content')
+      .first()
+      .type('checking callback :({backspace})', { delay: 200 }) // requiring a delay is a bug
+      .contains('checking callback :)');
+  });
 
   it('text_close', () => {
-      cy.run('text_close')
-      cy.get('.layout .window')
-        .should('have.length', 0);
-  })
-
-})
+    cy.run('text_close');
+    cy.get('.layout .window').should('have.length', 0);
+  });
+});


### PR DESCRIPTION
## Description
Ensuring functionality also using the `-use_frontend_client_polling` flag.

## Motivation and Context
Regarding the recent proxy-users and an upcoming code simplification of the server socket handlers, I suggest to add some testing of the polling-feature.
I have explicitly only added the "functional tests" to be tested against the `-use_frontend_client_polling` flag, which I though should be sufficient.

**In addition, a few minor changes were necessary in the following test cases:**
- the ImagePane tests `image_callback` and `image_callback2` failed now and then for the poller-implementation, but not for the websocket implementation. This was due to two windows being loaded in different orders in both implementation. (The image-panes load slower when using long polling). This PR solves this by adapting all cypress selectors for image panes to use a "pane with an Image" instead of the "first" pane in the list of panes.
- The test for the view modal did not work due to a similar problem: the image pane loaded slower for the poller-implementation. For sake of consistency, I've added `wait(500)` commands in between the respective pane-creation commands.
- The `text_callback` test failed randomly as well. This is probably due to too a missing order-enforcement of the events when passing incoming events to the callback. (Not sure here. Is this correct?). This PR increases the delay in-between callback keystrokes to `200ms` (from previously `50ms`) to solve the issue of inconsistent tests.

## How Has This Been Tested?
Testing using this very PR-action, which should already include the test.
Also, to test for consistency, I've triggered the exact same action onto 10 branches, see for instance [here](https://github.com/da-h/visdom/pull/22)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Test cases
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
 