### PR TITLE
Test for complete property update & fix the test `property_callback`

### DIFF
--- a/cypress/integration/properties.js
+++ b/cypress/integration/properties.js
@@ -20,21 +20,24 @@ describe('Properties Pane', () => {
 
       cy.get('input[value="initial"]').first().clear().type("changed{enter}")
       cy.get('.layout .react-grid-item .content-text').first().contains("Updated: Text input => changed")
+      cy.get('input[value="changed_updated"]')
 
       cy.get('input[value="12"]').first().clear().type("42{enter}")
       cy.get('.layout .react-grid-item .content-text').first().contains("Updated: Number input => 42")
+      cy.get('input[value="420"]')
 
       cy.get('button').contains("Start").click()
       cy.get('.layout .react-grid-item .content-text').first().contains("Updated: Button => clicked")
 
-      cy.get('input[type="checkbox"]').first().click()
+      cy.get('input[type="checkbox"]').first().should("be.checked").click()
       cy.get('.layout .react-grid-item .content-text').first().contains("Updated: Checkbox => False")
+      cy.get('input[type="checkbox"]').first().should("not.be.checked")
 
-      cy.get('select').first().select('Red').select('Blue')
+      cy.get('select').first().should("have.value", "1").select('Red')
       cy.get('.layout .react-grid-item .content-text').first().contains("Updated: Select => 0")
-
-      cy.get('select').first().select('Blue')
+      cy.get('select').first().should("have.value", "0").select('Blue')
       cy.get('.layout .react-grid-item .content-text').first().contains("Updated: Select => 2")
+      cy.get('select').first().should("have.value", "2")
 
   })
 

--- a/example/components/properties.py
+++ b/example/components/properties.py
@@ -30,7 +30,7 @@ def properties_callbacks(viz, env, args):
             else:
                 new_value = value
             properties[prop_id]['value'] = new_value
-            viz.properties(properties, win=properties_window)
+            viz.properties(properties, win=properties_window, env=env)
             viz.text("Updated: {} => {}".format(properties[event['propertyId']]['name'], str(event['value'])),
                      win=callback_text_window, append=True, env=env)
 


### PR DESCRIPTION

## Description
This PR applies two small changes to the testing-setup:
1. It adds some simple checks to test if properties in a `PropertyPane` are updated after a user-input.
2. Also fixing the respective test `property_callback`. The test did not update the properties correctly; it did write the changes, but to another `env`.

## Motivation and Context
`-`

## How Has This Been Tested?
`-`

## Screenshots (if appropriate):
`-`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
