### PR TITLE
[Big change] Migrate main.js to Functional React

### DIFF
--- a/cypress/integration/basic.js
+++ b/cypress/integration/basic.js
@@ -25,7 +25,7 @@ describe('Test Setup', () => {
   it('env selection works', () => {
     cy.visit('/')
     cy.get('.rc-tree-select [title="main"]').should('exist')
-    cy.get('.rc-tree-select').contains('main').trigger('mouseover')
+    cy.get('.rc-tree-select').contains('main').trigger('mouseover').wait(100);
     cy.get('.rc-tree-select .rc-tree-select-selection__choice__remove').click({force: true})
     cy.get('.rc-tree-select [title="main"]').should('not.exist')
     cy.get('.rc-tree-select').click()

--- a/cypress/integration/basic.js
+++ b/cypress/integration/basic.js
@@ -10,7 +10,11 @@ describe('Test Setup', () => {
   });
 
   it('manual server reconnect', () => {
-    cy.visit('/')
+    cy.visit('/').wait(1000)
+    cy.contains('online').click()
+    cy.contains('offline').click()
+    cy.contains('online').click()
+    cy.contains('offline').click()
     cy.contains('online').click()
     cy.contains('offline').click()
     cy.contains('online')

--- a/cypress/integration/pane.js
+++ b/cypress/integration/pane.js
@@ -68,13 +68,13 @@ basic_examples.forEach( (setting) => {
           [ height4, width4 ] = [ height, width];
       } else if (basic_example == "image_basic") {
           [ height, width ] = [ 545, 256 ];
-          [ height4, width4 ] = [ 624, width]; // this is an obvious bug in the ui
+          [ height4, width4 ] = [ 545, width];
       } else if (basic_example == "misc_plot_matplot") {
           [ height, width ] = [ 500, 622 ];
-          [ height4, width4 ] = [ 592, width];
+          [ height4, width4 ] = [ 500, width];
       } else if (basic_example == "plot_special_graph") {
           [ height, width ] = [ 515, 500 ];
-          [ height4, width4 ] = [ 610, width];
+          [ height4, width4 ] = [ 515, width];
       } else if (basic_example == "misc_video_tensor") {
           [ height, width ] = [ 290, 243 ];
           [ height4, width4 ] = [ 290, width];

--- a/js/main.js
+++ b/js/main.js
@@ -393,6 +393,9 @@ function App() {
     }
   };
 
+  // we need to update the socket-callback so that we have an up-to date state
+  if (_socket.current) _socket.current.onmessage = _handleMessage;
+
   // close server connection
   const disconnect = () => {
     _socket.current.close();

--- a/js/main.js
+++ b/js/main.js
@@ -744,18 +744,18 @@ function App() {
     });
   };
 
-  const updateToLayout = (layoutID) => {
+  const updateToLayout = (newLayoutID) => {
     setSelection((prev) => ({
       ...prev,
-      layoutID: layoutID,
+      layoutID: newLayoutID,
     }));
     // TODO this is very non-conventional react, someday it shall be fixed but
     // for now it's important to fix relayout grossness
-    selection.layoutID = layoutID;
+    selection.layoutID = newLayoutID;
     if (selection.layoutID !== DEFAULT_LAYOUT) {
-      relayout();
-      relayout();
-      relayout();
+      callbacks.current.push('relayout');
+      callbacks.current.push('relayout');
+      callbacks.current.push('relayout');
     }
   };
 
@@ -1076,17 +1076,11 @@ function App() {
       filter={filterString}
       onFilterChange={(ev) => {
         setFilterString(ev.target.value);
-        // TODO remove this once relayout is moved to a post-state
-        // update kind of thing
-        relayout();
-        relayout();
+        callbacks.current.push('relayout');
       }}
       onFilterClear={() => {
         setFilterString('');
-        // TODO remove this once relayout is moved to a post-state
-        // update kind of thing
-        relayout();
-        relayout();
+        callbacks.current.push('relayout');
       }}
     />
   );

--- a/js/main.js
+++ b/js/main.js
@@ -696,9 +696,6 @@ function App() {
       ...prev,
       panes: newPanes,
     }));
-    // TODO this is very non-conventional react, someday it shall be fixed but
-    // for now it's important to fix relayout grossness
-    storeData.panes = newPanes;
     updateLayout(newLayout);
   };
 

--- a/js/main.js
+++ b/js/main.js
@@ -813,12 +813,13 @@ function App() {
    *
    * @param data Data to be sent to backend.
    */
-  const sendPaneMessage = (data) => {
-    if (focusedPaneID === null || sessionInfo.readonly) {
+  const sendPaneMessage = (data, target = null) => {
+    if (!target) target = focusedPaneID;
+    if (target === null || sessionInfo.readonly) {
       return;
     }
     let finalData = {
-      target: focusedPaneID,
+      target: target,
       eid: selection.envID,
     };
     $.extend(finalData, data);

--- a/js/main.js
+++ b/js/main.js
@@ -14,7 +14,7 @@
 import 'fetch';
 import 'rc-tree-select/assets/index.css';
 
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import ReactResizeDetector from 'react-resize-detector';
 
@@ -61,78 +61,81 @@ if (ACTIVE_ENV !== '') {
   use_envs = JSON.parse(localStorage.getItem('envIDs')) || ['main'];
 }
 
-// TODO: Move some of this to smaller components and/or use something like redux
-// to move state out of the app to a standalone store.
-class App extends React.Component {
-  state = {
-    connected: false,
-    readonly: false,
-    sessionID: null,
+function App() {
+  // -------------- //
+  // state varibles //
+  // -------------- //
+
+  // internal variables
+  const mounted = useRef(false);
+  const [connected, setConnected] = useState(false);
+  const [sessionInfo, setSessionInfo] = useState({ id: null, readonly: false });
+  const [resizeClickHappened, setResizeClickHappened] = useState(false);
+  const windowSize = useRef({
+    width: 1280,
+    cols: 100,
+  });
+
+  // data stores
+  const [storeMeta, setStoreMeta] = useState({
+    envList: ENV_LIST.slice(),
+    layoutLists: new Map([['main', new Map([[DEFAULT_LAYOUT, new Map()]])]]),
+  });
+  const [storeData, setStoreData] = useState({
     panes: {},
-    consistent_pane_copy: {},
-    focusedPaneID: null,
+    layout: [],
+  });
+
+  // user-changeable
+  const [showEnvModal, setShowEnvModal] = useState(false);
+  const [showViewModal, setShowViewModal] = useState(false);
+  const [focusedPaneID, setFocusedPaneID] = useState(null);
+  const [selection, setSelection] = useState({
     envID: use_env,
     envIDs: use_envs,
     layoutID: DEFAULT_LAYOUT,
     // Bad form... make a copy of the global var we generated in python.
-    envList: ENV_LIST.slice(),
-    filter: localStorage.getItem('filter') || '',
-    layout: [],
-    cols: 100,
-    width: 1280,
-    layoutLists: new Map([['main', new Map([[DEFAULT_LAYOUT, new Map()]])]]),
-    showEnvModal: false,
-    showViewModal: false,
-    envSelectorStyle: {
-      width: 1280 / 2,
-    },
-  };
+  });
+  const [filterString, setFilterString] = useState(
+    localStorage.getItem('filter') || ''
+  );
 
-  _bin = null;
-  _socket = null;
-  _timeoutID = null;
-  _pendingPanes = [];
-  _firstLoad = true;
+  // non-triggering state variables
+  const consistent_pane_copy = useRef({});
+  const _bin = useRef(null);
+  const _socket = useRef(null);
+  const _timeoutID = useRef(null);
+  const _pendingPanes = useRef([]);
 
-  constructor() {
-    super();
-    this.updateDimensions = this.updateDimensions.bind(this);
-    this.resize_click_happened = false;
-  }
+  // --------------------- //
+  // grid helper functions //
+  // --------------------- //
 
-  colWidth = () => {
-    return (
-      (this.state.width - MARGIN * (this.state.cols - 1) - MARGIN * 2) /
-      this.state.cols
-    );
-  };
+  // calculate number of columns based on window width
+  const colWidth = () =>
+    (windowSize.current.width -
+      MARGIN * (windowSize.current.cols - 1) -
+      MARGIN * 2) /
+    windowSize.current.cols;
 
-  p2w = (w) => {
-    // translate pixels -> RGL grid coordinates
-    let colWidth = this.colWidth();
-    return (w + MARGIN) / (colWidth + MARGIN);
-  };
+  // translate pixels -> RGL grid coordinates
+  const p2w = (w) => (w + MARGIN) / (colWidth() + MARGIN);
+  const p2h = (h) => (h + MARGIN) / (ROW_HEIGHT + MARGIN);
 
-  w2p = (p) => {
-    let colWidth = this.colWidth();
-    return p * (colWidth + MARGIN) - MARGIN;
-  };
+  // translate RGL grid width to pixels
+  const w2p = (p) => p * (colWidth() + MARGIN) - MARGIN;
+  const h2p = (p) => p * (ROW_HEIGHT + MARGIN) - MARGIN;
 
-  p2h = (h) => {
-    return (h + MARGIN) / (ROW_HEIGHT + MARGIN);
-  };
+  // ---------------- //
+  // helper functions //
+  // ---------------- //
+  const deepcopy = (obj) => JSON.parse(JSON.stringify(obj));
 
-  h2p = (p) => {
-    return p * (ROW_HEIGHT + MARGIN) - MARGIN;
-  };
+  // append env to pane id for localStorage key
+  const keyLS = (key) => selection.envID + '_' + key;
 
-  keyLS = (key) => {
-    // append env to pane id for localStorage key
-    return this.state.envID + '_' + key;
-  };
-
-  getValidFilter = (filter) => {
-    // Ensure the regex filter is valid
+  // Ensure the regex filter is valid
+  const getValidFilter = (filter) => {
     try {
       'test_string'.match(filter);
     } catch (e) {
@@ -141,7 +144,8 @@ class App extends React.Component {
     return filter;
   };
 
-  correctPathname = () => {
+  // retrieve normalized window.location
+  const correctPathname = () => {
     var pathname = window.location.pathname;
     if (pathname.indexOf('/env/') > -1) {
       pathname = pathname.split('/env/')[0];
@@ -154,61 +158,77 @@ class App extends React.Component {
     return pathname;
   };
 
-  addPaneBatched = (pane) => {
-    if (!this._timeoutID) {
-      this._timeoutID = setTimeout(this.processBatchedPanes, 100);
+  // ------------------ //
+  // batched processing //
+  // ------------------ //
+
+  // store pane to be processed
+  const addPaneBatched = (pane) => {
+    if (!_timeoutID.current) {
+      _timeoutID.current = setTimeout(processBatchedPanes, 100);
     }
-    this._pendingPanes.push(pane);
+    _pendingPanes.current.push(pane);
   };
 
-  processBatchedPanes = () => {
-    let newPanes = Object.assign({}, this.state.panes);
-    let newLayout = this.state.layout.slice();
+  // run processing on queue
+  const processBatchedPanes = () => {
+    // wait until app is mounted
+    if (!mounted.current) {
+      _timeoutID.current = setTimeout(processBatchedPanes, 100);
+      return;
+    }
+    let newPanes = Object.assign({}, storeData.panes);
+    let newLayout = storeData.layout.slice();
 
-    this._pendingPanes.forEach((pane) => {
-      this.processPane(pane, newPanes, newLayout);
+    _pendingPanes.current.forEach((pane) => {
+      processPane(pane, newPanes, newLayout);
     });
 
-    this._pendingPanes = [];
-    this._timeoutID = null;
+    _pendingPanes.current = [];
+    _timeoutID.current = null;
 
-    this.setState({
+    setStoreData((prev) => ({
+      ...prev,
       panes: newPanes,
       layout: newLayout,
-    });
+    }));
   };
 
-  processPane = (newPane, newPanes, newLayout) => {
+  // process single pane
+  const processPane = (newPane, newPanes, newLayout) => {
     let exists = newPane.id in newPanes;
     newPanes[newPane.id] = newPane;
 
+    consistent_pane_copy.current[newPane.id] = deepcopy(newPane);
+
     if (!exists) {
-      this.state.consistent_pane_copy[newPane.id] = JSON.parse(
-        JSON.stringify(newPane)
-      ); //Deep Copy
-      let stored = JSON.parse(localStorage.getItem(this.keyLS(newPane.id)));
-      if (this._bin == null) {
-        this.rebin();
+      let stored = JSON.parse(localStorage.getItem(keyLS(newPane.id)));
+      if (_bin.current == null) {
+        rebin();
       }
+      let paneLayout;
       if (stored) {
-        var paneLayout = stored;
-        this._bin.content.push(paneLayout);
+        paneLayout = stored;
+        _bin.current.content.push(paneLayout);
       } else {
         let w = PANE_SIZE[newPane.type][0],
           h = PANE_SIZE[newPane.type][1];
 
-        if (newPane.width) w = this.p2w(newPane.width);
-        if (newPane.height) h = Math.ceil(this.p2h(newPane.height + 14));
+        if (newPane.width) w = p2w(newPane.width);
+        if (newPane.height) h = Math.ceil(p2h(newPane.height + 14));
         if (newPane.content && newPane.content.caption) h += 1;
 
-        this._bin.content.push({
+        _bin.current.content.push({
           width: w,
           height: h,
         });
 
-        let pos = this._bin.position(newLayout.length, this.state.cols);
+        let pos = _bin.current.position(
+          newLayout.length,
+          windowSize.current.cols
+        );
 
-        var paneLayout = {
+        paneLayout = {
           i: newPane.id,
           w: w,
           h: h,
@@ -223,23 +243,20 @@ class App extends React.Component {
       newLayout.push(paneLayout);
     } else {
       let currLayout = getLayoutItem(newLayout, newPane.id);
-      if (newPane.width) currLayout.w = this.p2w(newPane.width);
-      if (newPane.height)
-        currLayout.h = Math.ceil(this.p2h(newPane.height + 14));
+      if (newPane.width) currLayout.w = p2w(newPane.width);
+      if (newPane.height) currLayout.h = Math.ceil(p2h(newPane.height + 14));
       if (newPane.content && newPane.content.caption) currLayout.h += 1;
-      this.state.consistent_pane_copy[newPane.id] = JSON.parse(
-        JSON.stringify(newPane)
-      ); //Deep Copy
     }
   };
 
-  connect = () => {
-    if (this._socket) {
+  // connect to server
+  const connect = () => {
+    if (_socket.current) {
       return;
     }
     // eslint-disable-next-line no-undef
     if (USE_POLLING) {
-      this._socket = new Poller(this);
+      _socket.current = new Poller(this);
       return;
     }
     var url = window.location;
@@ -250,103 +267,101 @@ class App extends React.Component {
       ws_protocol = 'ws';
     }
     var socket = new WebSocket(
-      ws_protocol + '://' + url.host + this.correctPathname() + 'socket'
+      ws_protocol + '://' + url.host + correctPathname() + 'socket'
     );
 
-    socket.onmessage = this._handleMessage;
+    socket.onmessage = _handleMessage;
 
     socket.onopen = () => {
-      this.setState({
-        connected: true,
-      });
+      setConnected(true);
     };
 
     socket.onerror = socket.onclose = () => {
-      this.setState({ connected: false }, function () {
-        this._socket = null;
-      });
+      // check if is mounted. error can appear on unmounted component
+      if (mounted.current) {
+        setConnected(false);
+        socket.current = null;
+      }
     };
 
-    this._socket = socket;
+    _socket.current = socket;
   };
 
-  _checkWindow = (cmd, numTries) => {
-    if (cmd.win in this.state.consistent_pane_copy) {
-      // Apply patch and check hash. Re-fetch if final window doesn't match hash
-      let windowContent = this.state.consistent_pane_copy[cmd.win];
+  // Apply patch and check hash. Re-fetch if final window doesn't match hash
+  const _checkWindow = (cmd, numTries) => {
+    if (cmd.win in consistent_pane_copy.current) {
+      let windowContent = consistent_pane_copy.current[cmd.win];
       let finalWindow = jsonpatch.applyPatch(
         windowContent,
         cmd.content
       ).newDocument;
       let hashed = md5(stringify(finalWindow));
       if (hashed === cmd.finalHash) {
-        this.state.consistent_pane_copy[cmd.win] = finalWindow;
-        let modifiedWindow = this.state.panes[cmd.win];
+        consistent_pane_copy.current[cmd.win] = finalWindow;
+
+        let modifiedWindow = storeData.panes[cmd.win];
         let modifiedFinalWindow = jsonpatch.applyPatch(
           modifiedWindow,
           cmd.content
         ).newDocument;
-        this.addPaneBatched(modifiedFinalWindow);
+        addPaneBatched(modifiedFinalWindow);
       } else {
-        this.postForEnv(this.state.envIDs);
+        postForEnv(selection.envIDs);
       }
     } else {
       numTries--;
       if (numTries) {
-        setTimeout(this._checkWindow, 100, cmd, numTries);
+        setTimeout(_checkWindow, 100, cmd, numTries);
       } else {
-        this.postForEnv(this.state.envIDs);
+        postForEnv(selection.envIDs);
       }
     }
   };
 
-  _handleMessage = (evt) => {
+  // handle server messages
+  const _handleMessage = (evt) => {
     var cmd = JSON.parse(evt.data);
     switch (cmd.command) {
       case 'register':
-        this.setState(
-          {
-            sessionID: cmd.data,
-            readonly: cmd.readonly,
-          },
-          () => {
-            this.postForEnv(this.state.envIDs);
-          }
-        );
+        setSessionInfo((prev) => ({
+          ...prev,
+          id: cmd.data,
+          readonly: cmd.readonly,
+        }));
         break;
       case 'pane':
       case 'window':
         // If we're in compare mode and recieve an update to an environment
         // that is selected that isn't from the compare output, we need to
         // reload the compare output
-        if (this.state.envIDs.length > 1 && cmd.has_compare !== true) {
-          this.postForEnv(this.state.envIDs);
+        if (selection.envIDs.length > 1 && cmd.has_compare !== true) {
+          postForEnv(selection.envIDs);
         } else {
-          this.addPaneBatched(cmd);
+          addPaneBatched(cmd);
         }
         break;
       case 'window_update':
-        if (this.state.envIDs.length > 1 && cmd.has_compare !== true) {
-          this.postForEnv(this.state.envIDs);
+        if (selection.envIDs.length > 1 && cmd.has_compare !== true) {
+          postForEnv(selection.envIDs);
         } else {
           let numTries = 3;
           // Check to see if the window exists before trying to update
-          setTimeout(this._checkWindow, 0, cmd, numTries);
+          setTimeout(_checkWindow, 0, cmd, numTries);
         }
         break;
       case 'reload':
         for (var it in cmd.data) {
-          localStorage.setItem(this.keyLS(it), JSON.stringify(cmd.data[it]));
+          localStorage.setItem(keyLS(it), JSON.stringify(cmd.data[it]));
         }
         break;
       case 'close':
-        this.closePane(cmd.data);
+        closePane(cmd.data);
         break;
       case 'layout':
-        this.relayout();
+        relayout();
         break;
       case 'env_update':
-        var layoutLists = this.state.layoutLists;
+        var layoutLists = storeMeta.layoutLists;
         for (var envIdx in cmd.data) {
           if (!layoutLists.has(cmd.data[envIdx])) {
             layoutLists.set(
@@ -355,94 +370,97 @@ class App extends React.Component {
             );
           }
         }
-        this.setState({
+        setStoreMeta((prev) => ({
+          ...prev,
           envList: cmd.data,
           layoutLists: layoutLists,
-        });
+        }));
         break;
       case 'layout_update':
-        this.parseLayoutsFromServer(cmd.data);
+        parseLayoutsFromServer(cmd.data);
         break;
       default:
         console.error('unrecognized command', cmd);
     }
   };
 
-  disconnect = () => {
-    this._socket.close();
+  // close server connection
+  const disconnect = () => {
+    _socket.current.close();
+    _socket.current = null;
   };
 
-  sendSocketMessage(data) {
-    if (!this._socket) {
+  // send message to server
+  const sendSocketMessage = (data) => {
+    if (!_socket.current) {
       // TODO: error? warn?
       return;
     }
 
     let msg = JSON.stringify(data);
-    return this._socket.send(msg);
-  }
+    return _socket.current.send(msg);
+  };
 
-  closePane = (paneID, keepPosition = false, setState = true) => {
-    if (this.state.readonly) {
+  // remove paneID from pane list
+  // (also tell server)
+  const closePane = (paneID, keepPosition = false, setState = true) => {
+    if (sessionInfo.readonly) {
       return;
     }
-    let newPanes = Object.assign({}, this.state.panes);
-    let newPanesCopy = Object.assign({}, this.state.consistent_pane_copy);
+    let newPanes = Object.assign({}, storeData.panes);
+    let newPanesCopy = Object.assign({}, consistent_pane_copy.current);
     delete newPanes[paneID];
     delete newPanesCopy[paneID];
     if (!keepPosition) {
-      localStorage.removeItem(this.keyLS(this.id));
+      localStorage.removeItem(keyLS(paneID));
 
-      this.sendSocketMessage({
+      sendSocketMessage({
         cmd: 'close',
         data: paneID,
-        eid: this.state.envID,
+        eid: selection.envID,
       });
     }
 
     if (setState) {
-      let focusedPaneID = this.state.focusedPaneID;
       // Make sure we remove the pane from our layout.
-      let newLayout = this.state.layout.filter(
+      let newLayout = storeData.layout.filter(
         (paneLayout) => paneLayout.i !== paneID
       );
 
-      this.setState(
-        {
-          layout: newLayout,
-          panes: newPanes,
-          consistent_pane_copy: newPanesCopy,
-          focusedPaneID: focusedPaneID === paneID ? null : focusedPaneID,
-        },
-        () => {
-          this.relayout();
-        }
-      );
+      consistent_pane_copy.current = newPanesCopy;
+      setStoreData((prev) => ({
+        ...prev,
+        layout: newLayout,
+        panes: newPanes,
+        // TODO: before function based react, this has called a relayout (right after setState)
+        // () => relayout();
+      }));
+      setFocusedPaneID(focusedPaneID === paneID ? null : focusedPaneID);
     }
   };
 
-  closeAllPanes = () => {
-    if (this.state.readonly) {
+  const closeAllPanes = () => {
+    if (sessionInfo.readonly) {
       return;
     }
-    Object.keys(this.state.panes).map((paneID) => {
-      this.closePane(paneID, false, false);
+    Object.keys(storeData.panes).map((paneID) => {
+      closePane(paneID, false, false);
     });
-    this.rebin();
-    this.setState({
+    rebin();
+    consistent_pane_copy.current = {};
+    setStoreData((prev) => ({
+      ...prev,
       layout: [],
       panes: {},
-      consistent_pane_copy: {},
-      focusedPaneID: null,
-      // confirmClear: false,
-    });
+    }));
+    setFocusedPaneID(null);
   };
 
-  onEnvSelect = (selectedNodes) => {
-    var isSameEnv = selectedNodes.length == this.state.envIDs.length;
+  const onEnvSelect = (selectedNodes) => {
+    var isSameEnv = selectedNodes.length == selection.envIDs.length;
     if (isSameEnv) {
       for (var i = 0; i < selectedNodes.length; i++) {
-        if (selectedNodes[i] != this.state.envIDs[i]) {
+        if (selectedNodes[i] != selection.envIDs[i]) {
           isSameEnv = false;
           break;
         }
@@ -452,70 +470,74 @@ class App extends React.Component {
     if (selectedNodes.length == 1) {
       envID = selectedNodes[0];
     }
-    this.setState({
+    setSelection((prev) => ({
+      ...prev,
       envID: envID,
       envIDs: selectedNodes,
-      panes: isSameEnv ? this.state.panes : {},
-      layout: isSameEnv ? this.state.layout : [],
-      focusedPaneID: isSameEnv ? this.state.focusedPaneID : null,
-    });
+    }));
+    setStoreData((prev) => ({
+      ...prev,
+      panes: isSameEnv ? storeData.panes : {},
+      layout: isSameEnv ? storeData.layout : [],
+    }));
+    setFocusedPaneID(isSameEnv ? focusedPaneID : null);
     localStorage.setItem('envID', envID);
     localStorage.setItem('envIDs', JSON.stringify(selectedNodes));
-    this.postForEnv(selectedNodes);
+    postForEnv(selectedNodes);
   };
 
-  postForEnv = (envIDs) => {
+  const postForEnv = (envIDs) => {
     // This kicks off a new stream of events from the socket so there's nothing
     // to handle here. We might want to surface the error state.
     if (envIDs.length == 1) {
       $.post(
-        this.correctPathname() + 'env/' + envIDs[0],
+        correctPathname() + 'env/' + envIDs[0],
         JSON.stringify({
-          sid: this.state.sessionID,
+          sid: sessionInfo.id,
         })
       );
     } else if (envIDs.length > 1) {
       $.post(
-        this.correctPathname() + 'compare/' + envIDs.join('+'),
+        correctPathname() + 'compare/' + envIDs.join('+'),
         JSON.stringify({
-          sid: this.state.sessionID,
+          sid: sessionInfo.id,
         })
       );
     }
   };
 
-  onEnvDelete = (env2delete, previousEnv) => {
-    this.sendSocketMessage({
+  const onEnvDelete = (env2delete, previousEnv) => {
+    sendSocketMessage({
       cmd: 'delete_env',
       prev_eid: previousEnv,
       eid: env2delete,
     });
   };
 
-  onEnvSave = (env) => {
-    if (!this.state.connected) {
+  const onEnvSave = (env) => {
+    if (!connected) {
       return;
     }
 
-    this.updateLayout(this.state.layout);
+    updateLayout(storeData.layout);
 
     let payload = {};
-    Object.keys(this.state.panes).map((paneID) => {
-      payload[paneID] = JSON.parse(localStorage.getItem(this.keyLS(paneID)));
+    Object.keys(storeData.panes).map((paneID) => {
+      payload[paneID] = JSON.parse(localStorage.getItem(keyLS(paneID)));
     });
 
-    this.sendSocketMessage({
+    sendSocketMessage({
       cmd: 'save',
       data: payload,
-      prev_eid: this.state.envID,
+      prev_eid: selection.envID,
       eid: env,
     });
 
-    let newEnvList = this.state.envList;
+    let newEnvList = storeMeta.envList;
     if (newEnvList.indexOf(env) === -1) {
       newEnvList.push(env);
     }
-    let layoutLists = this.state.layoutLists;
+    let layoutLists = storeMeta.layoutLists;
 
     for (var envIdx in newEnvList) {
       if (!layoutLists.has(newEnvList[envIdx])) {
@@ -526,79 +548,78 @@ class App extends React.Component {
       }
     }
 
-    this.setState({
+    setStoreMeta((prev) => ({
+      ...prev,
       envList: newEnvList,
       layoutLists: layoutLists,
+    }));
+    setSelection((prev) => ({
+      ...prev,
       envID: env,
       envIDs: [env],
-    });
+    }));
   };
 
-  focusPane = (paneID, cb) => {
-    this.setState(
-      {
-        focusedPaneID: paneID,
-      },
-      cb
-    );
+  const focusPane = (paneID, callback) => {
+    if (callback) callback();
+    if (focusedPaneID != paneID) setFocusedPaneID(paneID);
   };
 
-  blurPane = (e) => {
-    this.setState({
-      focusedPaneID: null,
-    });
+  const blurPane = () => {
+    if (focusedPaneID != null) setFocusedPaneID(null);
   };
 
-  resizePane = (layout, oldLayoutItem, layoutItem) => {
+  const resizePane = (layout, oldLayoutItem, layoutItem) => {
     // register a double click on the resize handle to reset the window size
     if (
-      this.resize_click_happened &&
+      resizeClickHappened &&
       layoutItem.w == oldLayoutItem.w &&
       layoutItem.h == oldLayoutItem.h
     ) {
-      let pane = this.state.consistent_pane_copy[layoutItem.i];
+      let pane = consistent_pane_copy.current[layoutItem.i];
 
       // resets to default layout (same as during pane creation)
-      layoutItem.w = pane.width
-        ? this.p2w(pane.width)
-        : PANE_SIZE[pane.type][0];
+      layoutItem.w = pane.width ? p2w(pane.width) : PANE_SIZE[pane.type][0];
       layoutItem.h = pane.height
-        ? this.p2w(pane.height + 14)
+        ? Math.ceil(p2h(pane.height + 14))
         : PANE_SIZE[pane.type][1];
+      if (pane.content && pane.content.caption) layoutItem.h += 1;
     }
 
     // update layout according to user interaction
-    this.setState({
+    setSelection((prev) => ({
+      ...prev,
       layoutID: DEFAULT_LAYOUT,
-    });
-    this.focusPane(layoutItem.i);
-    this.updateLayout(layout);
-    this.sendLayoutItemState(layoutItem);
+    }));
+    focusPane(layoutItem.i);
+    updateLayout(layout);
+    sendLayoutItemState(layoutItem);
 
     // register a double click in this function
-    this.resize_click_happened = true;
+    setResizeClickHappened(true);
     setTimeout(
       function () {
-        this.resize_click_happened = false;
+        setResizeClickHappened(false);
       }.bind(this),
       400
     );
   };
 
-  movePane = (layout, oldLayoutItem, layoutItem) => {
-    this.setState({
+  const movePane = (layout) => {
+    setSelection((prev) => ({
+      ...prev,
       layoutID: DEFAULT_LAYOUT,
-    });
-    this.updateLayout(layout);
+    }));
+    updateLayout(layout);
   };
 
-  rebin = (layout) => {
-    layout = layout ? layout : this.state.layout;
-    let layoutID = this.state.layoutID;
+  const rebin = (layout) => {
+    layout = layout ? layout : storeData.layout;
+    let layoutID = selection.layoutID;
     if (layoutID !== DEFAULT_LAYOUT) {
-      let envLayoutList = this.getCurrLayoutList();
-      let layoutMap = envLayoutList.get(this.state.layoutID);
-      layout = layout.map((paneLayout, idx) => {
+      let envLayoutList = getCurrLayoutList();
+      let layoutMap = envLayoutList.get(selection.layoutID);
+      layout = layout.map((paneLayout) => {
         if (layoutMap.has(paneLayout.i)) {
           let storedVals = layoutMap.get(paneLayout.i);
           paneLayout.h = storedVals[1];
@@ -609,35 +630,35 @@ class App extends React.Component {
         return paneLayout;
       });
     }
-    let contents = layout.map((paneLayout, idx) => {
+    let contents = layout.map((paneLayout) => {
       return {
         width: paneLayout.w,
         height: paneLayout.h,
       };
     });
 
-    this._bin = new Bin.ShelfFirst(contents, this.state.cols);
+    _bin.current = new Bin.ShelfFirst(contents, windowSize.current.cols);
     return layout;
   };
 
-  getCurrLayoutList() {
-    if (this.state.layoutLists.has(this.state.envID)) {
-      return this.state.layoutLists.get(this.state.envID);
+  const getCurrLayoutList = () => {
+    if (storeMeta.layoutLists.has(selection.envID)) {
+      return storeMeta.layoutLists.get(selection.envID);
     } else {
       return new Map();
     }
-  }
+  };
 
-  relayout = (pack) => {
-    let layout = this.rebin();
+  const relayout = () => {
+    let layout = rebin();
 
     let sorted = sortLayout(layout);
-    let newPanes = Object.assign({}, this.state.panes);
-    let filter = this.getValidFilter(this.state.filter);
+    let newPanes = Object.assign({}, storeData.panes);
+    let filter = getValidFilter(filterString);
     let old_sorted = sorted.slice();
-    let layoutID = this.state.layoutID;
-    let envLayoutList = this.getCurrLayoutList();
-    let layoutMap = envLayoutList.get(this.state.layoutID);
+    let layoutID = selection.layoutID;
+    let envLayoutList = getCurrLayoutList();
+    let layoutMap = envLayoutList.get(selection.layoutID);
     // Sort out things that were filtered away
     sorted = sorted.sort(function (a, b) {
       let diff =
@@ -658,71 +679,81 @@ class App extends React.Component {
     });
 
     let newLayout = sorted.map((paneLayout, idx) => {
-      let pos = this._bin.position(idx, this.state.cols);
+      let pos = _bin.current.position(idx, windowSize.current.cols);
 
-      if (!newPanes[paneLayout.i]) debugger;
       newPanes[paneLayout.i].i = idx;
 
       return Object.assign({}, paneLayout, pos);
     });
 
-    this.setState({
+    setStoreData((prev) => ({
+      ...prev,
       panes: newPanes,
-    });
+    }));
     // TODO this is very non-conventional react, someday it shall be fixed but
     // for now it's important to fix relayout grossness
-    this.state.panes = newPanes;
-    this.updateLayout(newLayout);
+    storeData.panes = newPanes;
+    updateLayout(newLayout);
   };
 
-  toggleOnlineState = () => {
-    if (this.state.connected) {
-      this.disconnect();
+  const toggleOnlineState = () => {
+    if (connected) {
+      disconnect();
     } else {
-      this.connect();
+      connect();
     }
   };
 
-  updateLayout = (layout) => {
-    this.setState({ layout: layout }, (newState) => {
-      this.state.layout.map((playout, idx) => {
-        localStorage.setItem(this.keyLS(playout.i), JSON.stringify(playout));
-      });
-    });
+  const updateLayout = (layout) => {
+    setStoreData((prev) => ({ ...prev, layout: layout }));
     // TODO this is very non-conventional react, someday it shall be fixed but
     // for now it's important to fix relayout grossness
-    this.state.layout = layout;
+    storeData.layout = layout;
   };
+  useEffect(() => {
+    storeData.layout.map((playout) => {
+      localStorage.setItem(keyLS(playout.i), JSON.stringify(playout));
+    });
+  }, [storeData]);
 
   /**
    * Send layout item state to backend to update backend state.
    *
    * @param layout Layout to be sent to backend.
    */
-  sendLayoutItemState = ({ i, h, w, x, y, moved, static: staticBool }) => {
-    this.sendSocketMessage({
+  const sendLayoutItemState = ({
+    i,
+    h,
+    w,
+    x,
+    y,
+    moved,
+    static: staticBool,
+  }) => {
+    sendSocketMessage({
       cmd: 'layout_item_update',
-      eid: this.state.envID,
+      eid: selection.envID,
       win: i,
       data: { i, h, w, x, y, moved, static: staticBool },
     });
   };
 
-  updateToLayout = (layoutID) => {
-    this.setState({
+  const updateToLayout = (layoutID) => {
+    setSelection((prev) => ({
+      ...prev,
       layoutID: layoutID,
-    });
+    }));
     // TODO this is very non-conventional react, someday it shall be fixed but
     // for now it's important to fix relayout grossness
-    this.state.layoutID = layoutID;
-    if (layoutID !== DEFAULT_LAYOUT) {
-      this.relayout();
-      this.relayout();
-      this.relayout();
+    selection.layoutID = layoutID;
+    if (selection.layoutID !== DEFAULT_LAYOUT) {
+      relayout();
+      relayout();
+      relayout();
     }
   };
 
-  parseLayoutsFromServer(layoutJSON) {
+  const parseLayoutsFromServer = (layoutJSON) => {
     // Handles syncing layout state from the server
     if (layoutJSON.length == 0) {
       return; // Skip totally blank updates, these are empty inits
@@ -740,19 +771,23 @@ class App extends React.Component {
       }
       layoutLists.set(envName, layoutList);
     }
-    let currList = this.getCurrLayoutList();
-    let layoutID = this.state.layoutID;
-    if (!currList.has(this.state.layoutID)) {
+    let currList = getCurrLayoutList();
+    let layoutID = selection.layoutID;
+    if (!currList.has(selection.layoutID)) {
       // If the current view was deleted by someone else (eek)
       layoutID = DEFAULT_LAYOUT;
     }
-    this.setState({
+    setStoreMeta((prev) => ({
+      ...prev,
       layoutLists: layoutLists,
+    }));
+    setSelection((prev) => ({
+      ...prev,
       layoutID: layoutID,
-    });
-  }
+    }));
+  };
 
-  publishEvent = (event) => {
+  const publishEvent = (event) => {
     EventSystem.publish('global.event', event);
   };
 
@@ -765,37 +800,37 @@ class App extends React.Component {
    *
    * @param data Data to be sent to backend.
    */
-  sendPaneMessage = (data) => {
-    if (this.state.focusedPaneID === null || this.state.readonly) {
+  const sendPaneMessage = (data) => {
+    if (focusedPaneID === null || sessionInfo.readonly) {
       return;
     }
     let finalData = {
-      target: this.state.focusedPaneID,
-      eid: this.state.envID,
+      target: focusedPaneID,
+      eid: selection.envID,
     };
     $.extend(finalData, data);
-    this.sendSocketMessage({
+    sendSocketMessage({
       cmd: 'forward_to_vis',
       data: finalData,
     });
   };
 
-  sendEmbeddingPop = (data) => {
-    if (this.state.focusedPaneID === null || this.state.readonly) {
+  const sendEmbeddingPop = (data) => {
+    if (focusedPaneID === null || sessionInfo.readonly) {
       return;
     }
     let finalData = {
-      target: this.state.focusedPaneID,
-      eid: this.state.envID,
+      target: focusedPaneID,
+      eid: selection.envID,
     };
     $.extend(finalData, data);
-    this.sendSocketMessage({
+    sendSocketMessage({
       cmd: 'pop_embeddings_pane',
       data: finalData,
     });
   };
 
-  exportLayoutsToServer(layoutLists) {
+  const exportLayoutsToServer = (layoutLists) => {
     // pushes layouts to the server
     let objForm = {};
     for (let [envName, layoutList] of layoutLists) {
@@ -808,342 +843,294 @@ class App extends React.Component {
       }
     }
     let exportForm = JSON.stringify(objForm);
-    this.sendSocketMessage({
+    sendSocketMessage({
       cmd: 'save_layouts',
       data: exportForm,
     });
-  }
+  };
 
-  onLayoutSave(layoutName) {
+  const onLayoutSave = (layoutName) => {
     // Saves the current view as a new layout, pushes to the server
-    let sorted = sortLayout(this.state.layout);
+    let sorted = sortLayout(storeData.layout);
     let layoutMap = new Map();
     for (var idx = 0; idx < sorted.length; idx++) {
-      let pane = this.state.panes[sorted[idx].i];
-      let currLayout = getLayoutItem(this.state.layout, pane.id);
+      let pane = storeData.panes[sorted[idx].i];
+      let currLayout = getLayoutItem(storeData.layout, pane.id);
       layoutMap.set(sorted[idx].i, [idx, currLayout.h, currLayout.w]);
     }
-    let layoutLists = this.state.layoutLists;
-    layoutLists.get(this.state.envID).set(layoutName, layoutMap);
-    this.exportLayoutsToServer(layoutLists);
-    this.setState({
+    let layoutLists = storeMeta.layoutLists;
+    layoutLists.get(selection.envID).set(layoutName, layoutMap);
+    exportLayoutsToServer(layoutLists);
+    setStoreMeta((prev) => ({
+      ...prev,
       layoutLists: layoutLists,
+    }));
+    setSelection((prev) => ({
+      ...prev,
       layoutID: layoutName,
-    });
-  }
+    }));
+  };
 
-  onLayoutDelete(layoutName) {
+  const onLayoutDelete = (layoutName) => {
     // Deletes the selected view, pushes to server
-    let layoutLists = this.state.layoutLists;
-    layoutLists.get(this.state.envID).delete(layoutName);
-    this.exportLayoutsToServer(layoutLists);
-    this.setState({
+    let layoutLists = storeMeta.layoutLists;
+    layoutLists.get(selection.envID).delete(layoutName);
+    exportLayoutsToServer(layoutLists);
+    setStoreMeta((prev) => ({
+      ...prev,
       layoutLists: layoutLists,
-      layoutID: layoutLists.get(this.state.envID).keys()[0],
-    });
-  }
+    }));
+    setSelection((prev) => ({
+      ...prev,
+      layoutID: layoutLists.get(selection.envID).keys()[0],
+    }));
+  };
 
-  updateDimensions() {
-    this.setState({
-      width: window.innerWidth,
-      envSelectorStyle: {
-        width: this.getEnvSelectWidth(window.innerWidth),
-      },
-    });
-  }
+  // -------
+  // effects
+  // -------
 
-  getEnvSelectWidth(w) {
-    return Math.max(w / 3, 50);
-  }
+  // ask server for envs after registration succeeded
+  useEffect(() => {
+    postForEnv(selection.envIDs);
+  }, [sessionInfo]);
 
-  UNSAFE_componentWillMount() {
-    this.updateDimensions();
-  }
-  componentWillUnmount() {
-    //Remove event listener
-    window.removeEventListener('resize', this.updateDimensions);
-  }
+  // connect session upon componentDidMount
+  useEffect(connect, []);
 
-  componentDidMount() {
-    window.addEventListener('resize', this.updateDimensions);
-    this.setState({
-      width: window.innerWidth,
-      envSelectorStyle: {
-        width: this.getEnvSelectWidth(window.innerWidth),
-      },
-    });
-    this.connect();
-  }
-
-  componentDidUpdate() {
-    if (this._firstLoad && this.state.sessionID) {
-      this._firstLoad = false;
-      if (this.state.envIDs.length > 0) {
-        this.postForEnv(this.state.envIDs);
+  //componentDidUpdate
+  useEffect(() => {
+    if (mounted.current) {
+      if (selection.envIDs.length > 0) {
+        postForEnv(selection.envIDs);
       } else {
-        this.setState({
+        setSelection((prev) => ({
+          ...prev,
           envIDs: ['main'],
           envID: 'main',
-        });
-        this.postForEnv(['main']);
+        }));
+        postForEnv(['main']);
       }
     }
 
     // Bootstrap tooltips need some encouragement
-    if (this.state.confirmClear) {
-      $('#clear-button')
-        .attr('data-original-title', 'Are you sure?')
-        .tooltip('show');
-    } else {
-      $('#clear-button').attr(
-        'data-original-title',
-        'Clear Current Environment'
+    $('#clear-button').attr('data-original-title', 'Clear Current Environment');
+  }, [mounted.current]);
+
+  // define what mounted means for this app:
+  // 1. WidthProvider knows the correct windowSize
+  // 2. We have a connection to the server
+  useEffect(() => {
+    if (windowSize.current.width <= 0 && windowSize.current.cols <= 0) return;
+    if (!sessionInfo.id) return;
+    mounted.current = true;
+    relayout();
+  }, [windowSize.current, sessionInfo]);
+
+  // on filter change, ping all panes to force redraw
+  useEffect(() => {
+    Object.keys(storeData.panes).map((paneID) => {
+      focusPane(paneID);
+    });
+    localStorage.setItem('filter', filterString);
+  }, [filterString]);
+
+  const onWidthChange = (width, cols) => {
+    windowSize.current.cols = cols;
+    windowSize.current.width = width;
+  };
+
+  let panes = Object.keys(storeData.panes).map((id) => {
+    let pane = storeData.panes[id];
+
+    try {
+      let Comp = PANES[pane.type];
+      if (!Comp) {
+        throw new Error('unrecognized pane type: ' + pane);
+      }
+      let panelayout = getLayoutItem(storeData.layout, id);
+      let filter = getValidFilter(filterString);
+      let isVisible = pane.title.match(filter);
+
+      const PANE_TITLE_BAR_HEIGHT = 14;
+
+      var _height = Math.round(h2p(panelayout.h));
+      var _width = Math.round(w2p(panelayout.w));
+
+      return (
+        <div key={pane.id} className={isVisible ? '' : 'hidden-window'}>
+          <ReactResizeDetector handleWidth handleHeight>
+            <Comp
+              {...pane}
+              key={pane.id}
+              onClose={closePane}
+              onFocus={focusPane}
+              isFocused={pane.id === focusedPaneID}
+              w={panelayout.w}
+              h={panelayout.h}
+              width={w2p(panelayout.w)}
+              height={h2p(panelayout.h) - PANE_TITLE_BAR_HEIGHT}
+              _width={_width}
+              _height={_height - PANE_TITLE_BAR_HEIGHT}
+              appApi={{
+                sendPaneMessage: sendPaneMessage,
+                sendEmbeddingPop: sendEmbeddingPop,
+              }}
+            />
+          </ReactResizeDetector>
+        </div>
+      );
+    } catch (err) {
+      return (
+        <div key={pane.id}>
+          <TextPane
+            content={
+              'Error: ' +
+              (err.message ||
+                JSON.stringify(err, Object.getOwnPropertyNames(err)))
+            }
+            id={pane.id}
+            key={pane.id}
+            onClose={closePane}
+            onFocus={focusPane}
+            isFocused={pane.id === focusedPaneID}
+            w={300}
+            h={300}
+            appApi={{ sendPaneMessage: sendPaneMessage }}
+          />
+        </div>
       );
     }
-  }
+  });
 
-  onWidthChange = (width, cols) => {
-    this.setState(
-      {
-        cols: cols,
-        width: width,
-      },
-      () => {
-        this.relayout();
-      }
-    );
-  };
+  let modals = [
+    <EnvModal
+      key="EnvModal"
+      activeEnv={selection.envID}
+      connected={connected}
+      envList={storeMeta.envList}
+      onEnvDelete={onEnvDelete}
+      onEnvSave={onEnvSave}
+      onModalClose={() => setShowEnvModal(false)}
+      show={showEnvModal}
+    />,
+    <ViewModal
+      key="ViewModal"
+      activeLayout={selection.layoutID}
+      connected={connected}
+      layoutList={getCurrLayoutList()}
+      onModalClose={() => setShowViewModal(false)}
+      onLayoutDelete={onLayoutDelete.bind(this)}
+      onLayoutSave={onLayoutSave.bind(this)}
+      show={showViewModal}
+    />,
+  ];
 
-  generateWindowHash = (windowId) => {
-    let windowContent = this.state.panes[windowId];
+  let envControls = (
+    <EnvControls
+      connected={connected}
+      envID={selection.envID}
+      envIDs={selection.envIDs}
+      envList={storeMeta.envList}
+      envSelectorStyle={{
+        width: Math.max(window.innerWidth / 3, 50),
+      }}
+      onEnvClear={closeAllPanes}
+      onEnvManageButton={() => setShowEnvModal(!showEnvModal)}
+      onEnvSelect={onEnvSelect}
+      readonly={sessionInfo.readonly}
+    />
+  );
+  let viewControls = (
+    <ViewControls
+      activeLayout={selection.layoutID}
+      connected={connected}
+      envID={selection.envID}
+      layoutList={getCurrLayoutList()}
+      onRepackButton={() => {
+        relayout();
+        relayout();
+      }}
+      onViewChange={updateToLayout}
+      onViewManageButton={() => setShowViewModal(!showViewModal)}
+      readonly={sessionInfo.readonly}
+    />
+  );
+  let filterControl = (
+    <FilterControls
+      filter={filterString}
+      onFilterChange={(ev) => {
+        setFilterString(ev.target.value);
+        // TODO remove this once relayout is moved to a post-state
+        // update kind of thing
+        relayout();
+        relayout();
+      }}
+      onFilterClear={() => {
+        setFilterString('');
+        // TODO remove this once relayout is moved to a post-state
+        // update kind of thing
+        relayout();
+        relayout();
+      }}
+    />
+  );
+  let connectionIndicator = (
+    <ConnectionIndicator
+      connected={connected}
+      onClick={toggleOnlineState}
+      readonly={sessionInfo.readonly}
+    />
+  );
 
-    /*Convert JSON data to string with a space of 2. This detail is important.
-    It ensures that the server and browser generate same JSON string */
-    let content_string = JSON.stringify(windowContent, null, 2);
-    return md5(content_string);
-  };
-
-  getWindowHash = (windowId) => {
-    let url = 'http://' + window.location.host + '/win_hash';
-
-    let body = {
-      win: windowId,
-      env: this.state.envID,
-    };
-
-    return $.post(url, JSON.stringify(body));
-  };
-
-  render() {
-    let panes = Object.keys(this.state.panes).map((id) => {
-      let pane = this.state.panes[id];
-
-      try {
-        let Comp = PANES[pane.type];
-        if (!Comp) {
-          throw new Error('unrecognized pane type: ' + pane);
-        }
-        let panelayout = getLayoutItem(this.state.layout, id);
-        let filter = this.getValidFilter(this.state.filter);
-        let isVisible = pane.title.match(filter);
-
-        const PANE_TITLE_BAR_HEIGHT = 14;
-
-        var _height = Math.round(this.h2p(panelayout.h));
-        var _width = Math.round(this.w2p(panelayout.w));
-
-        return (
-          <div key={pane.id} className={isVisible ? '' : 'hidden-window'}>
-            <ReactResizeDetector handleWidth handleHeight>
-              <Comp
-                {...pane}
-                key={pane.id}
-                onClose={this.closePane}
-                onFocus={this.focusPane}
-                onInflate={this.onInflate}
-                isFocused={pane.id === this.state.focusedPaneID}
-                w={panelayout.w}
-                h={panelayout.h}
-                width={this.w2p(panelayout.w)}
-                height={this.h2p(panelayout.h) - PANE_TITLE_BAR_HEIGHT}
-                _width={_width}
-                _height={_height - PANE_TITLE_BAR_HEIGHT}
-                appApi={{
-                  sendPaneMessage: this.sendPaneMessage,
-                  sendEmbeddingPop: this.sendEmbeddingPop,
-                }}
-              />
-            </ReactResizeDetector>
-          </div>
-        );
-      } catch (err) {
-        return (
-          <div key={pane.id}>
-            <TextPane
-              content={
-                'Error: ' +
-                (err.message ||
-                  JSON.stringify(err, Object.getOwnPropertyNames(err)))
-              }
-              id={pane.id}
-              key={pane.id}
-              onClose={this.closePane}
-              onFocus={this.focusPane}
-              onInflate={this.onInflate}
-              isFocused={pane.id === this.state.focusedPaneID}
-              w={300}
-              h={300}
-              appApi={{ sendPaneMessage: this.sendPaneMessage }}
-            />
-          </div>
-        );
-      }
-    });
-
-    let modals = [
-      <EnvModal
-        key="EnvModal"
-        activeEnv={this.state.envID}
-        connected={this.state.connected}
-        envList={this.state.envList}
-        onEnvDelete={this.onEnvDelete}
-        onEnvSave={this.onEnvSave}
-        onModalClose={() => this.setState({ showEnvModal: false })}
-        show={this.state.showEnvModal}
-      />,
-      <ViewModal
-        key="ViewModal"
-        activeLayout={this.state.layoutID}
-        connected={this.state.connected}
-        layoutList={this.getCurrLayoutList()}
-        onModalClose={() => this.setState({ showViewModal: false })}
-        onLayoutDelete={this.onLayoutDelete.bind(this)}
-        onLayoutSave={this.onLayoutSave.bind(this)}
-        show={this.state.showViewModal}
-      />,
-    ];
-
-    let envControls = (
-      <EnvControls
-        connected={this.state.connected}
-        envID={this.state.envID}
-        envIDs={this.state.envIDs}
-        envList={this.state.envList}
-        envSelectorStyle={this.state.envSelectorStyle}
-        onEnvClear={this.closeAllPanes}
-        onEnvManageButton={() => {
-          this.setState({ showEnvModal: !this.state.showEnvModal });
-        }}
-        onEnvSelect={this.onEnvSelect}
-        readonly={this.state.readonly}
-      />
-    );
-    let viewControls = (
-      <ViewControls
-        activeLayout={this.state.layoutID}
-        connected={this.state.connected}
-        envID={this.state.envID}
-        layoutList={this.getCurrLayoutList()}
-        onRepackButton={() => {
-          this.relayout();
-          this.relayout();
-        }}
-        onViewChange={this.updateToLayout}
-        onViewManageButton={() => {
-          this.setState({ showViewModal: !this.state.showViewModal });
-        }}
-        readonly={this.state.readonly}
-      />
-    );
-    let filterControl = (
-      <FilterControls
-        filter={this.state.filter}
-        onFilterChange={(ev) => {
-          this.setState({ filter: ev.target.value }, () => {
-            Object.keys(this.state.panes).map((paneID) => {
-              this.focusPane(paneID);
-            });
-          });
-          localStorage.setItem('filter', ev.target.value);
-          // TODO remove this once relayout is moved to a post-state
-          // update kind of thing
-          this.state.filter = ev.target.value;
-          this.relayout();
-          this.relayout();
-        }}
-        onFilterClear={() => {
-          this.setState({ filter: '' }, () => {
-            Object.keys(this.state.panes).map((paneID) => {
-              this.focusPane(paneID);
-            });
-          });
-          // TODO remove this once relayout is moved to a post-state
-          // update kind of thing
-          this.state.filter = '';
-          localStorage.setItem('filter', '');
-          this.relayout();
-          this.relayout();
-        }}
-      />
-    );
-    let connectionIndicator = (
-      <ConnectionIndicator
-        connected={this.state.connected}
-        onClick={this.toggleOnlineState}
-        readonly={this.state.readonly}
-      />
-    );
-
-    return (
-      <div>
-        {modals}
-        <div className="navbar-form navbar-default">
-          <span className="navbar-brand visdom-title">visdom</span>
-          <span className="vertical-line" />
-          &nbsp;&nbsp;
-          {envControls}
-          &nbsp;&nbsp;
-          <span className="vertical-line" />
-          &nbsp;&nbsp;
-          {viewControls}
-          <span
-            style={{
-              float: 'right',
-            }}
-          >
-            {filterControl}
-            &nbsp;&nbsp;
-            {connectionIndicator}
-          </span>
-        </div>
-        <div
-          tabIndex="-1"
-          role="presentation"
-          className="no-focus"
-          onBlur={this.blurPane}
-          onClick={this.publishEvent}
-          onKeyUp={this.publishEvent}
-          onKeyDown={this.publishEvent}
-          onKeyPress={this.publishEvent}
+  return (
+    <div>
+      {modals}
+      <div className="navbar-form navbar-default">
+        <span className="navbar-brand visdom-title">visdom</span>
+        <span className="vertical-line" />
+        &nbsp;&nbsp;
+        {envControls}
+        &nbsp;&nbsp;
+        <span className="vertical-line" />
+        &nbsp;&nbsp;
+        {viewControls}
+        <span
+          style={{
+            float: 'right',
+          }}
         >
-          <GridLayout
-            className="layout"
-            rowHeight={ROW_HEIGHT}
-            autoSize={false}
-            margin={[MARGIN, MARGIN]}
-            layout={this.state.layout}
-            draggableHandle={'.bar'}
-            onLayoutChange={this.handleLayoutChange}
-            onWidthChange={this.onWidthChange}
-            onResizeStop={this.resizePane}
-            onDragStop={this.movePane}
-          >
-            {panes}
-          </GridLayout>
-        </div>
+          {filterControl}
+          &nbsp;&nbsp;
+          {connectionIndicator}
+        </span>
       </div>
-    );
-  }
+      <div
+        tabIndex="-1"
+        role="presentation"
+        className="no-focus"
+        onBlur={blurPane}
+        onClick={publishEvent}
+        onKeyUp={publishEvent}
+        onKeyDown={publishEvent}
+        onKeyPress={publishEvent}
+      >
+        <GridLayout
+          className="layout"
+          rowHeight={ROW_HEIGHT}
+          autoSize={false}
+          margin={[MARGIN, MARGIN]}
+          layout={storeData.layout}
+          draggableHandle={'.bar'}
+          onWidthChange={onWidthChange}
+          onResizeStop={resizePane}
+          onDragStop={movePane}
+        >
+          {panes}
+        </GridLayout>
+      </div>
+    </div>
+  );
 }
 
 function load() {

--- a/js/main.js
+++ b/js/main.js
@@ -107,13 +107,6 @@ function App() {
   const _timeoutID = useRef(null);
   const _pendingPanes = useRef([]);
 
-  // flush pre-render callbacks
-  const callbacks = useRef([]);
-  callbacks.current.forEach((cb) => {
-    if (cb) cb();
-  });
-  callbacks.current = [];
-
   // --------------------- //
   // grid helper functions //
   // --------------------- //
@@ -446,7 +439,7 @@ function App() {
         panes: newPanes,
       }));
       setFocusedPaneID(focusedPaneID === paneID ? null : focusedPaneID);
-      callbacks.current.push(relayout);
+      callbacks.current.push('relayout');
     }
   };
 
@@ -903,6 +896,14 @@ function App() {
   // -------
   // effects
   // -------
+
+  // flush pre-render callbacks
+  const callbacks = useRef([]);
+  callbacks.current.forEach((cb) => {
+    if (cb === 'relayout') relayout();
+    else if (cb) cb();
+  });
+  callbacks.current = [];
 
   // ask server for envs after registration succeeded
   useEffect(() => {

--- a/js/main.js
+++ b/js/main.js
@@ -180,11 +180,11 @@ function App() {
     let newPanes = Object.assign({}, storeData.panes);
     let newLayout = storeData.layout.slice();
 
-    _pendingPanes.current.forEach((pane) => {
+    let pendingPanes = _pendingPanes.current;
+    _pendingPanes.current = [];
+    pendingPanes.forEach((pane) => {
       processPane(pane, newPanes, newLayout);
     });
-
-    _pendingPanes.current = [];
     _timeoutID.current = null;
 
     setStoreData((prev) => ({

--- a/js/panes/ImagePane.js
+++ b/js/panes/ImagePane.js
@@ -17,7 +17,7 @@ const DEFAULT_WIDTH = 300;
 
 function ImagePane(props) {
   const { title, type, selected, width, height, appApi } = props;
-  var { content } = props;
+  var { isFocused, content } = props;
 
   // state varibles
   // --------------
@@ -179,7 +179,7 @@ function ImagePane(props) {
     return function cleanup() {
       EventSystem.unsubscribe('global.event', onEvent);
     };
-  }, [mouseLocation]);
+  }, [mouseLocation, isFocused]);
 
   // image size/pos computation
   // --------------------------

--- a/js/panes/PropertiesPane.js
+++ b/js/panes/PropertiesPane.js
@@ -21,11 +21,14 @@ function PropertiesPane(props) {
   // send updates in PropertyItem directly to all observers / sources
   const updateValue = (propId, value) => {
     onFocus(id, () => {
-      appApi.sendPaneMessage({
-        event_type: 'PropertyUpdate',
-        propertyId: propId,
-        value: value,
-      });
+      appApi.sendPaneMessage(
+        {
+          event_type: 'PropertyUpdate',
+          propertyId: propId,
+          value: value,
+        },
+        id
+      );
     });
   };
 


### PR DESCRIPTION
## Description
This PR follows up on #856 and migrates the remaining component (`App`) to functional React. As a side effect, this PR also fixes all the linting errors related to JavaScript files.

## Motivation and Context
The goal is again to modernize the code base to enable better long-term maintainability.

For me, this one has been the most challenging PR so far and it is my third attempt at solving the task.
This is probably due to
1. **my personal requirement of trying to keep the PR as reviewable as possible**.
   To accomplish this I have tried to keep all code blocks and functions in the same respective position. Unfortunately, the changes required for the migration are still numerous.
2. **some very specific timing-requirements of redraws for the application to work properly**. 
   In the previous code, there have been some comments noticing "non-conventional" React style and I think that these and some other design decisions did not fit well with  "hook based react/functional react" anymore.
   Solving these timing / redraw issues would have required a complete restructuring of many parts of the component, which would have been practically a complete rewrite of the code. This would have clashed with the former requirement.

Thus, I went with a `1:1` translation that is a bit easier to review (the first commit). The PR can be compared with the previous code in a side-by-side manner.
The drawback is that the many tricks from the old code (i.e. the "non-conventional" React parts) needed to be retained/reimplemented for the new style. (See the small commits after the huge first one).

**Future follow-up PR ideas**:
After this PR, tidying up the code base further should be possible in smaller PRs again.
For instance, I'd suggest to
- extract the API-related functions to an encapsulated API-component
- merge the variables `envID` and `envIDs` as they share the same function (one for compare views, the other for single view mode)
- Simplifying the pane-store structure.
  Especially variables such as `consistent_pane_copy` duplicates code and makes it hard to understand some functions. A comment in the code suggests to use redux. Is this still the "way to go" for applications such as visdom?

**A final note on the two additional test changes**:
- The new implementation fixes a bug related to window resize resetting (triggered by double-clicking the lower-right pane corner).
  As the cypress test did ignore that bug explicitly, this PR adapts the test to the now correct expected values.
- During work on this PR I found another inconsistency in the cypress tests, probably due to the new implementation.
  In more detail, closing an environment requires waiting for an animation to end (and an `x` to appear). With the new implementation, the animation is probably triggered slightly delayed, thus I've added a `100ms` delay in the respective test.

## How Has This Been Tested?
As I've said, this is my third attempt to finish this PR while making all tests succeed.
The new implementation may create new bugs that have not been present before, however, with the testing in place I am confident that almost all features work just as before the PR.

Just to be sure, I've also 10-fold triggered the PR against all tests without any errors on my fork.



## Screenshots (if appropriate):
`-`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
    (Maybe not yet? I am confident in the changes I've made, still I'd test the new version for at least a week or two before releasing it to the public. ;) )
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.