### PR TITLE
Replaced Window Update Check by 'versioning' (previously used 'hashing')

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,6 @@ vis._send({'data': [trace], 'layout': layout, 'win': 'mywin'})
 - [`vis.delete_env`](#visdelete_env) : delete an environment by env_id
 - [`vis.win_exists`](#viswin_exists) : check if a window already exists by id
 - [`vis.get_env_list`](#visget_env_list) : get a list of all of the environments on your server
-- [`vis.win_hash`](#viswin_hash): get md5 hash of window's contents
 - [`vis.get_window_data`](#visget_window_data): get current data for a window
 - [`vis.check_connection`](#vischeck_connection): check if the server is connected
 - [`vis.replay_log`](#visreplay_log): replay the actions from the provided log file
@@ -753,13 +752,6 @@ Optional arguments:
 #### vis.get_env_list
 
 This function returns a list of all of the environments on the server at the time of calling. It takes no arguments.
-
-#### vis.win_hash
-
-This function returns md5 hash of the contents of a window `win` if it exists on the server. Returns None otherwise.
-
-Optional arguments:
-- `env` : Environment to search for the window in. Default is `None`.
 
 
 #### vis.get_window_data

--- a/js/main.js
+++ b/js/main.js
@@ -38,7 +38,6 @@ import WidthProvider from './Width';
 
 const ReactGridLayout = require('react-grid-layout');
 const jsonpatch = require('fast-json-patch');
-const md5 = require('md5');
 const stringify = require('json-stable-stringify');
 const GridLayout = WidthProvider(ReactGridLayout);
 const sortLayout = ReactGridLayout.utils.sortLayoutItemsByRowCol;

--- a/js/main.js
+++ b/js/main.js
@@ -38,7 +38,6 @@ import WidthProvider from './Width';
 
 const ReactGridLayout = require('react-grid-layout');
 const jsonpatch = require('fast-json-patch');
-const stringify = require('json-stable-stringify');
 const GridLayout = WidthProvider(ReactGridLayout);
 const sortLayout = ReactGridLayout.utils.sortLayoutItemsByRowCol;
 const getLayoutItem = ReactGridLayout.utils.getLayoutItem;

--- a/js/main.js
+++ b/js/main.js
@@ -290,7 +290,10 @@ function App() {
 
   // Apply patch or queries window if window to be patched does not exist
   const updateWindow = (cmd) => {
-    if (cmd.win in storeData.panes) {
+    if (
+      cmd.win in storeData.panes &&
+      cmd.version == storeData.panes[cmd.win].version + 1
+    ) {
       let modifiedWindow = storeData.panes[cmd.win];
       let modifiedFinalWindow = jsonpatch.applyPatch(
         modifiedWindow,

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "https-browserify": "^1.0.0",
     "jquery": "^3.6.3",
     "json-stable-stringify": "^1.0.1",
-    "md5": "^2.3.0",
     "ml-savitzky-golay-generalized": "^4.0.1",
     "rc-tree-select": "^1.12.13",
     "react": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "fast-json-patch": "^3.1.1",
     "https-browserify": "^1.0.0",
     "jquery": "^3.6.3",
-    "json-stable-stringify": "^1.0.1",
     "ml-savitzky-golay-generalized": "^4.0.1",
     "rc-tree-select": "^1.12.13",
     "react": "^17.0.2",

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -890,40 +890,6 @@ class Visdom(object):
         else:
             return None
 
-    def _win_hash_wrap(self, win, env=None):
-        """
-        This function returns a hash of the contents of
-        the window if the window exists.
-        Return None otherwise.
-        """
-        assert win is not None
-
-        return self._send(
-            {
-                "win": win,
-                "env": env,
-            },
-            endpoint="win_hash",
-            quiet=True,
-        )
-
-    def win_hash(self, win, env=None):
-        """
-        This function returns md5 hash of the contents
-        of a window if it exists on the server.
-        Returns None, otherwise
-        """
-        try:
-            e = self._win_hash_wrap(win, env)
-        except ConnectionError:
-            print("Error connecting to Visdom server!")
-            return None
-
-        if re.match(r"([a-fA-F\d]{32})", e):
-            return e
-
-        return None
-
     def _has_connection(self):
         """
         This function returns a bool indicating whether or

--- a/py/visdom/server/app.py
+++ b/py/visdom/server/app.py
@@ -11,8 +11,6 @@ Main application class that pulls handlers together and maintains
 all of the required state about the currently running server.
 """
 
-import copy
-import hashlib
 import logging
 import os
 import platform
@@ -39,7 +37,6 @@ from visdom.server.handlers.web_handlers import (
     ErrorHandler,
     ExistsHandler,
     ForkEnvHandler,
-    HashHandler,
     IndexHandler,
     PostHandler,
     SaveHandler,
@@ -112,7 +109,6 @@ class Application(tornado.web.Application):
             (r"%s/win_exists" % self.base_url, ExistsHandler, {"app": self}),
             (r"%s/win_data" % self.base_url, DataHandler, {"app": self}),
             (r"%s/delete_env" % self.base_url, DeleteEnvHandler, {"app": self}),
-            (r"%s/win_hash" % self.base_url, HashHandler, {"app": self}),
             (r"%s/env_state" % self.base_url, EnvStateHandler, {"app": self}),
             (r"%s/fork_env" % self.base_url, ForkEnvHandler, {"app": self}),
             (r"%s/user/(.*)" % self.base_url, UserSettingsHandler, {"app": self}),

--- a/py/visdom/server/handlers/web_handlers.py
+++ b/py/visdom/server/handlers/web_handlers.py
@@ -42,7 +42,6 @@ from visdom.utils.server_utils import (
     escape_eid,
     compare_envs,
     load_env,
-    hash_md_window,
     broadcast,
     update_window,
     hash_password,
@@ -359,13 +358,12 @@ class UpdateHandler(BaseHandler):
         if len(stringify(p)) <= len(stringify(diff_packet)):
             broadcast(handler, p, eid)
         else:
-            hashed = hash_md_window(p)
             broadcast_packet = {
                 "command": "window_update",
                 "win": args["win"],
                 "env": eid,
                 "content": diff_packet,
-                "finalHash": hashed,
+                "version": p.get("version", 1),
             }
             broadcast(handler, broadcast_packet, eid)
         handler.write(p["id"])

--- a/py/visdom/server/handlers/web_handlers.py
+++ b/py/visdom/server/handlers/web_handlers.py
@@ -483,30 +483,6 @@ class ForkEnvHandler(BaseHandler):
         self.wrap_func(self, args)
 
 
-class HashHandler(BaseHandler):
-    def initialize(self, app):
-        self.app = app
-        self.state = app.state
-        self.login_enabled = app.login_enabled
-
-    @staticmethod
-    def wrap_func(handler, args):
-        eid = extract_eid(args)
-        handler_json = handler.state[eid]["jsons"]
-        if args["win"] in handler_json:
-            hashed = hash_md_window(handler_json[args["win"]])
-            handler.write(hashed)
-        else:
-            handler.write("false")
-
-    @check_auth
-    def post(self):
-        args = tornado.escape.json_decode(
-            tornado.escape.to_basestring(self.request.body)
-        )
-        self.wrap_func(self, args)
-
-
 class EnvHandler(BaseHandler):
     def initialize(self, app):
         self.state = app.state

--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -165,12 +165,14 @@ def update_window(p, args):
         pdata = p["content"]["data"]
         for i, d in enumerate(pdata):
             d["name"] = opts["legend"][i]
+    p["version"] += 1
     return p
 
 
 def window(args):
     """Build a window dict structure for sending to client"""
     uid = args.get("win", get_new_window_id())
+    version = args.get("version", 1)
     if uid is None:
         uid = get_new_window_id()
     opts = args.get("opts", {})
@@ -179,6 +181,7 @@ def window(args):
 
     p = {
         "command": "window",
+        "version": version,
         "id": str(uid),
         "title": opts.get("title", ""),
         "inflate": opts.get("inflate", True),
@@ -330,6 +333,7 @@ def compare_envs(state, eids, socket, env_path=DEFAULT_ENV_PATH):
 
     res["jsons"]["window_compare_legend"] = {
         "command": "window",
+        "version": 1,
         "id": "window_compare_legend",
         "title": "compare_legend",
         "inflate": True,
@@ -457,8 +461,3 @@ def recursive_order(node):
 
 def stringify(node):
     return json.dumps(recursive_order(node), separators=(",", ":"))
-
-
-def hash_md_window(window_json):
-    json_string = stringify(window_json).encode("utf-8")
-    return hashlib.md5(json_string).hexdigest()

--- a/yarn.lock
+++ b/yarn.lock
@@ -1575,10 +1575,6 @@
     "ansi-styles" "^4.1.0"
     "supports-color" "^7.1.0"
 
-"charenc@0.0.2":
-  "resolved" "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz"
-  "version" "0.0.2"
-
 "check-more-types@^2.24.0":
   "resolved" "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz"
   "version" "2.24.0"
@@ -1780,10 +1776,6 @@
     "path-key" "^3.1.0"
     "shebang-command" "^2.0.0"
     "which" "^2.0.1"
-
-"crypt@0.0.2":
-  "resolved" "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz"
-  "version" "0.0.2"
 
 "crypto-random-string@^1.0.0":
   "resolved" "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz"
@@ -2885,10 +2877,6 @@
     "call-bind" "^1.0.2"
     "has-tostringtag" "^1.0.0"
 
-"is-buffer@~1.1.6":
-  "resolved" "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-  "version" "1.1.6"
-
 "is-callable@^1.1.3", "is-callable@^1.1.4", "is-callable@^1.2.7":
   "resolved" "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz"
   "version" "1.2.7"
@@ -3159,12 +3147,6 @@
   "resolved" "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz"
   "version" "1.0.1"
 
-"json-stable-stringify@^1.0.1":
-  "resolved" "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.2.tgz"
-  "version" "1.0.2"
-  dependencies:
-    "jsonify" "^0.0.1"
-
 "json-stringify-safe@^5.0.1", "json-stringify-safe@~5.0.1":
   "resolved" "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
   "version" "5.0.1"
@@ -3186,10 +3168,6 @@
     "universalify" "^2.0.0"
   optionalDependencies:
     "graceful-fs" "^4.1.6"
-
-"jsonify@^0.0.1":
-  "resolved" "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz"
-  "version" "0.0.1"
 
 "jsprim@^2.0.2":
   "resolved" "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz"
@@ -3365,14 +3343,6 @@
   "version" "3.0.0"
   dependencies:
     "escape-string-regexp" "^4.0.0"
-
-"md5@^2.3.0":
-  "resolved" "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz"
-  "version" "2.3.0"
-  dependencies:
-    "charenc" "0.0.2"
-    "crypt" "0.0.2"
-    "is-buffer" "~1.1.6"
 
 "merge-stream@^2.0.0":
   "resolved" "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz"


### PR DESCRIPTION
## Description
This PR 
- removes the variable `consistent_pane_copy` from `js/main.js`
- **api-change**: implements version-numbers for window content, s.t. a client knows if it is up-to-date or needs to re-request the window content
- **api-change**: removes the api endpoint `/win_hash` (as it is not used anymore in the project)
- additionally, moves the pane-update to the `processPane` method. this is required to save some requests where the whole window content would have be resent (see notes below).

## Motivation and Context
(See discussion below).

## How Has This Been Tested?
(Just the cypress tests).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
