### PR TITLE
Fix unintentional Rolling-Release Python Linting & Update Black (black ver `22.10` -> black ver `23.1`)

### DIFF
--- a/.github/workflows/process-changes.yml
+++ b/.github/workflows/process-changes.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: psf/black@23.1.0
         with:
           src: "./py"
+          version: 23.1.0
       - name: Check for Linting Errors
         if: failure()
         run: echo "::warning title='Python Linter Check failed'::Please run \"pip install black; black py\" before committing code changes to python files."

--- a/.github/workflows/process-changes.yml
+++ b/.github/workflows/process-changes.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: psf/black@22.10.0
+      - uses: psf/black@23.1.0
         with:
           src: "./py"
       - name: Check for Linting Errors

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ We actively welcome your pull requests.
 6. Add demos for new features. Ensure the demos work.
 7. Make sure your code lints.
     - For JavaScript-Files, use `npm lint`
-    - For Python-Files, use `black py`
+    - For Python-Files, use `black py` (`pip install black==23.1`)
     - To do that automatically before each `git commit`, enable pre-commit hooks: `pre-commit install`.
 8. If you haven't already, complete the Contributor License Agreement ("CLA").
 

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -2233,7 +2233,6 @@ class Visdom(object):
 
         # add arrow heads:
         if opts["arrowheads"]:
-
             # compute tip points:
             alpha = 0.33  # size of arrow head relative to vector length
             beta = 0.33  # width of the base of the arrow head

--- a/py/visdom/server/build.py
+++ b/py/visdom/server/build.py
@@ -101,8 +101,7 @@ def download_scripts(proxies=None, install_dir=None):
         print("Downloading scripts, this may take a little while")
 
     # download files one-by-one:
-    for (key, val) in ext_files.items():
-
+    for key, val in ext_files.items():
         # set subdirectory:
         if val.endswith(".js") or val.endswith(".js.map"):
             sub_dir = "js"


### PR DESCRIPTION
## Description
This PR updates the python code-guidelines for this project from black `22.10` to black `23.1`.

## Motivation and Context
The recent black update did result in a failing test on our side (see #904, where no python files were changed, but the python linter check failed).
While we actually did fix the black-version in the github-workflow, the action defined under the tag `black@22.10.0` did actually use the most recent black version (ver 23), due to a missing argument describing which version to use. :facepalm:
Thus, this PR updates the github-action to `black@23.1.0` (major update), now additionally with the correct argument [(`version: 23.1.0`)](https://github.com/fossasia/visdom/actions/runs/4092742781/jobs/7057683357#step:3:20), saves the reformatted code black 23 applied and adds a small note  to `CONTRIBUTING.md` regarding the black version.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
