### PR TITLE
Auto-Generate Release Notes (of Future Releases)

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -30,12 +30,11 @@ jobs:
       - name: Create Release
         if: ${{ steps.version.outputs.TAG_EXISTS == '0' }}
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ steps.version.outputs.TAG_NAME }}
-          release_name: "Release ${{ steps.version.outputs.TAG_NAME }}"
+          name: "Visdom v${{ steps.version.outputs.TAG_NAME }}"
+          generate_release_notes: true
       - name: Set up Python
         if: ${{ steps.version.outputs.TAG_EXISTS == '0' }}
         uses: actions/setup-python@v4


### PR DESCRIPTION
## Description
As of now, this project uses GitHub's own action for creating new releases named `action/create-release`.
However, [the action is currently unmaintained, and the developers suggest using an alternative in their README.md](https://github.com/actions/create-release).

This PR also
- enables automatically generated release notes containing a list of PRs added with the new release.
  (Currently, auto-generation of release notes can be only done manually: editing a specific release reveals the button "Generate release notes").
- Adapts the release naming:
  - previously: `Release 0.2.4`
  - new naming: `Visdom v0.2.4`  
    (to match the tag name. any other suggestions?)


## How Has This Been Tested?
Tested the change successfully in a personal project of mine.
As an example release using this method I've attached a screenshot below:
![image](https://user-images.githubusercontent.com/19650074/220394399-4f049353-2df2-4d11-a41a-47714f2ad57a.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
