### PR TITLE
Test against multiple Python Versions

### DIFF
--- a/.github/workflows/process-changes.yml
+++ b/.github/workflows/process-changes.yml
@@ -141,6 +141,9 @@ jobs:
     name: "Functional Test (Websocket)"
     runs-on: ubuntu-latest
     needs: install-and-build
+    strategy:
+      matrix:
+        python: ['3.8', '3.9', '3.10']
     steps:
       - name: "Checkout Repository"
         uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
     long_description_content_type="text/markdown",
     long_description=readme,
     license='Apache-2.0',
+    python_requires='>=3.8',
 
     # Package info
     packages=find_packages(where="py"),


### PR DESCRIPTION
## Description
Just a short housekeeping-PR with the goal to ensure visdom works on the most recent python versions.

## Motivation and Context
I've chosen the oldest version to be python 3.8, [as 3.7 will end support in the next months](https://devguide.python.org/versions/).

To ensure visdom works with the recent versions, this PR does the following:
1. Adding the minimal required version (`3.8`) to `setup.py` which adds the requirement to pip.
2. Extending the functional tests to include all minor python version starting with the minimal version. Thus, the matrix of tests covers after this PR python3.8, python3.9, python3.10, python3.11. 


## How Has This Been Tested?
Tested the change successfully on top of #908.
(I.e. without #908 in-place, thus failing tests are expected until that one is merged)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
    