### PR TITLE
Minor Fix in Server: fix error "has no attribute 'last_read_time'"

### DIFF
--- a/py/visdom/server/handlers/socket_handlers.py
+++ b/py/visdom/server/handlers/socket_handlers.py
@@ -330,10 +330,16 @@ class SocketWrapper:
         # TODO mark wrapped subs and sources separately
         if len(self.subs) > 0 or len(self.sources) > 0:
             for sub in list(self.subs.values()):
-                if time.time() - sub.last_read_time > MAX_SOCKET_WAIT:
+                if (
+                    hasattr(sub, "last_read_time")
+                    and time.time() - sub.last_read_time > MAX_SOCKET_WAIT
+                ):
                     sub.close()
             for sub in list(self.sources.values()):
-                if time.time() - sub.last_read_time > MAX_SOCKET_WAIT:
+                if (
+                    hasattr(sub, "last_read_time")
+                    and time.time() - sub.last_read_time > MAX_SOCKET_WAIT
+                ):
                     sub.close()
         else:
             self.app.socket_wrap_monitor.stop()


### PR DESCRIPTION

## Description
I noticed that the last tests threw the following error when using the `-use_frontend_client_polling` option:
```
 ERROR:tornado.application:Exception in callback <bound method SocketWrapper.socket_wrap_monitor_thread of <visdom.server.handlers.socket_handlers.SocketWrapper object at 0x7efec864b670>>
Traceback (most recent call last):
  File "/home/runner/.local/lib/python3.10/site-packages/tornado/ioloop.py", line 921, in _run
    val = self.callback()
  File "/home/runner/work/visdom/visdom/py/visdom/server/handlers/socket_handlers.py", line 336, in socket_wrap_monitor_thread
    if time.time() - sub.last_read_time > MAX_SOCKET_WAIT:
```
(e.g. [here](https://github.com/fossasia/visdom/actions/runs/4428139100/jobs/7766820754?pr=911#step:4:457))

This PR is a simple fix for this error, by checking if the variable exists.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
