### PR TITLE
Merge variables envID and envIDs

### DIFF
--- a/js/topbar/EnvControls.js
+++ b/js/topbar/EnvControls.js
@@ -14,7 +14,6 @@ function EnvControls(props) {
   const {
     connected,
     envList,
-    envID,
     envIDs,
     readonly,
     envSelectorStyle,
@@ -101,7 +100,7 @@ function EnvControls(props) {
           title={confirmClear ? 'Are you sure?' : 'Clear Current Environment'}
           data-placement="bottom"
           className={confirmClear ? 'btn btn-warning' : 'btn btn-default'}
-          disabled={!(connected && envID && !readonly)}
+          disabled={!(connected && envIDs.length > 0 && !readonly)}
           onClick={() => {
             if (confirmClear) {
               onEnvClear();
@@ -117,7 +116,7 @@ function EnvControls(props) {
           title="Manage Environments"
           data-placement="bottom"
           className="btn btn-default"
-          disabled={!(connected && envID && !readonly)}
+          disabled={!(connected && envIDs.length > 0 && !readonly)}
           onClick={onEnvManageButton}
         >
           <span className="glyphicon glyphicon-folder-open" />

--- a/js/topbar/ViewControls.js
+++ b/js/topbar/ViewControls.js
@@ -11,7 +11,7 @@ import React from 'react';
 function ViewControls(props) {
   const {
     connected,
-    envID,
+    envIDs,
     activeLayout,
     layoutList,
     readonly,
@@ -50,9 +50,9 @@ function ViewControls(props) {
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="true"
-            disabled={!(connected && envID)}
+            disabled={!(connected && envIDs.length > 0)}
           >
-            {envID == null ? 'compare' : activeLayout}
+            {envIDs.length > 0 == null ? 'compare' : activeLayout}
             &nbsp;
             <span className="caret" />
           </button>
@@ -74,7 +74,7 @@ function ViewControls(props) {
           title="Manage Views"
           data-placement="bottom"
           className="btn btn-default"
-          disabled={!(connected && envID && !readonly)}
+          disabled={!(connected && envIDs.length > 0 && !readonly)}
           onClick={onViewManageButton}
         >
           <span className="glyphicon glyphicon-folder-open" />


### PR DESCRIPTION
## Description
Just a small proposal for simplification.
In the react component (`js/main.js`), there is a variable called `envID` and another one called `envIDs`.
As `envID == envIDs[0]` if any env is selected, this PR suggests to remove the duplicate variable `envID`.

## Motivation and Context
The javascript code distinguishes the case of a single selected environment and multiple ones.
However, if multiple ones are selected, some functions effectively use just the first environment of the list, instead of merging the environments somehow. For instance, forking environments or views is also possible for multiple envs selected, in both cases it uses always the name of the first environment. (I guess this is minor a bug).

I know that the proposed change does not solve this at all, still I suggest to simplify the code at this point.
If you have an idea how to improve this PR, please let me know. :)
For instance, I think it would be reasonable to just disable the Fork- and View-Buttons when multiple envs are selected for now as their behavior is currently not well-defined.

## How Has This Been Tested?
Just a short local test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
  