### PR TITLE
Extract js-api methods into seperate file

### DIFF
--- a/js/api/ApiContext.js
+++ b/js/api/ApiContext.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+const ApiContext = createContext({});
+
+export default ApiContext;

--- a/js/api/ApiProvider.js
+++ b/js/api/ApiProvider.js
@@ -43,27 +43,6 @@ const ApiProvider = ({ children }) => {
     return _socket.current.send(msg);
   };
 
-  // query env from server
-  const postForEnv = (envIDs) => {
-    // This kicks off a new stream of events from the socket so there's nothing
-    // to handle here. We might want to surface the error state.
-    if (envIDs.length == 1) {
-      $.post(
-        correctPathname() + 'env/' + envIDs[0],
-        JSON.stringify({
-          sid: sessionInfo.id,
-        })
-      );
-    } else if (envIDs.length > 1) {
-      $.post(
-        correctPathname() + 'compare/' + envIDs.join('+'),
-        JSON.stringify({
-          sid: sessionInfo.id,
-        })
-      );
-    }
-  };
-
   // connect to server
   const connect = () => {
     if (_socket.current) {
@@ -112,9 +91,9 @@ const ApiProvider = ({ children }) => {
     _socket.current = null;
   };
 
-  // ------------- //
-  // api functions //
-  // --------------//
+  // ------------------ //
+  // API receive events //
+  // -------------------//
 
   // handle server messages
   const handleMessage = (evt) => {
@@ -159,6 +138,31 @@ const ApiProvider = ({ children }) => {
 
   // we need to update the socket-callback so that we have an up-to date state
   if (_socket.current) _socket.current.onmessage = handleMessage;
+
+  // --------------- //
+  // API send events //
+  // ----------------//
+
+  // query env from server
+  const postForEnv = (envIDs) => {
+    // This kicks off a new stream of events from the socket so there's nothing
+    // to handle here. We might want to surface the error state.
+    if (envIDs.length == 1) {
+      $.post(
+        correctPathname() + 'env/' + envIDs[0],
+        JSON.stringify({
+          sid: sessionInfo.id,
+        })
+      );
+    } else if (envIDs.length > 1) {
+      $.post(
+        correctPathname() + 'compare/' + envIDs.join('+'),
+        JSON.stringify({
+          sid: sessionInfo.id,
+        })
+      );
+    }
+  };
 
   const toggleOnlineState = () => {
     if (connected) {
@@ -267,6 +271,10 @@ const ApiProvider = ({ children }) => {
     });
   };
 
+  // ------- //
+  // Effects //
+  // ------- //
+
   // connect on mount, disconnect on unmount
   useEffect(() => {
     connect();
@@ -275,9 +283,9 @@ const ApiProvider = ({ children }) => {
     };
   }, []);
 
-  // connect session upon componentDidMount
-  useEffect(connect, []);
-
+  // -------------- //
+  // Define Context //
+  // -------------- //
   return (
     <ApiContext.Provider
       value={{

--- a/js/api/ApiProvider.js
+++ b/js/api/ApiProvider.js
@@ -1,0 +1,304 @@
+import $ from 'jquery';
+import React, { useEffect, useRef, useState } from 'react';
+
+import ApiContext from './ApiContext';
+import Poller from './Legacy';
+
+const ApiProvider = ({ children }) => {
+  const [connected, setConnected] = useState(false);
+  const [sessionInfo, setSessionInfo] = useState({ id: null, readonly: false });
+  const _socket = useRef(null);
+  const onHandlers = useRef(null);
+
+  // ---------------- //
+  // helper functions //
+  // ---------------- //
+
+  // retrieve normalized window.location
+  const correctPathname = () => {
+    var pathname = window.location.pathname;
+    if (pathname.indexOf('/env/') > -1) {
+      pathname = pathname.split('/env/')[0];
+    } else if (pathname.indexOf('/compare/') > -1) {
+      pathname = pathname.split('/compare/')[0];
+    }
+    if (pathname.slice(-1) != '/') {
+      pathname = pathname + '/';
+    }
+    return pathname;
+  };
+
+  // ------------------- //
+  // basic communication //
+  // ------------------- //
+
+  // low-level message to server
+  const sendSocketMessage = (data) => {
+    if (!_socket.current) {
+      // TODO: error? warn?
+      return;
+    }
+
+    let msg = JSON.stringify(data);
+    return _socket.current.send(msg);
+  };
+
+  // query env from server
+  const postForEnv = (envIDs) => {
+    // This kicks off a new stream of events from the socket so there's nothing
+    // to handle here. We might want to surface the error state.
+    if (envIDs.length == 1) {
+      $.post(
+        correctPathname() + 'env/' + envIDs[0],
+        JSON.stringify({
+          sid: sessionInfo.id,
+        })
+      );
+    } else if (envIDs.length > 1) {
+      $.post(
+        correctPathname() + 'compare/' + envIDs.join('+'),
+        JSON.stringify({
+          sid: sessionInfo.id,
+        })
+      );
+    }
+  };
+
+  // connect to server
+  const connect = () => {
+    if (_socket.current) {
+      return;
+    }
+
+    const _onConnect = () => {
+      setConnected(true);
+    };
+    const _onDisconnect = () => {
+      onHandlers.current.onDisconnect(_socket);
+      setConnected(false);
+    };
+
+    // eslint-disable-next-line no-undef
+    if (USE_POLLING) {
+      _socket.current = new Poller(
+        correctPathname,
+        handleMessage,
+        _onConnect,
+        _onDisconnect
+      );
+      return;
+    }
+
+    var url = window.location;
+    var ws_protocol = null;
+    if (url.protocol == 'https:') {
+      ws_protocol = 'wss';
+    } else {
+      ws_protocol = 'ws';
+    }
+    var socket = new WebSocket(
+      ws_protocol + '://' + url.host + correctPathname() + 'socket'
+    );
+
+    socket.onmessage = handleMessage;
+    socket.onopen = _onConnect;
+    socket.onerror = socket.onclose = _onDisconnect;
+    _socket.current = socket;
+  };
+
+  // close server connection
+  const disconnect = () => {
+    _socket.current.close();
+    _socket.current = null;
+  };
+
+  // ------------- //
+  // api functions //
+  // --------------//
+
+  // handle server messages
+  const handleMessage = (evt) => {
+    var cmd = JSON.parse(evt.data);
+    switch (cmd.command) {
+      case 'register':
+        setSessionInfo((prev) => ({
+          ...prev,
+          id: cmd.data,
+          readonly: cmd.readonly,
+        }));
+        break;
+      case 'pane':
+      case 'window':
+      case 'window_update':
+        onHandlers.current.onWindowMessage({
+          cmd: cmd,
+          update: cmd.commmand == 'window_update',
+        });
+        break;
+      case 'reload':
+        onHandlers.current.onReloadMessage(cmd.data);
+        break;
+      case 'close':
+        onHandlers.current.onCloseMessage(cmd.data);
+        break;
+      case 'layout':
+      case 'layout_update':
+        onHandlers.current.onLayoutMessage({
+          cmd: cmd.data,
+          update: cmd.commmand == 'layout_update',
+        });
+        break;
+      case 'env_update':
+        onHandlers.current.onEnvUpdate(cmd.data);
+        break;
+
+      default:
+        console.error('unrecognized command', cmd);
+    }
+  };
+
+  // we need to update the socket-callback so that we have an up-to date state
+  if (_socket.current) _socket.current.onmessage = handleMessage;
+
+  const toggleOnlineState = () => {
+    if (connected) {
+      disconnect();
+    } else {
+      connect();
+    }
+  };
+
+  /**
+   * Send message to backend.
+   *
+   * The `data` object is extended by pane and environment Id.
+   * Note: Only focused panes should call this method.
+   *
+   * @param data Data to be sent to backend.
+   */
+  const sendPaneMessage = (data, targetPaneID, targetEnvID) => {
+    if (targetPaneID === null || sessionInfo.readonly) {
+      return;
+    }
+    let finalData = {
+      target: targetPaneID,
+      eid: targetEnvID,
+    };
+    $.extend(finalData, data);
+    sendSocketMessage({
+      cmd: 'forward_to_vis',
+      data: finalData,
+    });
+  };
+
+  const sendEmbeddingPop = (data, targetPaneID, targetEnvID) => {
+    if (targetPaneID === null || sessionInfo.readonly) {
+      return;
+    }
+    let finalData = {
+      target: targetPaneID,
+      eid: targetEnvID,
+    };
+    $.extend(finalData, data);
+    sendSocketMessage({
+      cmd: 'pop_embeddings_pane',
+      data: finalData,
+    });
+  };
+
+  const sendClosePane = (paneID, envID) => {
+    sendSocketMessage({
+      cmd: 'close',
+      data: paneID,
+      eid: envID,
+    });
+  };
+
+  const sendDeleteEnv = (envID, previousEnv) => {
+    sendSocketMessage({
+      cmd: 'delete_env',
+      prev_eid: previousEnv,
+      eid: envID,
+    });
+  };
+
+  const sendEnvSave = (envID, prev_envID, data) => {
+    sendSocketMessage({
+      cmd: 'save',
+      data: data,
+      prev_eid: prev_envID,
+      eid: envID,
+    });
+  };
+
+  /**
+   * Send layout item state to backend to update backend state.
+   *
+   * @param layout Layout to be sent to backend.
+   */
+  const sendLayoutItemState = (
+    envID,
+    { i, h, w, x, y, moved, static: staticBool }
+  ) => {
+    sendSocketMessage({
+      cmd: 'layout_item_update',
+      eid: envID,
+      win: i,
+      data: { i, h, w, x, y, moved, static: staticBool },
+    });
+  };
+
+  const exportLayoutsToServer = (layoutLists) => {
+    // pushes layouts to the server
+    let objForm = {};
+    for (let [envName, layoutList] of layoutLists) {
+      objForm[envName] = {};
+      for (let [layoutName, layoutMap] of layoutList) {
+        objForm[envName][layoutName] = {};
+        for (let [contentID, contentLoc] of layoutMap) {
+          objForm[envName][layoutName][contentID] = contentLoc;
+        }
+      }
+    }
+    let exportForm = JSON.stringify(objForm);
+    sendSocketMessage({
+      cmd: 'save_layouts',
+      data: exportForm,
+    });
+  };
+
+  // connect on mount, disconnect on unmount
+  useEffect(() => {
+    connect();
+    return () => {
+      disconnect();
+    };
+  }, []);
+
+  // connect session upon componentDidMount
+  useEffect(connect, []);
+
+  return (
+    <ApiContext.Provider
+      value={{
+        connected,
+        sessionInfo,
+        setConnected,
+        onHandlers,
+        postForEnv,
+        sendPaneMessage,
+        sendEmbeddingPop,
+        exportLayoutsToServer,
+        toggleOnlineState,
+        sendEnvSave,
+        sendDeleteEnv,
+        sendClosePane,
+        sendLayoutItemState,
+      }}
+    >
+      {children}
+    </ApiContext.Provider>
+  );
+};
+
+export default ApiProvider;

--- a/js/api/Legacy.js
+++ b/js/api/Legacy.js
@@ -1,4 +1,4 @@
-import { POLLING_INTERVAL } from './settings.js';
+import { POLLING_INTERVAL } from '../settings.js';
 
 function postData(url = ``, data = {}) {
   return fetch(url, {

--- a/js/main.js
+++ b/js/main.js
@@ -638,6 +638,7 @@ const App = () => {
   const onLayoutDelete = (layoutName) => {
     // Deletes the selected view, pushes to server
     let layoutLists = storeMeta.layoutLists;
+    let layoutKeys = Array.from(layoutLists.get(selection.envIDs[0]).keys());
     layoutLists.get(selection.envIDs[0]).delete(layoutName);
     sendLayoutsSave(layoutLists);
     setStoreMeta((prev) => ({
@@ -646,7 +647,7 @@ const App = () => {
     }));
     setSelection((prev) => ({
       ...prev,
-      layoutID: layoutLists.get(selection.envIDs[0]).keys()[0],
+      layoutID: layoutKeys[0] == layoutName ? layoutKeys[1] : layoutKeys[0],
     }));
   };
 

--- a/js/main.js
+++ b/js/main.js
@@ -63,16 +63,16 @@ const App = () => {
 
   // api variables & functions
   const {
+    apiHandlers,
     connected,
+    sendEnvDelete,
+    sendEnvQuery,
+    sendEnvSave,
+    sendLayoutsSave,
+    sendPaneClose,
+    sendPaneLayoutUpdate,
     sessionInfo,
     toggleOnlineState,
-    postForEnv,
-    exportLayoutsToServer,
-    onHandlers,
-    sendEnvSave,
-    sendDeleteEnv,
-    sendClosePane,
-    sendLayoutItemState,
   } = useContext(ApiContext);
 
   // internal variables
@@ -267,7 +267,7 @@ const App = () => {
     // that is selected that isn't from the compare output, we need to
     // reload the compare output
     if (selection.envIDs.length > 1 && cmd.has_compare !== true) {
-      postForEnv(selection.envIDs);
+      sendEnvQuery(selection.envIDs);
     } else if (update) {
       updateWindow(cmd);
     } else {
@@ -310,7 +310,7 @@ const App = () => {
     delete newPanes[paneID];
     if (!keepPosition) {
       localStorage.removeItem(keyLS(paneID));
-      sendClosePane(paneID, selection.envIDs[0]);
+      sendPaneClose(paneID, selection.envIDs[0]);
     }
 
     if (setState) {
@@ -366,11 +366,11 @@ const App = () => {
     }));
     setFocusedPaneID(isSameEnv ? focusedPaneID : null);
     localStorage.setItem('envIDs', JSON.stringify(selectedNodes));
-    postForEnv(selectedNodes);
+    sendEnvQuery(selectedNodes);
   };
 
   const onEnvDelete = (env2delete, previousEnv) => {
-    sendDeleteEnv(env2delete, previousEnv);
+    sendEnvDelete(env2delete, previousEnv);
   };
 
   const onEnvSave = (env) => {
@@ -624,7 +624,7 @@ const App = () => {
     }
     let layoutLists = storeMeta.layoutLists;
     layoutLists.get(selection.envIDs[0]).set(layoutName, layoutMap);
-    exportLayoutsToServer(layoutLists);
+    sendLayoutsSave(layoutLists);
     setStoreMeta((prev) => ({
       ...prev,
       layoutLists: layoutLists,
@@ -639,7 +639,7 @@ const App = () => {
     // Deletes the selected view, pushes to server
     let layoutLists = storeMeta.layoutLists;
     layoutLists.get(selection.envIDs[0]).delete(layoutName);
-    exportLayoutsToServer(layoutLists);
+    sendLayoutsSave(layoutLists);
     setStoreMeta((prev) => ({
       ...prev,
       layoutLists: layoutLists,
@@ -664,20 +664,20 @@ const App = () => {
 
   // ask server for envs after registration succeeded
   useEffect(() => {
-    postForEnv(selection.envIDs);
+    sendEnvQuery(selection.envIDs);
   }, [sessionInfo]);
 
   //componentDidUpdate
   useEffect(() => {
     if (mounted.current) {
       if (selection.envIDs.length > 0) {
-        postForEnv(selection.envIDs);
+        sendEnvQuery(selection.envIDs);
       } else {
         setSelection((prev) => ({
           ...prev,
           envIDs: ['main'],
         }));
-        postForEnv(['main']);
+        sendEnvQuery(['main']);
       }
     }
 
@@ -839,7 +839,7 @@ const App = () => {
   };
 
   const onCloseMessage = closePane;
-  onHandlers.current = {
+  apiHandlers.current = {
     onWindowMessage,
     onLayoutMessage,
     onReloadMessage,

--- a/js/modals/EnvModal.js
+++ b/js/modals/EnvModal.js
@@ -7,21 +7,16 @@
  *
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import ReactModal from 'react-modal';
 
+import ApiContext from '../api/ApiContext';
 import { MODAL_STYLE } from '../settings';
 
 function EnvModal(props) {
-  const {
-    activeEnv,
-    connected,
-    envList,
-    onModalClose,
-    onEnvSave,
-    onEnvDelete,
-    show,
-  } = props;
+  const { connected } = useContext(ApiContext);
+  const { activeEnv, envList, onModalClose, onEnvSave, onEnvDelete, show } =
+    props;
 
   // effects
   // -------

--- a/js/modals/ViewModal.js
+++ b/js/modals/ViewModal.js
@@ -88,7 +88,7 @@ function ViewModal(props) {
         </select>
         <button
           className="btn btn-default"
-          disabled={!connected || !selectText || selectText == DEFAULT_LAYOUT}
+          disabled={!connected || !selectText || layoutList.size <= 1}
           onClick={() => onLayoutDelete(selectText)}
         >
           Delete

--- a/js/modals/ViewModal.js
+++ b/js/modals/ViewModal.js
@@ -7,15 +7,16 @@
  *
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import ReactModal from 'react-modal';
 
+import ApiContext from '../api/ApiContext';
 import { DEFAULT_LAYOUT, MODAL_STYLE } from '../settings';
 
 function ViewModal(props) {
+  const { connected } = useContext(ApiContext);
   const {
     activeLayout,
-    connected,
     layoutList,
     onModalClose,
     onLayoutSave,

--- a/js/panes/EmbeddingsPane.js
+++ b/js/panes/EmbeddingsPane.js
@@ -14,6 +14,7 @@ import debounce from 'debounce';
 import React from 'react';
 import * as THREE from 'three';
 
+import ApiContext from '../api/ApiContext';
 import EventSystem from '../EventSystem';
 import lasso from '../lasso';
 import Pane from './Pane';
@@ -32,38 +33,57 @@ class EmbeddingsPane extends React.Component {
         e.preventDefault();
         break;
       case 'keyup':
-        this.props.appApi.sendPaneMessage({
-          event_type: 'KeyPress',
-          key: event.key,
-          key_code: event.keyCode,
-          pane_data: false, // No need to send the full data for this
-        });
+        if (this.props.isFocused)
+          this.context.sendPaneMessage(
+            {
+              event_type: 'KeyPress',
+              key: event.key,
+              key_code: event.keyCode,
+              pane_data: false, // No need to send the full data for this
+            },
+            this.props.id,
+            this.props.envID
+          );
         break;
     }
   };
 
   onEntitySelection = (e) => {
-    this.props.appApi.sendPaneMessage({
-      event_type: 'EntitySelected',
-      entityId: e.name,
-      idx: e.idx,
-      pane_data: false, // No need to send the full data for this
-    });
+    if (this.props.isFocused)
+      this.context.sendPaneMessage(
+        {
+          event_type: 'EntitySelected',
+          entityId: e.name,
+          idx: e.idx,
+          pane_data: false, // No need to send the full data for this
+        },
+        this.props.id,
+        this.props.envID
+      );
   };
 
   onRegionSelection = (pointIdxs) => {
-    this.props.appApi.sendPaneMessage({
-      event_type: 'RegionSelected',
-      selectedIdxs: pointIdxs,
-      pane_data: false, // No need to send the full data for this
-    });
+    if (this.props.isFocused)
+      this.context.sendPaneMessage(
+        {
+          event_type: 'RegionSelected',
+          selectedIdxs: pointIdxs,
+          pane_data: false, // No need to send the full data for this
+        },
+        this.props.id,
+        this.props.envID
+      );
   };
 
   // Used to pop an embeddings drilldown off of the stack
   onGoBack = () => {
-    this.props.appApi.sendEmbeddingPop({
-      pane_data: false, // No need to send the full data for this
-    });
+    this.context.sendEmbeddingPop(
+      {
+        pane_data: false, // No need to send the full data for this
+      },
+      this.props.id,
+      this.props.env
+    );
   };
 
   componentDidMount() {
@@ -663,5 +683,7 @@ class LassoSelection extends React.Component {
     );
   }
 }
+
+EmbeddingsPane.contextType = ApiContext;
 
 export default EmbeddingsPane;

--- a/js/panes/ImagePane.js
+++ b/js/panes/ImagePane.js
@@ -7,8 +7,9 @@
  *
  */
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 
+import ApiContext from '../api/ApiContext';
 import EventSystem from '../EventSystem';
 import Pane from './Pane';
 
@@ -16,7 +17,8 @@ const DEFAULT_HEIGHT = 400;
 const DEFAULT_WIDTH = 300;
 
 function ImagePane(props) {
-  const { title, type, selected, width, height, appApi } = props;
+  const { sendPaneMessage } = useContext(ApiContext);
+  const { envID, id, title, type, selected, width, height } = props;
   var { isFocused, content } = props;
 
   // state varibles
@@ -160,17 +162,27 @@ function ImagePane(props) {
           event.preventDefault();
           break;
         case 'keyup':
-          appApi.sendPaneMessage({
-            event_type: 'KeyPress',
-            key: event.key,
-            key_code: event.keyCode,
-          });
+          if (isFocused)
+            sendPaneMessage(
+              {
+                event_type: 'KeyPress',
+                key: event.key,
+                key_code: event.keyCode,
+              },
+              id,
+              envID
+            );
           break;
         case 'click':
-          appApi.sendPaneMessage({
-            event_type: 'Click',
-            image_coord: mouseLocation,
-          });
+          if (isFocused)
+            sendPaneMessage(
+              {
+                event_type: 'Click',
+                image_coord: mouseLocation,
+              },
+              id,
+              envID
+            );
           break;
       }
     };

--- a/js/panes/PropertiesPane.js
+++ b/js/panes/PropertiesPane.js
@@ -7,13 +7,15 @@
  *
  */
 
-import React from 'react';
+import React, { useContext } from 'react';
 
+import ApiContext from '../api/ApiContext';
 import Pane from './Pane';
 import PropertyItem from './PropertyItem';
 
 function PropertiesPane(props) {
-  const { id, content, appApi, onFocus } = props;
+  const { sendPaneMessage } = useContext(ApiContext);
+  const { envID, id, content, onFocus } = props;
 
   // private events
   // --------------
@@ -21,13 +23,14 @@ function PropertiesPane(props) {
   // send updates in PropertyItem directly to all observers / sources
   const updateValue = (propId, value) => {
     onFocus(id, () => {
-      appApi.sendPaneMessage(
+      sendPaneMessage(
         {
           event_type: 'PropertyUpdate',
           propertyId: propId,
           value: value,
         },
-        id
+        id,
+        envID
       );
     });
   };

--- a/js/panes/TextPane.js
+++ b/js/panes/TextPane.js
@@ -7,13 +7,15 @@
  *
  */
 
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
 
+import ApiContext from '../api/ApiContext';
 import EventSystem from '../EventSystem';
 import Pane from './Pane';
 
 function TextPane(props) {
-  const { content, isFocused, appApi } = props;
+  const { sendPaneMessage } = useContext(ApiContext);
+  const { envID, id, content, isFocused } = props;
 
   // private events
   // --------------
@@ -26,11 +28,15 @@ function TextPane(props) {
         e.preventDefault();
         break;
       case 'keyup':
-        appApi.sendPaneMessage({
-          event_type: 'KeyPress',
-          key: e.key,
-          key_code: e.keyCode,
-        });
+        sendPaneMessage(
+          {
+            event_type: 'KeyPress',
+            key: e.key,
+            key_code: e.keyCode,
+          },
+          id,
+          envID
+        );
         break;
     }
   };

--- a/js/topbar/ConnectionIndicator.js
+++ b/js/topbar/ConnectionIndicator.js
@@ -6,11 +6,14 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import React from 'react';
+import React, { useContext } from 'react';
 const classNames = require('classnames');
+import ApiContext from '../api/ApiContext';
 
 function ConnectionIndicator(props) {
-  const { connected, readonly, onClick } = props;
+  const { connected, sessionInfo } = useContext(ApiContext);
+  const readonly = sessionInfo.readonly;
+  const { onClick } = props;
 
   // rendering
   // ---------

--- a/js/topbar/EnvControls.js
+++ b/js/topbar/EnvControls.js
@@ -8,14 +8,16 @@
  */
 
 import TreeSelect, { SHOW_CHILD } from 'rc-tree-select';
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
+
+import ApiContext from '../api/ApiContext';
 
 function EnvControls(props) {
+  const { connected, sessionInfo } = useContext(ApiContext);
+  const readonly = sessionInfo.readonly;
   const {
-    connected,
     envList,
     envIDs,
-    readonly,
     envSelectorStyle,
     onEnvSelect,
     onEnvClear,

--- a/js/topbar/ViewControls.js
+++ b/js/topbar/ViewControls.js
@@ -6,15 +6,17 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import React from 'react';
+import React, { useContext } from 'react';
+
+import ApiContext from '../api/ApiContext';
 
 function ViewControls(props) {
+  const { connected, sessionInfo } = useContext(ApiContext);
+  const readonly = sessionInfo.readonly;
   const {
-    connected,
     envIDs,
     activeLayout,
     layoutList,
-    readonly,
     onViewManageButton,
     onRepackButton,
     onViewChange,


### PR DESCRIPTION

## Description
This PR refactors server-related functions in the client code by moving them into the `js/api/ApiProvider.js` component.

Also:
- Enhanced `sendPaneMessage` and `sendEmbeddingPop` by adding `targetId` and `envID` as arguments, making the code more versatile for pane-functions that trigger server messages when not selected. However, no changes in user functionality have been made.
- Replaced all "raw" `sendSocketMessage` calls with specialized versions for improved code readability and maintainability.
- Renamed communication functions for better semantics and consistency:
    - `sendX`: Functions send data or queries *to the server*. Normalized naming to `sendNounVerb` for an improved autocompletion experience.
    - `onX`: Functions that are called when the server sends something *to the client*, aligning with event naming conventions.

## Motivation and Context
The aim was to enhance code readability and reduce the lines of code in `main.js`.
Using `useContext` has simplified the use of API functions in child components. Previously, these functions needed to be forwarded in the JSX calls, but now they can be accessed globally.



## How Has This Been Tested?
`-`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
