### PR TITLE
Fix tests for PRs with new visual regression tests

### DIFF
--- a/.github/workflows/process-changes.yml
+++ b/.github/workflows/process-changes.yml
@@ -94,6 +94,7 @@ jobs:
         shell: bash
         run: |
           git checkout PR-HEAD -- ./cypress
+          git checkout PR-HEAD -- ./example
 
       - name: Cypress test:init
         uses: cypress-io/github-action@v4


### PR DESCRIPTION
## Description
This PR enables future PRs to add or adapt visual regression tests.

The test-suite already does the checkout to the tests of the PR to allow this, but it did not load the `example` directory containing the python-code for these tests.
The fix is thus to also checkout the `./example` directory.

## Motivation and Context
See #917, which failed the initialization of the visual regression tests due to it adding a new test to the `example/` directory.

## How Has This Been Tested?
`-`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
