### PR TITLE
Fix disabled text and number property inputs by removing keypress preventDefault() calls interfering from unrelated panes.

### DIFF
--- a/js/panes/EmbeddingsPane.js
+++ b/js/panes/EmbeddingsPane.js
@@ -30,7 +30,7 @@ class EmbeddingsPane extends React.Component {
     switch (e.type) {
       case 'keydown':
       case 'keypress':
-        e.preventDefault();
+        // e.preventDefault();
         break;
       case 'keyup':
         if (this.props.isFocused)

--- a/js/panes/ImagePane.js
+++ b/js/panes/ImagePane.js
@@ -159,7 +159,7 @@ function ImagePane(props) {
       switch (event.type) {
         case 'keydown':
         case 'keypress':
-          event.preventDefault();
+        //   event.preventDefault();
           break;
         case 'keyup':
           if (isFocused)

--- a/js/panes/TextPane.js
+++ b/js/panes/TextPane.js
@@ -25,7 +25,7 @@ function TextPane(props) {
     switch (e.type) {
       case 'keydown':
       case 'keypress':
-        e.preventDefault();
+        // e.preventDefault();
         break;
       case 'keyup':
         sendPaneMessage(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Commented out some preventDefault calls on keypress events that were being called from panes that weren't the target for the event.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Text and number property inputs were not functioning when a separate embeddings, text, or image pane was present and had a keypress callback handler registered to it. 
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #935 
