### PR TITLE
docs: Clarify required image shape (C × H × W) for vis.image

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,14 @@ This function draws an `img`. It takes as input an `CxHxW` tensor `img` that con
 Most Python image libraries (e.g. OpenCV, PIL, matplotlib) return images in `HxWxC` format.
 Passing images in that format will raise errors or lead to incorrect rendering.
 
+For example:
+
+```python
+# Convert HxWxC → CxHxW before passing to vis.image
+img = img.transpose(2, 0, 1)   # NumPy
+img = img.permute(2, 0, 1)     # PyTorch
+```
+
 The following `opts` are supported:
 
 - `jpgquality`: JPG quality (`number` 0-100). If defined image will be saved as JPG to reduce file size. If not defined image will be saved as PNG.


### PR DESCRIPTION
## Description
This PR adds a small clarification to the `vis.image` documentation to explicitly highlight the required image shape (C × H × W).
The existing documentation mentions the expected shape, but it is easy for new users to miss, especially since most Python image libraries return images in H × W × C format.

## Motivation and Context
While using Visdom as a first-time user, passing images in H × W × C format resulted in a non-obvious runtime error originating from PIL. This change makes the shape requirement explicit at the point of use to help prevent common confusion and reduce avoidable errors for
new users.

## How Has This Been Tested?
- Verified that `vis.image` works correctly when passing images in
  C × H × W format.
- Reproduced the runtime error when passing images in H × W × C format
  to confirm the documented behavior.
- No code paths were modified; this change only affects documentation.

## Screenshots (if appropriate):
N/A (documentation-only change)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
- [ ] I adapted the version number under `py/visdom/VERSION` according to Semantic Versioning
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

## Summary by Sourcery

Documentation:
- Expand the vis.image README documentation to explicitly warn that many Python image libraries return HxWxC images, which will error or render incorrectly if passed directly.