### PR TITLE
Fix: persist environments with long IDs safely

### DIFF
--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -114,12 +114,21 @@ class LazyEnvData(Mapping):
         self.lazy_load_data()
         return len(self._raw_dict)
 
-
 def serialize_env(state, eids, env_path=DEFAULT_ENV_PATH):
     env_ids = [i for i in eids if i in state]
     if env_path is not None:
         for env_id in env_ids:
-            env_path_file = os.path.join(env_path, "{0}.json".format(env_id))
+            # Truncate long environment IDs to prevent filesystem errors
+            MAX_FILENAME_LENGTH = 200  # Leave room for .json extension
+            if len(env_id) > MAX_FILENAME_LENGTH:
+                # Keep first 190 chars + 10 char hash for uniqueness
+                import hashlib
+                hash_part = hashlib.md5(env_id.encode()).hexdigest()[:10]
+                safe_env_id = env_id[:190] + "_" + hash_part
+                env_path_file = os.path.join(env_path, "{0}.json".format(safe_env_id))
+            else:
+                env_path_file = os.path.join(env_path, "{0}.json".format(env_id))
+            
             with open(env_path_file, "w") as fn:
                 if isinstance(state[env_id], LazyEnvData):
                     fn.write(json.dumps(state[env_id]._raw_dict))
@@ -382,7 +391,17 @@ def load_env(state, eid, socket, env_path=DEFAULT_ENV_PATH):
     if eid in state:
         env = state.get(eid)
     elif env_path is not None:
-        p = os.path.join(env_path, eid.strip(), ".json")
+        # Try to find the environment file
+        # First try exact filename
+        p = os.path.join(env_path, "{0}.json".format(eid.strip()))
+        
+        # If not found and env_id is long, try truncated version
+        if not os.path.exists(p) and len(eid) > 200:
+            import hashlib
+            hash_part = hashlib.md5(eid.encode()).hexdigest()[:10]
+            safe_eid = eid[:190] + "_" + hash_part
+            p = os.path.join(env_path, "{0}.json".format(safe_eid))
+        
         if os.path.exists(p):
             with open(p, "r") as fn:
                 env = tornado.escape.json_decode(fn.read())

--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -23,6 +23,7 @@ import os
 import time
 import tornado.escape
 from collections import OrderedDict
+import hashlib
 
 try:
     # for after python 3.8
@@ -41,7 +42,38 @@ from visdom.utils.shared_utils import warn_once, get_rand_id, get_new_window_id
 
 
 # ---- Vaguely server-security related functions ---- #
-
+def _safe_env_filename(env_id, max_length=200, extension=".json"):
+    """
+    Return a filesystem-safe filename for the given env_id.
+    
+    If env_id fits within max_length (including extension), use it as-is.
+    Otherwise, truncate and append a hash for uniqueness.
+    """
+    # Strip whitespace once for consistency
+    env_id = env_id.strip()
+    
+    # Calculate available space for the base name
+    base_length = max_length - len(extension)
+    
+    # If it already fits, use as-is
+    if len(env_id) <= base_length:
+        return f"{env_id}{extension}"
+    
+    # Reserve space for "_" + hash
+    HASH_LEN = 10
+    SEP_LEN = 1  # underscore
+    prefix_length = base_length - (HASH_LEN + SEP_LEN)
+    
+    # Safety check in case max_length is too small
+    if prefix_length <= 0:
+        # If max_length is too small, just use hash
+        hash_part = hashlib.md5(env_id.encode()).hexdigest()[:HASH_LEN]
+        return f"{hash_part}{extension}"
+    
+    # Truncate and add hash
+    hash_part = hashlib.md5(env_id.encode()).hexdigest()[:HASH_LEN]
+    safe_env_id = f"{env_id[:prefix_length]}_{hash_part}"
+    return f"{safe_env_id}{extension}"
 
 def check_auth(f):
     """
@@ -118,16 +150,8 @@ def serialize_env(state, eids, env_path=DEFAULT_ENV_PATH):
     env_ids = [i for i in eids if i in state]
     if env_path is not None:
         for env_id in env_ids:
-            # Truncate long environment IDs to prevent filesystem errors
-            MAX_FILENAME_LENGTH = 200  # Leave room for .json extension
-            if len(env_id) > MAX_FILENAME_LENGTH:
-                # Keep first 190 chars + 10 char hash for uniqueness
-                import hashlib
-                hash_part = hashlib.md5(env_id.encode()).hexdigest()[:10]
-                safe_env_id = env_id[:190] + "_" + hash_part
-                env_path_file = os.path.join(env_path, "{0}.json".format(safe_env_id))
-            else:
-                env_path_file = os.path.join(env_path, "{0}.json".format(env_id))
+            safe_filename = _safe_env_filename(env_id)
+            env_path_file = os.path.join(env_path, safe_filename)
             
             with open(env_path_file, "w") as fn:
                 if isinstance(state[env_id], LazyEnvData):
@@ -391,17 +415,8 @@ def load_env(state, eid, socket, env_path=DEFAULT_ENV_PATH):
     if eid in state:
         env = state.get(eid)
     elif env_path is not None:
-        # Try to find the environment file
-        # First try exact filename
-        p = os.path.join(env_path, "{0}.json".format(eid.strip()))
-        
-        # If not found and env_id is long, try truncated version
-        if not os.path.exists(p) and len(eid) > 200:
-            import hashlib
-            hash_part = hashlib.md5(eid.encode()).hexdigest()[:10]
-            safe_eid = eid[:190] + "_" + hash_part
-            p = os.path.join(env_path, "{0}.json".format(safe_eid))
-        
+        safe_filename = _safe_env_filename(eid)
+        p = os.path.join(env_path, safe_filename)
         if os.path.exists(p):
             with open(p, "r") as fn:
                 env = tornado.escape.json_decode(fn.read())


### PR DESCRIPTION
## Description
This PR fixes issue #648: "Envs with >255 chars do not get saved". 

When environment names (eid) exceed filesystem filename length limits (typically 255 characters), the `serialize_env` function fails silently because it cannot create the corresponding `.json` file. This fix ensures environments with arbitrarily long names are persisted safely.

### Technical Changes:
1. **Filename Truncation**: Environment IDs longer than 200 characters are truncated
2. **Hash-Based Uniqueness**: A 10-character MD5 hash suffix prevents collisions between different long names with similar prefixes
3. **Backward Compatibility**: The `load_env` function is updated to locate truncated files
4. **Path Correction**: Fixed incorrect file path construction in `load_env` (changed from `eid/.json` to `eid.json`)

### Implementation Details:
- **Safe Length**: 200 characters (leaves buffer for `.json` extension and directory paths)
- **Hash Algorithm**: MD5, using first 10 characters (sufficient for this use case)
- **Filename Pattern**: `{first_190_chars}_{10_char_hash}.json`
- **Scope**: Changes limited to `py/visdom/utils/server_utils.py`

## Motivation and Context
Filesystems impose filename length limitations (255 bytes on Linux ext4, 260 characters total path length on Windows). Without this fix:
- Environments with long names fail to persist silently
- Users lose data without error messages
- The issue disproportionately affects auto-generated or UUID-based environment names

This addresses a real-world usability issue where environment names naturally exceed safe limits.

## How Has This Been Tested?
### Test Environment:
- Windows 10, Python 3.12
- Visdom server running on port 8097
- Both short and long environment names tested

### Test Cases:
1. **Short Names**: `"test_env"` - Saves as `test_env.json` (unchanged behavior)
2. **Long Names**: `"a" * 300` - Saves as truncated file with hash suffix
3. **Multiple Long Names**: Different 300-character names produce different hashes
4. **Load Verification**: Confirmed truncated files can be loaded successfully

### Test Results:
- ✅ Short environment names work as before
- ✅ 300-character environment names are successfully persisted
- ✅ Different long names produce unique hashes (no collisions)
- ✅ Truncated files can be loaded correctly
- ✅ No regression in existing functionality

### Example:
```python
# Before fix: Environment with 300 'a's fails silently
# After fix: Saves as "aaaaaaaa...aaa_4e5475d125.json" (truncated + hash)

## Summary by Sourcery

Ensure environments with very long IDs are safely persisted and can be reloaded without filesystem filename length issues.

Bug Fixes:
- Prevent serialization from failing silently when environment IDs exceed filesystem filename length limits by truncating and hashing long IDs for filenames.
- Correct the environment file path used during load to reference `<eid>.json` instead of an incorrect directory-based path.
- Allow loading of environments whose IDs were truncated at save time by resolving the corresponding hashed filename when the original long ID is requested.