### PR TITLE
Enable Custom x/y axis values for heatmap

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -1831,6 +1831,8 @@ class Visdom(object):
         - `opts.xmax`    : clip maximum value (`number`; default = `X:max()`)
         - `opts.columnnames`: `list` containing x-axis labels
         - `opts.rownames`: `list` containing y-axis labels
+        - `opts.x`: list containing x-axis labels
+        - `opts.y`: list containing y-axis labels
         - `opts.nancolor`: if not None, color for plotting nan
                            (`string`; default = `None`)
         """
@@ -1866,6 +1868,12 @@ class Visdom(object):
         _title2str(opts)
         _assert_opts(opts)
 
+        if "x" in opts and isinstance(opts["x"], np.ndarray):
+            opts["x"] = opts["x"].tolist()
+    
+        if "y" in opts and isinstance(opts["y"], np.ndarray):
+            opts["y"] = opts["y"].tolist()
+
         if opts.get("columnnames") is not None:
             assert (
                 len(opts["columnnames"]) == X.shape[1]
@@ -1882,13 +1890,17 @@ class Visdom(object):
 
         if opts.get("y") is not None:
             assert len(opts["y"]) == X.shape[0], \
-                "length of y must match number of row in X"
+                "length of y must match number of rows in X"
+
+        x_vals = opts["x"] if "x" in opts else opts.get("columnnames")
+        y_vals = opts["y"] if "y" in opts else opts.get("rownames")
+
 
         data = [
             {
                 "z": nan2none(X.tolist()),
-                "x": opts.get("x", opts.get("columnnames")),
-                "y": opts.get("y", opts.get("rownames")),
+                "x": x_vals,
+                "y": y_vals,
                 "zmin": opts.get("xmin"),
                 "zmax": opts.get("xmax"),
                 "type": "heatmap",
@@ -1927,6 +1939,7 @@ class Visdom(object):
             endpoint = "update"
 
         return self._send(data_to_send, endpoint=endpoint)
+    
 
     @pytorch_wrap
     def bar(self, X, Y=None, win=None, env=None, opts=None):


### PR DESCRIPTION
Summary:
This PR adds support for explicit x-and y-axis values in visdom.heatmap(), allowing users to provide
properly Scaled axes instead of replying on inferred pixel indices.

Changes:
*Added optional opts["x"] for explicit x-axis values
*Added optional opts["y"] for explicit y-axis values
*validated axis length against the input heatmap shape
*preserved backward compatibility with existing columnnames / rownames

Motivation:
Currently, visdom.heatmap() always infers axis values from pixel indices, which makes it difficult to interpret heatmaps generated from non-integer or non-uniform Grids.

This change enables users to pass meaningful axis values directly, aligning visdom behavior with common
plotting tools like plotly and matplotlib.

Related issue:
Closes #937 

Checklist:
*Change is backward compatible
*No API breakage
*Minimal and scoped to heatmap()
*CI passes input Shapes
*Validates input Shapes

## Summary by Sourcery

Allow visdom heatmap plots to accept explicit x and y axis values while preserving existing behavior.

New Features:
- Add support for explicit x-axis values via opts['x'] in visdom.heatmap.
- Add support for explicit y-axis values via opts['y'] in visdom.heatmap.

Enhancements:
- Validate custom x and y axis lengths against the input heatmap shape to prevent mismatches.