### PR TITLE
update artifact actions v3 to v4, fix matrix name

### DIFF
--- a/.github/workflows/process-changes.yml
+++ b/.github/workflows/process-changes.yml
@@ -62,7 +62,7 @@ jobs:
         if: steps.checkout.outputs.jsfileschanged > 0
 
       - name: "Save built js-files"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr-build
           if-no-files-found: error
@@ -104,7 +104,7 @@ jobs:
           wait-on: 'http://localhost:8098'
           spec: cypress/integration/*.init.js
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: cypress-init-screenshots
           path: cypress/screenshots_init
@@ -119,7 +119,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: ./.github/actions/prepare
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: cypress-init-screenshots
           path: cypress/screenshots_init
@@ -132,7 +132,7 @@ jobs:
           wait-on: 'http://localhost:8098'
           spec: cypress/integration/screenshots.js
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-screenshots-visual
@@ -158,10 +158,10 @@ jobs:
           wait-on: 'http://localhost:8098'
           config: ignoreTestFiles=screenshots.*
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: cypress-screenshots-functional
+          name: cypress-screenshots-functional-${{ matrix.python }}
           path: cypress/screenshots
 
   funcitonal-test-polling:
@@ -181,7 +181,7 @@ jobs:
           wait-on: 'http://localhost:8098'
           config: ignoreTestFiles=screenshots.*
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-screenshots-functional-polling


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 Fixes failing CI on Dependabot PRs caused by a [v3 deprecated artifact actions](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). Therefore this PR:
  - Bumps `upload-artifact` and `download-artifact` from v3 to v4
  - Fixes artifact name collision in the Python matrix job (`funcitonal-test`):
    v4 requires unique artifact names per run, so the name is now suffixed
    with the Python version (e.g. `cypress-screenshots-functional-3.10`)

## Motivation and Context
Failing actions from dependabot.

## How Has This Been Tested?
It hasn't, actions are hard to test locally so I guess we'll do once merged.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Summary by Sourcery

Update GitHub Actions workflow to use the latest artifact actions and avoid artifact name collisions in matrix jobs.

Build:
- Bump GitHub Actions upload-artifact and download-artifact usages from v3 to v4 in the process-changes workflow.

CI:
- Adjust functional test job artifact naming to include the Python matrix version, ensuring unique artifact names per run when capturing Cypress screenshots.