### PR TITLE
Update download-artifact

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -62,7 +62,7 @@ runs:
 
       # load artifacts from previous runs
       - name: "Load built js-files"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v7
         with:
           name: pr-build
           path: ./py/visdom/static/js/

--- a/.github/workflows/process-changes.yml
+++ b/.github/workflows/process-changes.yml
@@ -119,7 +119,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: ./.github/actions/prepare
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: cypress-init-screenshots
           path: cypress/screenshots_init


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Bump the GitHub Actions download-artifact step in the process-changes workflow from v4 to v7 for retrieving Cypress initialization screenshots.