### PR TITLE
Fix Plotly 6 binary array serialization compatibility

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -15,8 +15,6 @@ import threading
 import websocket  # type: ignore
 import json
 import hashlib
-import base64
-import numpy as np
 
 try:
     # for after python 3.8
@@ -1120,8 +1118,8 @@ class Visdom(object):
 
             return self._send(
                 {
-                    "data": figure_dict["data"],
-                    "layout": figure_dict["layout"],
+                    "data": figure_dict.get("data") or [],
+                    "layout": figure_dict.get("layout") or {},
                     "win": win,
                     "eid": env,
                     "opts": opts,

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -60,9 +60,7 @@ try:
         perplexity = (
             50
             if num_entities >= 150
-            else num_entities // 3
-            if num_entities >= 21
-            else 7
+            else num_entities // 3 if num_entities >= 21 else 7
         )
         Y = bhtsne.run_bh_tsne(
             X, initial_dims=X.shape[1], perplexity=perplexity, verbose=True
@@ -179,9 +177,11 @@ def _axisformat(xy, opts):
         return {
             "type": opts.get(xy + "type"),
             "title": opts.get(xy + "label"),
-            "range": [opts.get(xy + "tickmin"), opts.get(xy + "tickmax")]
-            if has_ticks
-            else None,
+            "range": (
+                [opts.get(xy + "tickmin"), opts.get(xy + "tickmax")]
+                if has_ticks
+                else None
+            ),
             "tickvals": opts.get(xy + "tickvals"),
             "ticktext": opts.get(xy + "ticklabels"),
             "dtick": opts.get(xy + "tickstep"),
@@ -209,17 +209,21 @@ def _axisformat3d(xyz, opts):
         return {
             "type": opts.get(xyz + "type"),
             "title": opts.get(xyz + "label"),
-            "range": [opts.get(xyz + "tickmin"), opts.get(xyz + "tickmax")]
-            if has_ticks
-            else None,
+            "range": (
+                [opts.get(xyz + "tickmin"), opts.get(xyz + "tickmax")]
+                if has_ticks
+                else None
+            ),
             "tickvals": opts.get(xyz + "tickvals"),
             "ticktext": opts.get(xyz + "ticklabels"),
             "nticks": (
-                (opts.get(xyz + "tickmax") - opts.get(xyz + "tickmin"))
-                / opts.get(xyz + "tickstep")
-            )
-            if has_step
-            else None,
+                (
+                    (opts.get(xyz + "tickmax") - opts.get(xyz + "tickmin"))
+                    / opts.get(xyz + "tickstep")
+                )
+                if has_step
+                else None
+            ),
             "tickfont": opts.get(xyz + "tickfont"),
         }
 
@@ -1064,7 +1068,7 @@ class Visdom(object):
                 width = width.replace("pt", "00")
                 opts["width"] = 1.35 * int(math.ceil(float(width)))
         return self.svg(svgstr=svg, opts=opts, env=env, win=win)
-    
+
     def _decode_binary_arrays(self, obj):
         """
         Recursively decode Plotly 6 binary array encoding
@@ -1112,7 +1116,8 @@ class Visdom(object):
                 title_prop = figure_dict["layout"]["title"]
 
                 opts["title"] = (
-                    title_prop["text"] if isinstance(title_prop, dict) and "text" in title_prop
+                    title_prop["text"]
+                    if isinstance(title_prop, dict) and "text" in title_prop
                     else title_prop
                 )
 
@@ -1690,9 +1695,9 @@ class Visdom(object):
                     "x": nan2none(X.take(0, 1)[ind].tolist()),
                     "y": nan2none(X.take(1, 1)[ind].tolist()),
                     "name": trace_name,
-                    "type": "scatter3d"
-                    if is3d
-                    else ("scattergl" if use_gl else "scatter"),
+                    "type": (
+                        "scatter3d" if is3d else ("scattergl" if use_gl else "scatter")
+                    ),
                     "mode": opts.get("mode"),
                     "text": L[ind].tolist() if L is not None else None,
                     "textposition": "right",

--- a/py/visdom/server/app.py
+++ b/py/visdom/server/app.py
@@ -51,7 +51,6 @@ from visdom.server.defaults import (
     LAYOUT_FILE,
 )
 
-
 tornado_settings = {
     "autoescape": None,
     "debug": "/dbg/" in __file__,

--- a/py/visdom/server/handlers/socket_handlers.py
+++ b/py/visdom/server/handlers/socket_handlers.py
@@ -34,7 +34,6 @@ from visdom.utils.server_utils import (
 )
 from visdom.server.defaults import MAX_SOCKET_WAIT
 
-
 # TODO move the logic that actually parses environments and layouts to
 # new classes in the data_model folder.
 # TODO move generalized initialization logic from these handlers into the

--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -14,7 +14,6 @@ At the moment, this just inherited all of the floating functions
 in the previous server.py class.
 """
 
-
 import copy
 import hashlib
 import json
@@ -38,7 +37,6 @@ from visdom.server.defaults import (
     DEFAULT_PORT,
 )
 from visdom.utils.shared_utils import warn_once, get_rand_id, get_new_window_id
-
 
 # ---- Vaguely server-security related functions ---- #
 
@@ -327,9 +325,7 @@ def compare_envs(state, eids, socket, env_path=DEFAULT_ENV_PATH):
         border: 1px solid black;
     }}
     </style>
-    <table> {} </table>""".format(
-        " ".join(tableRows)
-    )
+    <table> {} </table>""".format(" ".join(tableRows))
 
     res["jsons"]["window_compare_legend"] = {
         "command": "window",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR restores compatibility between Visdom and Plotly >= 6 by handling Plotly’s new binary array serialization format.

Starting from Plotly 6.0.0, NumPy arrays are serialized in JSON using a binary representation:

{
  "dtype": "...",
  "bdata": "<base64 encoded buffer>"
}

Visdom’s current `plotlyplot()` implementation forwards this JSON directly to the frontend, which does not decode this structure. As a result, certain plots (e.g., histograms) fail to render silently.

This PR introduces a recursive decoding step on the Python side that:

- Detects `{dtype, bdata}` objects
- Base64-decodes the buffer
- Reconstructs the NumPy array
- Converts it into standard Python lists before sending to the frontend

This ensures compatibility with Plotly >= 6 while preserving existing behavior for earlier versions.

## Motivation and Context
Plotly 5.x serialized arrays as plain JSON lists, which Visdom handled correctly.

Plotly 6.x introduced binary JSON encoding for performance reasons. The Visdom frontend does not currently interpret this `{dtype, bdata}` format, causing rendering to fail without visible errors.

Initial reports suggested the issue was dataset-size dependent, but testing confirmed it is version-dependent:

- Plotly 5.18.0 → works correctly
- Plotly 6.0.0+ → rendering fails without fix

Python version (3.10 vs 3.12) and size parameter do not appear to be the root cause.

Fixes #927 

## How Has This Been Tested?
Testing environment:

- OS: Windows 11
- Python: 3.10
- Visdom: master (installed via `pip install -e .`)
- Plotly versions tested: 5.18.0 and 6.x

Testing steps:

1. Ran histogram example:

   data = np.random.normal(0, 1, size=10000)
   fig = go.Figure(data=[go.Histogram(x=data)])
   viz.plotlyplot(fig)

2. Observed behavior:

   - Plotly 5.18.0 → histogram renders correctly.
   - Plotly 6.x before fix → empty window.
   - Plotly 6.x after fix → histogram renders correctly.

3. Verified that `demo.py` works correctly and existing functionality shows no regression when comparing this branch with a clean branch.

## Screenshots (if appropriate):
**Before Update:**
<img width="486" height="466" alt="Screenshot 2026-02-21 163643" src="https://github.com/user-attachments/assets/26e618fd-1ec4-41ae-8964-daa91953e554" />

**After Update**
<img width="592" height="641" alt="Screenshot 2026-02-22 131556" src="https://github.com/user-attachments/assets/c645c305-9f92-429f-acfc-1f17fa6f98c7" />

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
- [ ] I adapted the version number under `py/visdom/VERSION` according to Semantic Versioning
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Summary by Sourcery

Restore compatibility of Visdom's Plotly integration with Plotly 6+ binary array serialization while retaining support for older Plotly/Plotly.js versions.

Bug Fixes:
- Decode Plotly 6 binary-encoded NumPy arrays on the Python side before sending data to the frontend so plots render correctly again.
- Handle layout title extraction more defensively to support both dict-based and legacy title formats without errors when layout or title is missing.

Enhancements:
- Use safe dictionary access when sending Plotly figure data and layout to avoid key errors when those sections are absent.