### PR TITLE
Add PyTorch CNN MNIST training example with Visdom logging

### DIFF
--- a/example/pytorch_mnist_demo.py
+++ b/example/pytorch_mnist_demo.py
@@ -75,18 +75,20 @@ def grad_norm(mdl):
 
 
 def train_epoch(mdl, loader, optimizer, criterion):
+    """Train for one epoch; return average loss and average gradient norm."""
     mdl.train()
     running_loss = 0.0
-    norm = 0.0
+    norm_sum = 0.0
     for images, labels in loader:
         images, labels = images.to(DEVICE), labels.to(DEVICE)
         optimizer.zero_grad()
         loss = criterion(mdl(images), labels)
         loss.backward()
-        norm = grad_norm(mdl)  # capture norm before the weights move
+        norm_sum += grad_norm(mdl)  # accumulate before weights move
         optimizer.step()
         running_loss += loss.item()
-    return running_loss / len(loader), norm
+    n = len(loader)
+    return running_loss / n, norm_sum / n
 
 
 def evaluate(mdl, loader):
@@ -132,7 +134,7 @@ if __name__ == "__main__":
     ), "No connection could be formed quickly, start with: python -m visdom.server"
 
     # show a sample of images before training starts
-    # de-normalise from [-1, 1] back to [0, 1] for display
+    # denormalize from [-1, 1] back to [0, 1] for display
     sample_images, _ = next(iter(train_loader))
     viz.images(
         sample_images[:8] * 0.5 + 0.5,


### PR DESCRIPTION
## Description

Adds `example/pytorch_mnist_demo.py`, a self-contained example that trains a LeNet-style CNN on MNIST for 10 epochs and logs four training metrics to Visdom live during training. Each metric is logged with an explicit `viz.line()` call to demonstrate what manual instrumentation looks like in practice.

Five Visdom dashboard windows are produced:

| Window | What it shows |
|---|---|
| `loss` | Training loss per epoch |
| `accuracy` | Test accuracy per epoch |
| `lr` | Learning rate |
| `grad_norm` | Global L2 gradient norm per epoch |
| `samples` | 8 MNIST sample images logged before training starts |

## Motivation and Context

The existing examples cover scatter, line, image, and surface plots but there is no end-to-end PyTorch training example showing how to wire Visdom into a real training loop. This example fills that gap, giving new users a concrete starting point for visualizing their own training runs.

## How Has This Been Tested?

Tested locally with:

- Python 3.12, PyTorch 2.x, torchvision 0.x
- Visdom installed from source (`pip install -e .`)
- Visdom server started with `python -m visdom.server`

Steps run:

1. `python example/pytorch_mnist_demo.py` — confirmed all five windows appear on the dashboard at `http://localhost:8097` and update live after each epoch
2. `python example/demo.py` — confirmed no existing functionality is affected

Reached ~99% test accuracy by epoch 10 on MNIST, consistent with expected results for this architecture.

## Screenshots

Dashboard after 10 epochs:

<img width="1710" height="1031" alt="image" src="https://github.com/user-attachments/assets/080363ec-cd2c-4b08-99c1-ec6ae9386398" />


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist

- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Summary by Sourcery

Add a self-contained PyTorch MNIST training example that streams key training metrics to Visdom dashboards during training.

New Features:
- Introduce a PyTorch-based MNIST CNN example script that trains a small LeNet-style network and logs training progress to Visdom.
- Visualize loss, test accuracy, learning rate, gradient norm, and sample input images in separate Visdom windows during the training run.