### PR TITLE
feat(compare): use environment names as legend labels in env comparison

### DIFF
--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -235,9 +235,24 @@ def gather_envs(state, env_path=DEFAULT_ENV_PATH):
     return sorted(list(set(items + list(state.keys()))))
 
 
+_COMPARE_LEGEND_NAME_MAX = 50
+
+
+def _compare_legend_label(eid):
+    """Return eid truncated to _COMPARE_LEGEND_NAME_MAX chars.
+
+    Long environment names are shortened with a trailing ellipsis so
+    that Plotly legend entries remain readable without horizontal
+    scrolling.
+    """
+    if len(eid) <= _COMPARE_LEGEND_NAME_MAX:
+        return eid
+    return eid[:47] + "..."
+
+
 def compare_envs(state, eids, socket, env_path=DEFAULT_ENV_PATH):
     logging.info("comparing envs")
-    eidNums = {e: str(i) for i, e in enumerate(eids)}
+    eid_labels = {e: _compare_legend_label(e) for e in eids}
     env = {}
     envs = {}
     for eid in eids:
@@ -292,7 +307,7 @@ def compare_envs(state, eids, socket, env_path=DEFAULT_ENV_PATH):
                     if "name" not in data:
                         break  # stop working with this plot, not right format
                     destWidJson["content"]["data"][dataIdx]["name"] = "{}_{}".format(
-                        eidNums[eid], data["name"]
+                        eid_labels[eid], data["name"]
                     )
             else:
                 if "name" not in destWidJson["content"]["data"][0]:
@@ -305,7 +320,7 @@ def compare_envs(state, eids, socket, env_path=DEFAULT_ENV_PATH):
                     if "name" not in data:
                         destWidJson["has_compare"] = False
                         break  # stop working with this plot, not right format
-                    data["name"] = "{}_{}".format(eidNums[eid], data["name"])
+                    data["name"] = "{}_{}".format(eid_labels[eid], data["name"])
                     destWidJson["content"]["data"].append(data)
 
     # Make sure that only plots that are shared by at least two envs are shown.
@@ -316,18 +331,21 @@ def compare_envs(state, eids, socket, env_path=DEFAULT_ENV_PATH):
         ):
             del res["jsons"][destWid]
 
-    # create legend mapping environment names to environment numbers so one can
-    # look it up for the new legend
+    # create legend mapping environment names to legend labels so users
+    # can identify which line belongs to which environment
     tableRows = [
-        "<tr> <td> {} </td> <td> {} </td> </tr>".format(v, eidNums[v]) for v in eidNums
+        "<tr> <td> {} </td> <td> {} </td> </tr>".format(v, eid_labels[v])
+        for v in eid_labels
     ]
 
-    tbl = """"<style>
+    tbl = """<style>
     table, th, td {{
         border: 1px solid black;
     }}
     </style>
-    <table> {} </table>""".format(
+    <table>
+    <tr> <th>Env name</th> <th>Legend label</th> </tr>
+    {} </table>""".format(
         " ".join(tableRows)
     )
 


### PR DESCRIPTION
## Description

When comparing environments the Plotly legend showed trace names like `0_loss`, `1_loss` (numeric index + data name) instead of the actual environment names. This forced users to consult the separate `compare_legend` text pane to identify which line came from which environment.

Changes:
- Added `_COMPARE_LEGEND_NAME_MAX = 50` module-level constant.
- Added `_compare_legend_label(eid)` — returns the env name unchanged if it fits within the limit; otherwise truncates to 47 chars and appends `"..."`. Truncation is centralised so the threshold is easy to adjust.
- Replaced the numeric `eidNums` dict with `eid_labels` (same keys, env-name values).
- Trace names are now `"expt1_loss"`, `"expt2_loss"` etc. instead of `"0_loss"`, `"1_loss"`.
- The `compare_legend` table now has a header row (`Env name | Legend label`) so users can always match a truncated label back to its full environment name.

## Motivation and Context

Fixes #401. The numeric-index scheme was unintuitive — users had to memorise which number corresponded to which environment on every page load.

## How Has This Been Tested?

- `python -m py_compile py/visdom/utils/server_utils.py` — no syntax errors.
- `python -m black --check py` — clean.
- Manually verified:
  - Short env names (≤ 50 chars): label equals the env name unchanged.
  - Long env names (> 50 chars): label is truncated to 47 chars + `"..."`.
  - `compare_legend` table renders the header row and both columns correctly.

## Screenshots (if appropriate):

**Before:** legend entries show `0_train_loss`, `1_train_loss`
**After:** legend entries show `expt1_train_loss`, `expt2_train_loss`

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] I adapted the version number under `py/visdom/VERSION` according to Semantic Versioning
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.