### PR TITLE
feat(scatter): support float Y labels in scatter plots

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -60,9 +60,7 @@ try:
         perplexity = (
             50
             if num_entities >= 150
-            else num_entities // 3
-            if num_entities >= 21
-            else 7
+            else num_entities // 3 if num_entities >= 21 else 7
         )
         Y = bhtsne.run_bh_tsne(
             X, initial_dims=X.shape[1], perplexity=perplexity, verbose=True
@@ -179,9 +177,11 @@ def _axisformat(xy, opts):
         return {
             "type": opts.get(xy + "type"),
             "title": opts.get(xy + "label"),
-            "range": [opts.get(xy + "tickmin"), opts.get(xy + "tickmax")]
-            if has_ticks
-            else None,
+            "range": (
+                [opts.get(xy + "tickmin"), opts.get(xy + "tickmax")]
+                if has_ticks
+                else None
+            ),
             "tickvals": opts.get(xy + "tickvals"),
             "ticktext": opts.get(xy + "ticklabels"),
             "dtick": opts.get(xy + "tickstep"),
@@ -209,17 +209,21 @@ def _axisformat3d(xyz, opts):
         return {
             "type": opts.get(xyz + "type"),
             "title": opts.get(xyz + "label"),
-            "range": [opts.get(xyz + "tickmin"), opts.get(xyz + "tickmax")]
-            if has_ticks
-            else None,
+            "range": (
+                [opts.get(xyz + "tickmin"), opts.get(xyz + "tickmax")]
+                if has_ticks
+                else None
+            ),
             "tickvals": opts.get(xyz + "tickvals"),
             "ticktext": opts.get(xyz + "ticklabels"),
             "nticks": (
-                (opts.get(xyz + "tickmax") - opts.get(xyz + "tickmin"))
-                / opts.get(xyz + "tickstep")
-            )
-            if has_step
-            else None,
+                (
+                    (opts.get(xyz + "tickmax") - opts.get(xyz + "tickmin"))
+                    / opts.get(xyz + "tickstep")
+                )
+                if has_step
+                else None
+            ),
             "tickfont": opts.get(xyz + "tickfont"),
         }
 
@@ -1607,17 +1611,29 @@ class Visdom(object):
         if Y is not None:
             Y = np.ravel(Y)
             assert X.shape[0] == Y.shape[0], "sizes of X and Y should match"
-            assert np.equal(np.mod(Y, 1), 0).all(), "labels should be integers"
-            assert Y.min() >= 1, "labels are assumed to be at least 1"
-            labels = np.unique(Y.astype(int, copy=False))
+            # Float labels are supported: if Y is already a valid set of
+            # 1-based integer labels keep the existing path unchanged.
+            # Otherwise remap arbitrary values (int or float) to sequential
+            # 1-based indices via np.unique/np.searchsorted.  label_values
+            # stores the original values so the legend shows real text;
+            # it is None for the integer path (trace names keep str(k)).
+            if np.equal(np.mod(Y, 1), 0).all() and Y.min() >= 1:
+                labels = np.unique(Y.astype(int, copy=False))
+                K = int(Y.max())  # largest label
+                label_values = None  # integer path: use str(k) for names
+            else:
+                label_values = np.unique(Y)
+                K = len(label_values)
+                Y = (np.searchsorted(label_values, Y) + 1).astype(int)
+                labels = np.arange(1, K + 1, dtype=int)
             assert (
                 len(labels) == 1 or name is None
             ), "name should not be specified with multiple labels or lines"
-            K = int(Y.max())  # largest label
         else:
             Y = np.ones(X.shape[0], dtype=int)
             labels = np.ones(1, dtype=int)
             K = 1  # largest label
+            label_values = None  # single unlabelled trace
 
         is3d = X.shape[1] == 3
 
@@ -1666,15 +1682,20 @@ class Visdom(object):
                 elif len(labels) == 1 and name is not None:
                     trace_name = name
                 else:
-                    trace_name = str(k)
+                    # For float-remapped labels show the original value;
+                    # for integer labels keep existing str(k) behaviour.
+                    if label_values is not None:
+                        trace_name = str(label_values[k - 1])
+                    else:
+                        trace_name = str(k)
                 use_gl = opts.get("webgl", False)
                 _data = {
                     "x": nan2none(X.take(0, 1)[ind].tolist()),
                     "y": nan2none(X.take(1, 1)[ind].tolist()),
                     "name": trace_name,
-                    "type": "scatter3d"
-                    if is3d
-                    else ("scattergl" if use_gl else "scatter"),
+                    "type": (
+                        "scatter3d" if is3d else ("scattergl" if use_gl else "scatter")
+                    ),
                     "mode": opts.get("mode"),
                     "text": L[ind].tolist() if L is not None else None,
                     "textposition": "right",


### PR DESCRIPTION
## Description

`scatter()` previously hard-asserted that `Y` must contain integers ≥ 1, raising `AssertionError('labels should be integers')` for any float label array. This prevented common use-cases such as colouring scatter points by a continuous metric (dice score, F1, loss, etc.).

This PR extends `scatter()` to accept arbitrary numeric `Y` arrays:

**Integer fast-path (unchanged):** if all `Y` values are already whole numbers and `Y.min() >= 1`, the existing code runs exactly as before.

**Float / arbitrary path (new):**
1. `label_values = np.unique(Y)` captures the sorted original values.
2. `Y` is remapped to sequential 1-based indices via `np.searchsorted`, so that `markercolor`, `linecolor`, `dash`, and all palette lookups (which expect integer indices) continue to work correctly.
3. `labels = np.arange(1, K+1)` where `K = len(label_values)`.
4. Trace names show the real label value (`"0.1"`, `"0.5"`) instead of the internal index (`"1"`, `"2"`).

`label_values` is `None` on the integer path and when `Y` is not provided, so the trace-name fallback remains `str(k)` — fully backward-compatible.

## Motivation and Context

Fixes #651. Users want to use float-valued data (e.g. confidence scores, dice coefficients) directly as scatter group labels without manually converting them to integers.

## How Has This Been Tested?

- `python -m py_compile py/visdom/__init__.py` — no syntax errors.
- `python -m black --check py` — clean.
- Manually verified:
  - Integer labels `[1, 2, 3]`: trace names "1", "2", "3" (unchanged). ✓
  - Non-contiguous integer labels `[1, 3, 5]`: trace names "1", "3", "5" (unchanged via `str(k)` path). ✓
  - Float labels `[0.1, 0.5, 0.9]`: remapped to indices 1, 2, 3; trace names "0.1", "0.5", "0.9". ✓
  - Zero-origin integer labels `[0, 1, 2]`: remapped to 1, 2, 3; trace names "0", "1", "2". ✓
  - Single-trace `Y=None` + `name=`: unchanged behaviour. ✓

## Screenshots (if appropriate):

N/A — internal label-mapping change; legend text update visible in Plotly.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] I adapted the version number under `py/visdom/VERSION` according to Semantic Versioning
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.