### PR TITLE
Fix WebSocketClosedError on writing to closed sockets (#934)

### DIFF
--- a/py/visdom/server/handlers/socket_handlers.py
+++ b/py/visdom/server/handlers/socket_handlers.py
@@ -32,6 +32,7 @@ from visdom.utils.server_utils import (
     send_to_sources,
     broadcast,
     escape_eid,
+    safe_write_message,
 )
 from visdom.server.defaults import MAX_SOCKET_WAIT
 
@@ -225,10 +226,11 @@ class VisSocketHandlerOrWrapper(AnySocketHandlerOrWrapper):
             self.close()
             return
         super().open("sources")
-        try:
-            self.write_message(json.dumps({"command": "alive", "data": "vis_alive"}))
-        except tornado.websocket.WebSocketClosedError:
-            pass
+        safe_write_message(
+            self,
+            json.dumps({"command": "alive", "data": "vis_alive"}),
+            "VisSocketHandler open",
+        )
 
     def on_close(self):
         if self in list(self.sources.values()):
@@ -241,10 +243,9 @@ class VisSocketHandlerOrWrapper(AnySocketHandlerOrWrapper):
         if cmd == "echo":
             logging.info(f"from visdom client: {message}")
             for sub in self.sources.values():
-                try:
-                    sub.write_message(json.dumps(msg))
-                except tornado.websocket.WebSocketClosedError:
-                    pass
+                safe_write_message(
+                    sub, json.dumps(msg), "VisSocketHandler on_message echo"
+                )
             return
 
         super().on_message(message)
@@ -277,14 +278,10 @@ class SocketHandlerOrWrapper(AnySocketHandlerOrWrapper):
 
         super().open("subs")
 
-        try:
-            self.write_message(
-                json.dumps(
-                    {"command": "register", "data": self.sid, "readonly": self.readonly}
-                )
-            )
-        except tornado.websocket.WebSocketClosedError:
-            pass
+        msg = json.dumps(
+            {"command": "register", "data": self.sid, "readonly": self.readonly}
+        )
+        safe_write_message(self, msg, "SocketHandler open")
         self.broadcast_layouts([self])
         broadcast_envs(self, [self])
 
@@ -292,12 +289,8 @@ class SocketHandlerOrWrapper(AnySocketHandlerOrWrapper):
         if target_subs is None:
             target_subs = self.subs.values()
         for sub in target_subs:
-            try:
-                sub.write_message(
-                    json.dumps({"command": "layout_update", "data": self.app.layouts})
-                )
-            except tornado.websocket.WebSocketClosedError:
-                pass
+            msg = json.dumps({"command": "layout_update", "data": self.app.layouts})
+            safe_write_message(sub, msg, "SocketHandler broadcast_layouts")
 
     def initialize(self, app):
         super().initialize(app)

--- a/py/visdom/server/handlers/socket_handlers.py
+++ b/py/visdom/server/handlers/socket_handlers.py
@@ -22,6 +22,7 @@ import types
 
 import tornado.ioloop
 import tornado.escape
+import tornado.websocket
 from visdom.server.handlers.base_handlers import BaseWebSocketHandler, BaseHandler
 from visdom.utils.shared_utils import get_rand_id
 from visdom.utils.server_utils import (
@@ -224,7 +225,10 @@ class VisSocketHandlerOrWrapper(AnySocketHandlerOrWrapper):
             self.close()
             return
         super().open("sources")
-        self.write_message(json.dumps({"command": "alive", "data": "vis_alive"}))
+        try:
+            self.write_message(json.dumps({"command": "alive", "data": "vis_alive"}))
+        except tornado.websocket.WebSocketClosedError:
+            pass
 
     def on_close(self):
         if self in list(self.sources.values()):
@@ -237,7 +241,10 @@ class VisSocketHandlerOrWrapper(AnySocketHandlerOrWrapper):
         if cmd == "echo":
             logging.info(f"from visdom client: {message}")
             for sub in self.sources.values():
-                sub.write_message(json.dumps(msg))
+                try:
+                    sub.write_message(json.dumps(msg))
+                except tornado.websocket.WebSocketClosedError:
+                    pass
             return
 
         super().on_message(message)
@@ -270,11 +277,14 @@ class SocketHandlerOrWrapper(AnySocketHandlerOrWrapper):
 
         super().open("subs")
 
-        self.write_message(
-            json.dumps(
-                {"command": "register", "data": self.sid, "readonly": self.readonly}
+        try:
+            self.write_message(
+                json.dumps(
+                    {"command": "register", "data": self.sid, "readonly": self.readonly}
+                )
             )
-        )
+        except tornado.websocket.WebSocketClosedError:
+            pass
         self.broadcast_layouts([self])
         broadcast_envs(self, [self])
 
@@ -282,9 +292,12 @@ class SocketHandlerOrWrapper(AnySocketHandlerOrWrapper):
         if target_subs is None:
             target_subs = self.subs.values()
         for sub in target_subs:
-            sub.write_message(
-                json.dumps({"command": "layout_update", "data": self.app.layouts})
-            )
+            try:
+                sub.write_message(
+                    json.dumps({"command": "layout_update", "data": self.app.layouts})
+                )
+            except tornado.websocket.WebSocketClosedError:
+                pass
 
     def initialize(self, app):
         super().initialize(app)

--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -22,6 +22,7 @@ import logging
 import os
 import time
 import tornado.escape
+import tornado.websocket
 from collections import OrderedDict
 
 try:
@@ -347,14 +348,23 @@ def compare_envs(state, eids, socket, env_path=DEFAULT_ENV_PATH):
         "has_compare": True,
     }
     if "reload" in res:
-        socket.write_message(json.dumps({"command": "reload", "data": res["reload"]}))
+        try:
+            socket.write_message(json.dumps({"command": "reload", "data": res["reload"]}))
+        except tornado.websocket.WebSocketClosedError:
+            pass
 
     jsons = list(res.get("jsons", {}).values())
     windows = sorted(jsons, key=lambda k: ("i" not in k, k.get("i", None)))
     for v in windows:
-        socket.write_message(v)
+        try:
+            socket.write_message(v)
+        except tornado.websocket.WebSocketClosedError:
+            pass
 
-    socket.write_message(json.dumps({"command": "layout"}))
+    try:
+        socket.write_message(json.dumps({"command": "layout"}))
+    except tornado.websocket.WebSocketClosedError:
+        pass
     socket.eid = eids
 
 
@@ -365,15 +375,21 @@ def broadcast_envs(handler, target_subs=None):
     if target_subs is None:
         target_subs = handler.subs.values()
     for sub in target_subs:
-        sub.write_message(
-            json.dumps({"command": "env_update", "data": list(handler.state.keys())})
-        )
+        try:
+            sub.write_message(
+                json.dumps({"command": "env_update", "data": list(handler.state.keys())})
+            )
+        except tornado.websocket.WebSocketClosedError:
+            pass
 
 
 def send_to_sources(handler, msg):
     target_sources = handler.sources.values()
     for source in target_sources:
-        source.write_message(json.dumps(msg))
+        try:
+            source.write_message(json.dumps(msg))
+        except tornado.websocket.WebSocketClosedError:
+            pass
 
 
 def load_env(state, eid, socket, env_path=DEFAULT_ENV_PATH):
@@ -389,25 +405,37 @@ def load_env(state, eid, socket, env_path=DEFAULT_ENV_PATH):
                 state[eid] = env
 
     if "reload" in env:
-        socket.write_message(json.dumps({"command": "reload", "data": env["reload"]}))
+        try:
+            socket.write_message(json.dumps({"command": "reload", "data": env["reload"]}))
+        except tornado.websocket.WebSocketClosedError:
+            pass
 
     jsons = list(env.get("jsons", {}).values())
     windows = sorted(jsons, key=lambda k: ("i" not in k, k.get("i", None)))
     for v in windows:
-        socket.write_message(v)
+        try:
+            socket.write_message(v)
+        except tornado.websocket.WebSocketClosedError:
+            pass
 
-    socket.write_message(json.dumps({"command": "layout"}))
+    try:
+        socket.write_message(json.dumps({"command": "layout"}))
+    except tornado.websocket.WebSocketClosedError:
+        pass
     socket.eid = eid
 
 
 def broadcast(self, msg, eid):
     for s in self.subs:
-        if isinstance(self.subs[s].eid, dict):
-            if eid in self.subs[s].eid:
-                self.subs[s].write_message(msg)
-        else:
-            if self.subs[s].eid == eid:
-                self.subs[s].write_message(msg)
+        try:
+            if isinstance(self.subs[s].eid, dict):
+                if eid in self.subs[s].eid:
+                    self.subs[s].write_message(msg)
+            else:
+                if self.subs[s].eid == eid:
+                    self.subs[s].write_message(msg)
+        except tornado.websocket.WebSocketClosedError:
+            pass
 
 
 def register_window(self, p, eid):

--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -347,49 +347,53 @@ def compare_envs(state, eids, socket, env_path=DEFAULT_ENV_PATH):
         "i": 1,
         "has_compare": True,
     }
+
     if "reload" in res:
+        safe_write_message(
+            socket,
+            json.dumps({"command": "reload", "data": res["reload"]}),
+            "compare_envs",
+        )
         try:
-            socket.write_message(json.dumps({"command": "reload", "data": res["reload"]}))
+            socket.write_message(
+                json.dumps({"command": "reload", "data": res["reload"]})
+            )
         except tornado.websocket.WebSocketClosedError:
             pass
 
     jsons = list(res.get("jsons", {}).values())
     windows = sorted(jsons, key=lambda k: ("i" not in k, k.get("i", None)))
     for v in windows:
-        try:
-            socket.write_message(v)
-        except tornado.websocket.WebSocketClosedError:
-            pass
+        safe_write_message(socket, v, "compare_envs windows")
 
-    try:
-        socket.write_message(json.dumps({"command": "layout"}))
-    except tornado.websocket.WebSocketClosedError:
-        pass
+    safe_write_message(socket, json.dumps({"command": "layout"}), "compare_envs layout")
     socket.eid = eids
 
 
 # ------- Broadcasting functions ---------- #
 
 
+def safe_write_message(socket, msg, context=""):
+    """Safely write a message to a websocket, dropping if client is disconnected.
+    Logs debug information if writing fails."""
+    try:
+        socket.write_message(msg)
+    except tornado.websocket.WebSocketClosedError:
+        logging.debug(f"Failed to write to closed websocket in {context}")
+
+
 def broadcast_envs(handler, target_subs=None):
     if target_subs is None:
         target_subs = handler.subs.values()
     for sub in target_subs:
-        try:
-            sub.write_message(
-                json.dumps({"command": "env_update", "data": list(handler.state.keys())})
-            )
-        except tornado.websocket.WebSocketClosedError:
-            pass
+        msg = json.dumps({"command": "env_update", "data": list(handler.state.keys())})
+        safe_write_message(sub, msg, "broadcast_envs")
 
 
 def send_to_sources(handler, msg):
     target_sources = handler.sources.values()
     for source in target_sources:
-        try:
-            source.write_message(json.dumps(msg))
-        except tornado.websocket.WebSocketClosedError:
-            pass
+        safe_write_message(source, json.dumps(msg), "send_to_sources")
 
 
 def load_env(state, eid, socket, env_path=DEFAULT_ENV_PATH):
@@ -405,37 +409,34 @@ def load_env(state, eid, socket, env_path=DEFAULT_ENV_PATH):
                 state[eid] = env
 
     if "reload" in env:
-        try:
-            socket.write_message(json.dumps({"command": "reload", "data": env["reload"]}))
-        except tornado.websocket.WebSocketClosedError:
-            pass
+        safe_write_message(
+            socket,
+            json.dumps({"command": "reload", "data": env["reload"]}),
+            "load_env reload",
+        )
 
     jsons = list(env.get("jsons", {}).values())
     windows = sorted(jsons, key=lambda k: ("i" not in k, k.get("i", None)))
     for v in windows:
-        try:
-            socket.write_message(v)
-        except tornado.websocket.WebSocketClosedError:
-            pass
+        safe_write_message(socket, v, "load_env windows")
 
-    try:
-        socket.write_message(json.dumps({"command": "layout"}))
-    except tornado.websocket.WebSocketClosedError:
-        pass
+    safe_write_message(socket, json.dumps({"command": "layout"}), "load_env layout")
     socket.eid = eid
 
 
 def broadcast(self, msg, eid):
     for s in self.subs:
-        try:
-            if isinstance(self.subs[s].eid, dict):
-                if eid in self.subs[s].eid:
-                    self.subs[s].write_message(msg)
-            else:
-                if self.subs[s].eid == eid:
-                    self.subs[s].write_message(msg)
-        except tornado.websocket.WebSocketClosedError:
-            pass
+        sub = self.subs[s]
+        should_send = False
+        if isinstance(sub.eid, dict):
+            if eid in sub.eid:
+                should_send = True
+        else:
+            if sub.eid == eid:
+                should_send = True
+
+        if should_send:
+            safe_write_message(sub, msg, "broadcast to subs")
 
 
 def register_window(self, p, eid):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix WebSocketClosedError when writing to disconnected clients (#934)

## Description
This Pull Request prevents the server from crashing when broadcasting to closed WebSocket connections.

When sending data to clients via WebSockets, occasional disconnects leave stale websocket connections on the server side until they are clean. During this window, writing a message to these closed sockets raises a `tornado.websocket.WebSocketClosedError`, leading to an `Uncaught exception POST /events (127.0.0.1)` on the server and crashing the broadcast event. This fixes [#934](https://github.com/fosdem/visdom/issues/934).

**Updates based on PR Feedback:**
- Abstracted the `try...except tornado.websocket.WebSocketClosedError` logic into a single centralized helper function `safe_write_message(socket, msg, context="")` in `server_utils.py`.
- Applied `safe_write_message` across all broadcasting functions in `server_utils.py` and across sockets in `socket_handlers.py`.
- Added a `logging.debug` statement within the exception handler to improve operational visibility without crashing the server.
- Ensured that `write_message` is the only operation inside the try/except block so no other critical errors (like `KeyError` or `AttributeError`) are silently masked.

## Motivation and Context
This ignores the error for closed sockets, allowing the loop to continue broadcasting to other healthy websocket clients without crashing the server.

## How Has This Been Tested?
Ran `demo.py` from the examples to verify that normal plotting and updates work as expected, and simulated ungraceful websocket closures to confirm it resolves the `WebSocketClosedError` without crashing the `POST /events` endpoint.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
