### PR TITLE
Bind event handlers to (env, window) pair to prevent cross-talk

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -548,14 +548,16 @@ class Visdom(object):
         self._session = sess
         return sess
 
-    def register_event_handler(self, handler, target):
-        assert callable(handler), "Event handler must be a function"
-        assert self.use_socket, (
-            "Must be using the incoming socket to " "register events to web actions"
-        )
-        if target not in self.event_handlers:
-            self.event_handlers[target] = []
-        self.event_handlers[target].append(handler)
+    def register_event_handler(self, handler, target, env=None):
+    assert callable(handler), 'Event handler must be a function'
+    assert self.use_socket, 'Must be using the incoming socket to register events to web actions'
+
+    key = (env, target)
+
+    if key not in self.event_handlers:
+        self.event_handlers[key] = []
+
+    self.event_handlers[key].append(handler)
 
     def clear_event_handlers(self, target):
         self.event_handlers[target] = []
@@ -577,8 +579,11 @@ class Visdom(object):
                             "Visdom server failed handshake, may not "
                             "be properly connected"
                         )
-            if "target" in message:
-                for handler in list(self.event_handlers.get(message["target"], [])):
+            if 'target' in message:
+                env = message.get('eid')
+                key = (env, message['target'])
+
+                for handler in list(self.event_handlers.get(key, [])):
                     handler(message)
 
         def on_close(ws):


### PR DESCRIPTION
Previously event handlers were registered only using the window target id. This could cause cross-talk when windows with the same name existed in different environments.

This change binds event handlers using the (env, target) pair to ensure events are dispatched only to the correct environment window combination.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, experiments you ran to see how -->
<!--- your change affects existing areas of the code and their behaviors, etc. -->
<!--- One method of testing is to run the `demo.py` script from the examples -->
<!--- both on your branch and a clean branch and ensure that none of the functionality -->
<!--- appears different. Be sure to install from source when testing. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Summary by Sourcery

Bug Fixes:
- Prevent cross-talk between windows with the same target identifier across different environments by including the environment ID in event handler registration and lookup.