### PR TITLE
Fix shape mismatch in visdom.line when Y has shape (N,1)

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -1785,6 +1785,9 @@ class Visdom(object):
         if Y.ndim == 2 and X.ndim == 1:
             X = np.tile(X, (Y.shape[1], 1)).transpose()
 
+        if Y.ndim == 2 and Y.shape[1] == 1:
+            Y = Y.reshape(Y.shape[0])
+
         assert X.shape == Y.shape, "X and Y should be the same shape"
 
         opts = {} if opts is None else opts


### PR DESCRIPTION
Flatten Y when it has shape (N,1) to prevent incorrect reshaping that causes X to be tiled incorrectly and results in a shape mismatch error.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, experiments you ran to see how -->
<!--- your change affects existing areas of the code and their behaviors, etc. -->
<!--- One method of testing is to run the `demo.py` script from the examples -->
<!--- both on your branch and a clean branch and ensure that none of the functionality -->
<!--- appears different. Be sure to install from source when testing. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Summary by Sourcery

Bug Fixes:
- Normalize Y with shape (N,1) to a 1D array in visdom.line so that X tiling and shape checks no longer fail for single-column data.