### PR TITLE
Fix histogram input handling for multiple observations (#927)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-
-
 <h3 align="center">
     <br/>
     <img src="https://user-images.githubusercontent.com/19650074/198746195-574bb828-026f-41cb-82a9-250fcbc4e090.png" width="300" alt="Logo"/><br/><br/>
@@ -190,6 +188,22 @@ Start the server (probably in a  `screen` or `tmux`) from the command line:
 Visdom now can be accessed by going to `http://localhost:8097` in your browser, or your own host address if specified.
 
 > The `visdom` command is equivalent to running `python -m visdom.server`.
+
+### Troubleshooting Installation Errors
+
+Some users may experience installation errors when running:
+
+pip install visdom
+
+This issue may occur when using newer Python versions (e.g. Python 3.13) because
+the pkg_resources module is no longer available in newer setuptools builds.
+
+Possible solution:
+
+pip install "setuptools<81"
+pip install tornado websocket-client numpy scipy
+
+If installation still fails, run the server directly from the source code.
 
 >If the above does not work, try using an SSH tunnel to your server by adding the following line to your local  `~/.ssh/config`:
 ```LocalForward 127.0.0.1:8097 127.0.0.1:8097```.

--- a/README.md
+++ b/README.md
@@ -160,10 +160,6 @@ Using the repack icon (9 boxes), visdom will attempt to pack your windows in a w
 Using the view dropdown it is possible to select previously saved views, restoring the locations and sizes of all of the windows within the current environment to the places they were when that view was saved last.
 </details>
 
-
-
-
-
 ## Setup
 Python and web clients come bundled with the python server.
 
@@ -191,19 +187,37 @@ Visdom now can be accessed by going to `http://localhost:8097` in your browser, 
 
 ### Troubleshooting Installation Errors
 
-Some users may experience installation errors when running:
+Some users may encounter installation errors when running:
 
+```bash
 pip install visdom
+```
 
-This issue may occur when using newer Python versions (e.g. Python 3.13) because
-the pkg_resources module is no longer available in newer setuptools builds.
+This may happen when using newer Python versions (e.g., Python 3.13)
+because the `pkg_resources` module is removed from newer `setuptools`.
 
-Possible solution:
+### Possible Solution
 
+Create a virtual environment and install compatible dependencies:
+
+```bash
+python -m venv visdom-env
+source visdom-env/bin/activate
 pip install "setuptools<81"
 pip install tornado websocket-client numpy scipy
+```
 
-If installation still fails, run the server directly from the source code.
+### Run Visdom from Source
+
+If installation still fails, run the server directly from the repository root:
+
+```bash
+python -m visdom.server
+```
+
+The dashboard will be available at:
+
+http://localhost:8097
 
 >If the above does not work, try using an SSH tunnel to your server by adding the following line to your local  `~/.ssh/config`:
 ```LocalForward 127.0.0.1:8097 127.0.0.1:8097```.

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -2002,7 +2002,7 @@ class Visdom(object):
 
         - `opts.numbins`: number of bins (`number`; default = 30)
         """
-        X = np.asarray(X)   # ✅ Added line (convert list/tensor to numpy array)
+        X = np.asarray(X)   # Added line (convert list/tensor to numpy array)
         X = np.squeeze(X)
         assert X.ndim == 1, "X should be one-dimensional"
 

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -2002,7 +2002,18 @@ class Visdom(object):
 
         - `opts.numbins`: number of bins (`number`; default = 30)
         """
-        X = np.asarray(X)   # Added line (convert list/tensor to numpy array)
+        # handle torch tensors if available
+        torch = None
+        try:
+            import torch
+        except ImportError:
+            pass
+
+        if torch is not None and torch.is_tensor(X):
+            X = X.detach().cpu().numpy()
+        else:
+            X = np.asarray(X)
+            
         X = np.squeeze(X)
         assert X.ndim == 1, "X should be one-dimensional"
 

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -2002,7 +2002,7 @@ class Visdom(object):
 
         - `opts.numbins`: number of bins (`number`; default = 30)
         """
-
+        X = np.asarray(X)   # ✅ Added line (convert list/tensor to numpy array)
         X = np.squeeze(X)
         assert X.ndim == 1, "X should be one-dimensional"
 


### PR DESCRIPTION
Fix for Issue #927

Problem:
The histogram() function fails when users pass a Python list as input.

Example:
vis.histogram(X=[1,2,3,4,5])

Solution:
Converted input X to a NumPy array inside the histogram() function so that it works with lists, tensors, and NumPy arrays.

Changes:
Added conversion:
X = np.array(X)

This ensures histogram plotting works correctly for multiple observations.

## Summary by Sourcery

Improve histogram input robustness and document installation troubleshooting steps for newer Python environments.

Bug Fixes:
- Ensure histogram plotting works with Python lists, NumPy arrays, and torch tensors by normalizing inputs to NumPy arrays.

Documentation:
- Add troubleshooting guidance for pip installation issues on newer Python versions and instructions for running Visdom from source.