### PR TITLE
Fix environment saving when env name exceeds filesystem filename limit

### DIFF
--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -118,13 +118,31 @@ class LazyEnvData(Mapping):
 def serialize_env(state, eids, env_path=DEFAULT_ENV_PATH):
     env_ids = [i for i in eids if i in state]
     if env_path is not None:
-        for env_id in env_ids:
-            env_path_file = os.path.join(env_path, "{0}.json".format(env_id))
-            with open(env_path_file, "w") as fn:
-                if isinstance(state[env_id], LazyEnvData):
-                    fn.write(json.dumps(state[env_id]._raw_dict))
-                else:
-                    fn.write(json.dumps(state[env_id]))
+       for env_id in env_ids:
+    filename = f"{env_id}.json"
+    env_path_file = os.path.join(env_path, filename)
+
+    try:
+        with open(env_path_file, "w") as fn:
+            if isinstance(state[env_id], LazyEnvData):
+                fn.write(json.dumps(state[env_id]._raw_dict))
+            else:
+                fn.write(json.dumps(state[env_id]))
+
+    except OSError:
+        # fallback if filename exceeds filesystem limit
+        hashed_name = hashlib.md5(env_id.encode("utf-8")).hexdigest() + ".json"
+        env_path_file = os.path.join(env_path, hashed_name)
+
+        logging.warning(
+            f"Environment name too long, saving as hashed filename: {hashed_name}"
+        )
+
+        with open(env_path_file, "w") as fn:
+            if isinstance(state[env_id], LazyEnvData):
+                fn.write(json.dumps(state[env_id]._raw_dict))
+            else:
+                fn.write(json.dumps(state[env_id]))
     return env_ids
 
 


### PR DESCRIPTION
Attempt to save environment JSON normally and fall back to a hashed filename if the filesystem raises an error due to filename length.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, experiments you ran to see how -->
<!--- your change affects existing areas of the code and their behaviors, etc. -->
<!--- One method of testing is to run the `demo.py` script from the examples -->
<!--- both on your branch and a clean branch and ensure that none of the functionality -->
<!--- appears different. Be sure to install from source when testing. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Summary by Sourcery

Handle failures when saving environment files due to overly long environment names by falling back to a hashed filename.

Bug Fixes:
- Prevent environment saving from failing when the environment name exceeds the filesystem filename length limit.

Enhancements:
- Log a warning when an environment is saved using a hashed filename due to a name length issue.