### PR TITLE
Fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Environments are automatically hierarchically organized by the first `_`.
 #### Selecting Environments
 <p align="center"><img align="center" src="https://user-images.githubusercontent.com/19650074/198821299-6602d557-7a02-4b9f-b1d5-d57615cdc15c.png" width="300" /></p>
 
-From the main page it is possible to toggle between different environments using the environment selector. Selecting a new environment will query the server for the plots that exist in that environment. The environment selector allows for searching and filtering for the new enironment.
+From the main page it is possible to toggle between different environments using the environment selector. Selecting a new environment will query the server for the plots that exist in that environment. The environment selector allows for searching and filtering for the new environment.
 
 #### Comparing Environments
 


### PR DESCRIPTION
## Description

This PR fixes a small typo in the README under the **Environments → Selecting Environments** section and improves the sentence for better clarity.

## Motivation and Context

The README currently contains a typo ("enironment") which may affect readability.
This change corrects the spelling and improves the sentence structure.

## How Has This Been Tested?

This change only modifies documentation (README.md) and does not affect the codebase or functionality.

## Types of changes

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [x] Code refactor or cleanup

## Checklist

* [ ] I adapted the version number under `py/visdom/VERSION`
* [ ] My code follows the code style of this project.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.

## Summary by Sourcery

Improve README documentation clarity for environment selection and server usage.

Documentation:
- Fix a typo in the environment selection section of the README.
- Clarify and reformat README instructions for starting the Visdom server, accessing the dashboard, and configuring SSH tunneling.