### PR TITLE
Add support for comparing text windows across environments

### DIFF
--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -266,7 +266,7 @@ def compare_envs(state, eids, socket, env_path=DEFAULT_ENV_PATH):
         env = envs[eid]
         for wid in env.get("jsons", {}).keys():
             win = env["jsons"][wid]
-            if win.get("type", None) != "plot":
+            if win.get("type", None) not in ["plot", "text"]:
                 continue
             if "content" not in win:
                 continue
@@ -275,6 +275,19 @@ def compare_envs(state, eids, socket, env_path=DEFAULT_ENV_PATH):
             title = win["title"]
             if title not in name2Wid or title == "":
                 continue
+
+            if win.get("type") == "text":
+                destWid = name2Wid[title]
+                destWidJson = res["jsons"][destWid]
+
+                if ix == 0:
+                    destWidJson["content"] = f"<b>{eidNums[eid]}</b><br>{win['content']}"
+                    destWidJson["type"] = "text"
+                    destWidJson["has_compare"] = False
+                else:
+                    destWidJson["has_compare"] = True
+                    destWidJson["content"] += f"<br><br><b>{eidNums[eid]}</b><br>{win['content']}"
+                    continue
 
             destWid = name2Wid[title]
             destWidJson = res["jsons"][destWid]


### PR DESCRIPTION
Currently the compare environments feature only supports plot windows with the same title across different environments. Text windows with identical titles are ignored during comparison.

This change extends the compare_envs logic to also include text windows. Text windows with the same title across environments are now displayed in the compare view, with their contents grouped together and labeled by environment index.

This makes it easier to compare experiment configurations or logs that are stored in text windows across multiple runs.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, experiments you ran to see how -->
<!--- your change affects existing areas of the code and their behaviors, etc. -->
<!--- One method of testing is to run the `demo.py` script from the examples -->
<!--- both on your branch and a clean branch and ensure that none of the functionality -->
<!--- appears different. Be sure to install from source when testing. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Summary by Sourcery

New Features:
- Display text windows with matching titles in the compare environments view, grouping their contents by environment index.