### PR TITLE
Remove redundant hostname assignment in run_server

### DIFF
--- a/py/visdom/server/run_server.py
+++ b/py/visdom/server/run_server.py
@@ -58,8 +58,6 @@ def start_server(
 
     if "HOSTNAME" in os.environ and hostname == DEFAULT_HOSTNAME:
         hostname = os.environ["HOSTNAME"]
-    else:
-        hostname = hostname
     if print_func is None:
         print("You can navigate to http://%s:%s%s" % (hostname, port, base_url))
     else:


### PR DESCRIPTION
## Description

This PR removes a redundant assignment in the server startup logic.

The `else` block contained `hostname = hostname`, which has no effect and can be safely removed.

## Motivation and Context

Removing unnecessary assignments improves code readability and avoids redundant logic in the server initialization code.

## How Has This Been Tested?

This change only removes redundant code and does not modify functionality. The server startup logic remains unchanged.


## Types of changes

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [x] Code refactor or cleanup

## Checklist:

* [ ] I adapted the version number under `py/visdom/VERSION`
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.

