### PR TITLE
docs: improve docstrings and fix typo in server_utils

### DIFF
--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -7,11 +7,10 @@
 # LICENSE file in the root directory of this source tree.
 
 """
-Utilities for the server architecture that don't really have
-a more appropriate place.
+Utility functions supporting the Visdom server.
 
-At the moment, this just inherited all of the floating functions
-in the previous server.py class.
+Includes helpers for authentication, environment management,
+window handling, and server communication.
 """
 
 
@@ -61,7 +60,7 @@ def check_auth(f):
 
 
 def set_cookie(value=None):
-    """Create cookie secret key for authentication"""
+    """Create and store a cookie secret key used for authentication."""
     if value is not None:
         cookie_secret = value
     else:
@@ -71,11 +70,11 @@ def set_cookie(value=None):
 
 
 def hash_password(password):
-    """Hashing Password with SHA-256"""
+    """Hash a password using SHA-256."""
     return hashlib.sha256(password.encode("utf-8")).hexdigest()
 
 
-# ------- File management helprs ----- #
+# ------- File management helpers ----- #
 
 
 class LazyEnvData(Mapping):


### PR DESCRIPTION
## Description
Improved docstrings in `server_utils.py` to enhance clarity and readability. 
Also fixed a minor typo in a comment ("helprs" → "helpers").

## Motivation and Context
The existing docstrings were vague and less descriptive. Improving them helps developers better understand the purpose of utility functions.
The typo fix improves overall code quality.

## How Has This Been Tested?
- Verified that changes are limited to docstrings and comments only.
- No functional code was modified.
- Ensured no impact on existing behavior.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
- [ ] I adapted the version number under `py/visdom/VERSION` according to Semantic Versioning
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.