### PR TITLE
Add troubleshooting note for pkg_resources (setuptools dependency)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,18 @@ We want to make contributing to this project as easy and transparent as
 possible.
 
 ## Issues
+
+**Issue: ModuleNotFoundError: No module named 'pkg_resources'**
+
+This error may occur during project setup if the required dependency is missing.
+
+The `pkg_resources` module is part of the `setuptools` package.
+
+To resolve this issue, install setuptools:
+
+```bash
+pip install setuptools
+
 Before you post an issue on our tracker, please check the following list of
 issues to see if it resolves your issue. If this document does not resolve your
 problem, please scroll all the way down for details on how to report an issue.


### PR DESCRIPTION
## Description

This PR improves the contributor onboarding experience by adding a troubleshooting note for the `pkg_resources` module error in the CONTRIBUTING.md file.

## Problem

New contributors may encounter the following error during project setup:

ModuleNotFoundError: No module named 'pkg_resources'

This happens because `pkg_resources` is part of the `setuptools` package, which is not explicitly mentioned in the documentation.

## Solution

- Added a new issue entry under the "Issues" section
- Explained that `pkg_resources` comes from `setuptools`
- Provided installation instruction: `pip install setuptools`
- Included an additional step to upgrade pip if needed

## Impact

This change helps new contributors quickly resolve setup issues and reduces confusion during the initial project setup.

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature

## Summary by Sourcery

Documentation:
- Add an Issues section entry explaining the ModuleNotFoundError for pkg_resources and how to resolve it by installing setuptools.