### PR TITLE
fix: remove invalid user/style.css reference from index.html

### DIFF
--- a/py/visdom/static/index.html
+++ b/py/visdom/static/index.html
@@ -62,7 +62,6 @@ LICENSE file in the root directory of this source tree.
     </script>
     <script src={{ static_url("js/main.js") }}></script>
     <link rel="stylesheet" href={{ static_url("css/style.css") }}>
-   <link rel="stylesheet" href={{ static_url("css/style.css") }}>
     <!-- Added Script for NetworkPane -->
     <link rel="stylesheet" href={{ static_url("css/network.css") }}>
 

--- a/py/visdom/static/index.html
+++ b/py/visdom/static/index.html
@@ -62,7 +62,7 @@ LICENSE file in the root directory of this source tree.
     </script>
     <script src={{ static_url("js/main.js") }}></script>
     <link rel="stylesheet" href={{ static_url("css/style.css") }}>
-    <link rel="stylesheet" href={{ static_url("../user/style.css") }}>
+   <link rel="stylesheet" href={{ static_url("css/style.css") }}>
     <!-- Added Script for NetworkPane -->
     <link rel="stylesheet" href={{ static_url("css/network.css") }}>
 


### PR DESCRIPTION
## Fix: Remove invalid static CSS path

### Problem
The frontend attempted to load a stylesheet from `../user/style.css`, which does not exist, causing a static file error.

### Solution
- Removed incorrect stylesheet reference
- Kept the valid `css/style.css` import

### Result
- No more static file errors
- UI loads correctly

## Summary by Sourcery

Bug Fixes:
- Eliminate reference to a non-existent user stylesheet in index.html that caused static file load errors.