### PR TITLE
Add experiment tagging feature with UI, API, and filtering support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ py/visdom/static/version.built
 __pycache__/
 py/visdom/static/js/layout_bin_packer.js
 py/visdom/extra_deps/**/*
+venv/

--- a/README.md
+++ b/README.md
@@ -112,6 +112,33 @@ You can use the eraser button to remove all of the current contents of an enviro
 
 Pressing the folder icon opens a dialog that allows you to fork or force save the current environment, or delete any of your existing environments. Use of this feature is fully described in the **State** section.
 
+#### Experiment Tags
+Experiment tagging enables better organization, search, and comparison of machine learning experiments.
+
+Each environment can now store `tags` (useful for experiment tracking). Tags are saved in the env JSON and remain backward compatible for older env files that do not include tags yet.
+
+Example env JSON:
+```json
+{
+  "jsons": {},
+  "reload": {},
+  "tags": ["cnn", "resnet", "vision"]
+}
+```
+
+You can add tags from the top bar UI (`Add tags (comma)`) and filter environments with `Filter env by tag`.
+
+API examples:
+```bash
+curl -X POST http://localhost:8097/experiment/exp1/tags \
+  -H "Content-Type: application/json" \
+  -d '{"tags":["cnn","resnet","vision"]}'
+```
+
+```bash
+curl "http://localhost:8097/experiments?tag=cnn"
+```
+
 >**Env Files:**
 >Your envs are loaded upon request by the user, by default from `$HOME/.visdom/`. Custom paths can be passed as a cmd-line argument. Envs are removed by using the delete button or by deleting the corresponding `.json` file from the env dir. In case you want the server to pre-load all files into cache, use the flag `-eager_data_loading`.
 

--- a/js/api/ApiProvider.js
+++ b/js/api/ApiProvider.js
@@ -167,6 +167,31 @@ const ApiProvider = ({ children }) => {
     }
   };
 
+  const getExperiments = (tag = '') => {
+    const query = tag ? '?tag=' + encodeURIComponent(tag) : '';
+    return fetch(correctPathname() + 'experiments' + query, {
+      method: 'GET',
+      credentials: 'same-origin',
+    }).then((res) => res.json());
+  };
+
+  const addExperimentTags = (experimentID, tags) => {
+    return fetch(
+      correctPathname() +
+        'experiment/' +
+        encodeURIComponent(experimentID) +
+        '/tags',
+      {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+        },
+        body: JSON.stringify({ tags: tags }),
+      }
+    ).then((res) => res.json());
+  };
+
   // Toggle connection state between online and offline
   const toggleOnlineState = () => {
     if (connected) {
@@ -297,6 +322,8 @@ const ApiProvider = ({ children }) => {
         sendPaneClose,
         sendPaneLayoutUpdate,
         sendPaneMessage,
+        getExperiments,
+        addExperimentTags,
         sessionInfo,
         setConnected,
         toggleOnlineState,

--- a/js/main.js
+++ b/js/main.js
@@ -71,6 +71,8 @@ const App = () => {
     sendLayoutsSave,
     sendPaneClose,
     sendPaneLayoutUpdate,
+    getExperiments,
+    addExperimentTags,
     sessionInfo,
     toggleOnlineState,
   } = useContext(ApiContext);
@@ -105,6 +107,12 @@ const App = () => {
   const [filterString, setFilterString] = useState(
     localStorage.getItem('filter') || ''
   );
+  const [experimentTags, setExperimentTags] = useState({});
+  const [tagInput, setTagInput] = useState('');
+  const [tagFilter, setTagFilter] = useState(
+    localStorage.getItem('tagFilter') || ''
+  );
+  const [tagFilteredEnvList, setTagFilteredEnvList] = useState(null);
 
   // non-triggering state variables
   const _bin = useRef(null);
@@ -298,6 +306,27 @@ const App = () => {
       envList: data,
       layoutLists: layoutLists,
     }));
+    refreshExperimentTags(tagFilter);
+  };
+
+  const refreshExperimentTags = (tag = '') => {
+    getExperiments(tag).then((resp) => {
+      const experiments = (resp && resp.experiments) || [];
+      let nextTags = {};
+      let filteredEnvs = [];
+      experiments.forEach((experiment) => {
+        nextTags[experiment.experiment_id] = experiment.tags || [];
+        filteredEnvs.push(experiment.experiment_id);
+      });
+
+      if (!tag || tag.trim() === '') {
+        setExperimentTags(nextTags);
+        setTagFilteredEnvList(null);
+      } else {
+        setExperimentTags((prev) => ({ ...prev, ...nextTags }));
+        setTagFilteredEnvList(filteredEnvs);
+      }
+    });
   };
 
   // remove paneID from pane list
@@ -371,6 +400,24 @@ const App = () => {
 
   const onEnvDelete = (env2delete, previousEnv) => {
     sendEnvDelete(env2delete, previousEnv);
+  };
+
+  const onTagSubmit = () => {
+    const activeExperimentID = selection.envIDs[0];
+    if (!activeExperimentID) {
+      return;
+    }
+    const tags = tagInput
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter((tag) => tag.length > 0);
+    if (tags.length === 0) {
+      return;
+    }
+    addExperimentTags(activeExperimentID, tags).then(() => {
+      setTagInput('');
+      refreshExperimentTags(tagFilter);
+    });
   };
 
   const onEnvSave = (env) => {
@@ -704,6 +751,11 @@ const App = () => {
     localStorage.setItem('filter', filterString);
   }, [filterString]);
 
+  useEffect(() => {
+    localStorage.setItem('tagFilter', tagFilter);
+    refreshExperimentTags(tagFilter);
+  }, [tagFilter]);
+
   const onWidthChange = (width, cols) => {
     windowSize.current.cols = cols;
     windowSize.current.width = width;
@@ -793,13 +845,20 @@ const App = () => {
   let envControls = (
     <EnvControls
       envIDs={selection.envIDs}
-      envList={storeMeta.envList}
+      envList={tagFilteredEnvList || storeMeta.envList}
       envSelectorStyle={{
         width: Math.max(window.innerWidth / 3, 50),
       }}
       onEnvClear={closeAllPanes}
       onEnvManageButton={() => setShowEnvModal(!showEnvModal)}
       onEnvSelect={onEnvSelect}
+      activeExperimentTags={experimentTags[selection.envIDs[0]] || []}
+      tagInput={tagInput}
+      onTagInputChange={(ev) => setTagInput(ev.target.value)}
+      onTagInputSubmit={onTagSubmit}
+      tagFilter={tagFilter}
+      onTagFilterChange={(ev) => setTagFilter(ev.target.value)}
+      onTagFilterClear={() => setTagFilter('')}
     />
   );
   let viewControls = (

--- a/js/topbar/EnvControls.js
+++ b/js/topbar/EnvControls.js
@@ -22,6 +22,13 @@ function EnvControls(props) {
     onEnvSelect,
     onEnvClear,
     onEnvManageButton,
+    activeExperimentTags,
+    tagInput,
+    onTagInputChange,
+    onTagInputSubmit,
+    tagFilter,
+    onTagFilterChange,
+    onTagFilterClear,
   } = props;
   const [confirmClear, setConfirmClear] = useState(false);
 
@@ -123,6 +130,62 @@ function EnvControls(props) {
         >
           <span className="glyphicon glyphicon-folder-open" />
         </button>
+      </div>
+      <span style={{ marginLeft: 10 }}>
+        <span className="label label-default">Tags</span>
+        {activeExperimentTags.map((tag) => (
+          <span key={tag} className="label label-primary" style={{ marginLeft: 5 }}>
+            {tag}
+          </span>
+        ))}
+      </span>
+      <div
+        className="input-group navbar-btn"
+        style={{ width: 200, display: 'inline-flex', marginLeft: 10 }}
+      >
+        <input
+          type="text"
+          className="form-control"
+          placeholder="Add tags (comma)"
+          value={tagInput}
+          onChange={onTagInputChange}
+          onKeyDown={(ev) => {
+            if (ev.key === 'Enter') {
+              onTagInputSubmit();
+            }
+          }}
+        />
+        <span className="input-group-btn">
+          <button
+            type="button"
+            className="btn btn-default"
+            disabled={!(connected && envIDs.length > 0 && !readonly)}
+            onClick={onTagInputSubmit}
+          >
+            Add
+          </button>
+        </span>
+      </div>
+      <div
+        className="input-group navbar-btn"
+        style={{ width: 180, display: 'inline-flex', marginLeft: 10 }}
+      >
+        <input
+          type="text"
+          className="form-control"
+          placeholder="Filter env by tag"
+          value={tagFilter}
+          onChange={onTagFilterChange}
+        />
+        <span className="input-group-btn">
+          <button
+            type="button"
+            className="btn btn-default"
+            onClick={onTagFilterClear}
+          >
+            <span className="glyphicon glyphicon-erase" />
+          </button>
+        </span>
       </div>
     </span>
   );

--- a/py/tests/test_experiment_tags.py
+++ b/py/tests/test_experiment_tags.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+from visdom.utils.server_utils import (
+    add_tags,
+    get_experiments_by_tag,
+    remove_tag,
+)
+
+
+def test_add_tags_on_legacy_env_structure():
+    # Legacy envs may not have a "tags" key; this should still work.
+    state = {"exp1": {"jsons": {}, "reload": {}}}
+    updated_tags = add_tags(state, "exp1", ["cnn", "resnet"])
+
+    assert updated_tags == ["cnn", "resnet"]
+    assert state["exp1"]["tags"] == ["cnn", "resnet"]
+
+
+def test_get_experiments_by_tag_filters_expected_envs():
+    state = {
+        "exp1": {"jsons": {}, "reload": {}, "tags": ["cnn", "vision"]},
+        "exp2": {"jsons": {}, "reload": {}, "tags": ["nlp"]},
+        "exp3": {"jsons": {}, "reload": {}},
+    }
+
+    filtered = get_experiments_by_tag(state, "cnn")
+
+    assert filtered == ["exp1"]
+
+
+def test_remove_tag_updates_tag_list():
+    state = {"exp1": {"jsons": {}, "reload": {}, "tags": ["cnn", "vision"]}}
+
+    updated_tags = remove_tag(state, "exp1", "cnn")
+
+    assert updated_tags == ["vision"]
+    assert state["exp1"]["tags"] == ["vision"]

--- a/py/visdom/server/app.py
+++ b/py/visdom/server/app.py
@@ -20,7 +20,12 @@ import tornado.web  # noqa E402: gotta install ioloop first
 import tornado.escape  # noqa E402: gotta install ioloop first
 
 from visdom.utils.shared_utils import warn_once, ensure_dir_exists, get_visdom_path
-from visdom.utils.server_utils import serialize_env, LazyEnvData
+from visdom.utils.server_utils import (
+    serialize_env,
+    LazyEnvData,
+    ensure_env_structure,
+    build_empty_env,
+)
 from visdom.server.handlers.socket_handlers import (
     SocketHandler,
     SocketWrap,
@@ -42,6 +47,8 @@ from visdom.server.handlers.web_handlers import (
     SaveHandler,
     UpdateHandler,
     UserSettingsHandler,
+    ExperimentTagsHandler,
+    ExperimentsHandler,
 )
 from visdom.server.defaults import (
     DEFAULT_BASE_URL,
@@ -111,6 +118,12 @@ class Application(tornado.web.Application):
             (r"%s/delete_env" % self.base_url, DeleteEnvHandler, {"app": self}),
             (r"%s/env_state" % self.base_url, EnvStateHandler, {"app": self}),
             (r"%s/fork_env" % self.base_url, ForkEnvHandler, {"app": self}),
+            (
+                r"%s/experiment/(.*)/tags" % self.base_url,
+                ExperimentTagsHandler,
+                {"app": self},
+            ),
+            (r"%s/experiments" % self.base_url, ExperimentsHandler, {"app": self}),
             (r"%s/user/(.*)" % self.base_url, UserSettingsHandler, {"app": self}),
             (r"%s(.*)" % self.base_url, IndexHandler, {"app": self}),
         ]
@@ -161,7 +174,7 @@ class Application(tornado.web.Application):
                 "env_path=None.",
                 RuntimeWarning,
             )
-            return {"main": {"jsons": {}, "reload": {}}}
+            return {"main": build_empty_env()}
         ensure_dir_exists(env_path)
         env_jsons = [i for i in os.listdir(env_path) if ".json" in i]
         for env_json in env_jsons:
@@ -181,11 +194,12 @@ class Application(tornado.web.Application):
                     continue
 
                 state[eid] = {"jsons": env_data["jsons"], "reload": env_data["reload"]}
+                ensure_env_structure(state[eid])
             else:
                 state[eid] = LazyEnvData(env_path_file)
 
         if "main" not in state and "main.json" not in env_jsons:
-            state["main"] = {"jsons": {}, "reload": {}}
+            state["main"] = build_empty_env()
             serialize_env(state, ["main"], env_path=self.env_path)
 
         return state

--- a/py/visdom/server/handlers/socket_handlers.py
+++ b/py/visdom/server/handlers/socket_handlers.py
@@ -31,6 +31,7 @@ from visdom.utils.server_utils import (
     send_to_sources,
     broadcast,
     escape_eid,
+    ensure_env_structure,
 )
 from visdom.server.defaults import MAX_SOCKET_WAIT
 
@@ -112,6 +113,7 @@ class AnySocketHandlerOrWrapper(BaseWebSocketHandler):
             if "data" in msg and "eid" in msg:
                 msg["eid"] = escape_eid(msg["eid"])
                 self.state[msg["eid"]] = copy.deepcopy(self.state[msg["prev_eid"]])
+                ensure_env_structure(self.state[msg["eid"]])
                 self.state[msg["eid"]]["reload"] = msg["data"]
                 self.eid = msg["eid"]
                 serialize_env(self.state, [self.eid], env_path=self.env_path)

--- a/py/visdom/server/handlers/web_handlers.py
+++ b/py/visdom/server/handlers/web_handlers.py
@@ -46,6 +46,11 @@ from visdom.utils.server_utils import (
     update_window,
     hash_password,
     stringify,
+    build_empty_env,
+    ensure_env_structure,
+    add_tags,
+    remove_tag,
+    get_experiments_by_tag,
 )
 from visdom.server.handlers.base_handlers import BaseHandler
 
@@ -468,6 +473,7 @@ class ForkEnvHandler(BaseHandler):
         assert prev_eid in handler.state, "env to be forked doesn't exit"
 
         handler.state[eid] = copy.deepcopy(handler.state[prev_eid])
+        ensure_env_structure(handler.state[eid])
         serialize_env(handler.state, [eid], env_path=handler.app.env_path)
         broadcast_envs(handler)
 
@@ -515,7 +521,7 @@ class EnvHandler(BaseHandler):
         if "eid" in msg_args:
             eid = msg_args["eid"]
             if eid not in self.state:
-                self.state[eid] = {"jsons": {}, "reload": {}}
+                self.state[eid] = build_empty_env()
                 broadcast_envs(self)
 
 
@@ -594,7 +600,9 @@ class DataHandler(BaseHandler):
             data = json.loads(args["data"])
 
             if eid not in handler.state:
-                handler.state[eid] = {"jsons": {}, "reload": {}}
+                handler.state[eid] = build_empty_env()
+            else:
+                ensure_env_structure(handler.state[eid])
 
             if "win" in args and args["win"] is None:
                 handler.state[eid]["jsons"] = data
@@ -681,3 +689,61 @@ class ErrorHandler(BaseHandler):
     def get(self, text):
         error_text = text or "test error"
         raise Exception(error_text)
+
+
+class ExperimentTagsHandler(BaseHandler):
+    def initialize(self, app):
+        self.app = app
+        self.state = app.state
+        self.login_enabled = app.login_enabled
+        self.env_path = app.env_path
+
+    @check_auth
+    def post(self, experiment_id):
+        body = tornado.escape.json_decode(
+            tornado.escape.to_basestring(self.request.body)
+        )
+        tags = body.get("tags", [])
+        updated_tags = add_tags(self.state, experiment_id, tags)
+        serialize_env(self.state, [escape_eid(experiment_id)], env_path=self.env_path)
+        self.write(
+            json.dumps(
+                {"experiment_id": escape_eid(experiment_id), "tags": updated_tags}
+            )
+        )
+
+    @check_auth
+    def delete(self, experiment_id):
+        body = tornado.escape.json_decode(
+            tornado.escape.to_basestring(self.request.body)
+        )
+        tag = body.get("tag", "")
+        updated_tags = remove_tag(self.state, experiment_id, tag)
+        serialize_env(self.state, [escape_eid(experiment_id)], env_path=self.env_path)
+        self.write(
+            json.dumps(
+                {"experiment_id": escape_eid(experiment_id), "tags": updated_tags}
+            )
+        )
+
+
+class ExperimentsHandler(BaseHandler):
+    def initialize(self, app):
+        self.state = app.state
+        self.login_enabled = app.login_enabled
+
+    @check_auth
+    def get(self):
+        tag = self.get_argument("tag", default=None)
+        if tag is None or tag.strip() == "":
+            experiment_ids = sorted(list(self.state.keys()))
+        else:
+            experiment_ids = get_experiments_by_tag(self.state, tag)
+
+        experiments = []
+        for experiment_id in experiment_ids:
+            env = ensure_env_structure(self.state[experiment_id])
+            experiments.append(
+                {"experiment_id": experiment_id, "tags": env.get("tags", [])}
+            )
+        self.write(json.dumps({"experiments": experiments}))

--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -96,7 +96,11 @@ class LazyEnvData(Mapping):
                     self._env_path_file, repr(e)
                 )
             )
-        self._raw_dict = {"jsons": env_data["jsons"], "reload": env_data["reload"]}
+        self._raw_dict = {
+            "jsons": env_data["jsons"],
+            "reload": env_data["reload"],
+            "tags": env_data.get("tags", []),
+        }
 
     def __getitem__(self, key):
         self.lazy_load_data()
@@ -133,6 +137,37 @@ def serialize_all(state, env_path=DEFAULT_ENV_PATH):
 
 
 # ------- Environment management helpers ----- #
+def build_empty_env():
+    """Creates a default env record."""
+    return {"jsons": {}, "reload": {}, "tags": []}
+
+
+def ensure_env_structure(env):
+    """Normalizes an env record so legacy data without tags still works."""
+    if "jsons" not in env:
+        env["jsons"] = {}
+    if "reload" not in env:
+        env["reload"] = {}
+    if "tags" not in env or env["tags"] is None:
+        env["tags"] = []
+    return env
+
+
+def normalize_tags(tags):
+    """Converts user-provided tags into a unique, trimmed list of strings."""
+    if tags is None:
+        return []
+    if isinstance(tags, str):
+        tags = [tags]
+    clean_tags = []
+    for tag in tags:
+        if tag is None:
+            continue
+        tag_str = str(tag).strip()
+        if tag_str != "":
+            clean_tags.append(tag_str)
+    # Keep insertion order while removing duplicates.
+    return list(dict.fromkeys(clean_tags))
 
 
 def escape_eid(eid):
@@ -147,6 +182,44 @@ def extract_eid(args):
     it returns 'main'."""
     eid = "main" if args.get("eid") is None else args.get("eid")
     return escape_eid(eid)
+
+
+def add_tags(state, experiment_id, tags):
+    """Adds one or more tags to an experiment (environment) id."""
+    eid = escape_eid(experiment_id)
+    if eid not in state:
+        state[eid] = build_empty_env()
+    env = ensure_env_structure(state[eid])
+    existing = normalize_tags(env.get("tags", []))
+    additions = normalize_tags(tags)
+    env["tags"] = list(dict.fromkeys(existing + additions))
+    return env["tags"]
+
+
+def remove_tag(state, experiment_id, tag):
+    """Removes a single tag from an experiment (environment) id."""
+    eid = escape_eid(experiment_id)
+    if eid not in state:
+        return []
+    env = ensure_env_structure(state[eid])
+    tag_to_remove = str(tag).strip()
+    if tag_to_remove == "":
+        return normalize_tags(env.get("tags", []))
+    env["tags"] = [t for t in normalize_tags(env.get("tags", [])) if t != tag_to_remove]
+    return env["tags"]
+
+
+def get_experiments_by_tag(state, tag):
+    """Returns experiment ids that include the provided tag."""
+    target_tag = str(tag).strip()
+    if target_tag == "":
+        return sorted(list(state.keys()))
+    matched = []
+    for experiment_id, env in state.items():
+        env = ensure_env_structure(env)
+        if target_tag in normalize_tags(env.get("tags", [])):
+            matched.append(experiment_id)
+    return sorted(matched)
 
 
 def update_window(p, args):
@@ -415,7 +488,9 @@ def register_window(self, p, eid):
     is_new_env = False
     if eid not in self.state:
         is_new_env = True
-        self.state[eid] = {"jsons": {}, "reload": {}}
+        self.state[eid] = build_empty_env()
+    else:
+        ensure_env_structure(self.state[eid])
 
     env = self.state[eid]["jsons"]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR introduces an experiment tagging feature in Visdom to improve experiment organization and tracking.

Users can now:
- Add tags to environments using a comma-separated input
- View tags as badges in the UI
- Filter environments based on tags
- Use API endpoints to manage and query tags

Tags are stored in the environment JSON structure and remain backward compatible with existing environments.

---

## Motivation and Context

Currently, Visdom does not provide a structured way to organize or search experiments. This makes it difficult for users to manage multiple runs.

This change enables:
- Better categorization of experiments
- Easier search and filtering
- Improved experiment management workflow

This is a starter implementation toward more advanced experiment tracking features.

---

## How Has This Been Tested?

- Ran Visdom server locally using:
  ```bash
 PYTHONPATH=py python3 -m visdom.server.run_server

## Screenshots (if appropriate):

<img width="1909" height="908" alt="image" src="https://github.com/user-attachments/assets/e7f8bac2-616e-4bde-ad29-a49cb06c7d37" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

## Summary by Sourcery

Introduce experiment tagging support across server, API, and UI for organizing and filtering environments.

New Features:
- Add persistent experiment tags to environment state with backward-compatible storage in env JSON.
- Expose REST endpoints to add/remove tags for a given experiment and to list experiments optionally filtered by tag.
- Add top-bar UI to display active experiment tags, add tags via input, and filter environment selection by tag.
- Extend front-end API client with helpers for fetching experiments by tag and updating tags on experiments.

Enhancements:
- Normalize environment records on load and fork to ensure tags, jsons, and reload fields are always present.
- Refine environment creation and loading utilities to centralize default env initialization and tag handling.

Documentation:
- Update README with documentation and examples for experiment tagging, UI usage, and HTTP API endpoints.

Tests:
- Add unit tests covering tag addition on legacy env structures, tag-based experiment filtering, and tag removal behavior.