### PR TITLE
Add authenticated user-scoped environment isolation skeleton

### DIFF
--- a/py/visdom/server/app.py
+++ b/py/visdom/server/app.py
@@ -74,6 +74,8 @@ class Application(tornado.web.Application):
     ):
         self.eager_data_loading = eager_data_loading
         self.env_path = env_path
+        self.user_credential = user_credential
+        self.login_enabled = user_credential is not None
         self.state = self.load_state()
         self.layouts = self.load_layouts()
         self.user_settings = self.load_user_settings()
@@ -82,13 +84,10 @@ class Application(tornado.web.Application):
         self.port = port
         self.base_url = base_url
         self.readonly = readonly
-        self.user_credential = user_credential
-        self.login_enabled = False
         self.last_access = time.time()
         self.wrap_socket = use_frontend_client_polling
 
         if user_credential:
-            self.login_enabled = True
             with open(DEFAULT_ENV_PATH + "COOKIE_SECRET", "r") as fn:
                 tornado_settings["cookie_secret"] = fn.read()
 
@@ -184,7 +183,7 @@ class Application(tornado.web.Application):
             else:
                 state[eid] = LazyEnvData(env_path_file)
 
-        if "main" not in state and "main.json" not in env_jsons:
+        if (not self.login_enabled) and "main" not in state and "main.json" not in env_jsons:
             state["main"] = {"jsons": {}, "reload": {}}
             serialize_env(state, ["main"], env_path=self.env_path)
 

--- a/py/visdom/server/handlers/socket_handlers.py
+++ b/py/visdom/server/handlers/socket_handlers.py
@@ -30,7 +30,7 @@ from visdom.utils.server_utils import (
     serialize_env,
     send_to_sources,
     broadcast,
-    escape_eid,
+    scope_eid_for_handler,
 )
 from visdom.server.defaults import MAX_SOCKET_WAIT
 
@@ -81,7 +81,7 @@ class AnySocketHandlerOrWrapper(BaseWebSocketHandler):
         self.sid = get_rand_id()
         register_list = self.sources if register_to == "sources" else self.subs
         if self not in list(register_list.values()):
-            self.eid = "main"
+            self.eid = scope_eid_for_handler(self, "main")
             register_list[self.sid] = self
 
     def broadcast_layouts(self):
@@ -98,7 +98,8 @@ class AnySocketHandlerOrWrapper(BaseWebSocketHandler):
         elif cmd == "close":
             if "data" in msg and "eid" in msg:
                 logging.info(f"closing window {msg['data']}")
-                p_data = self.state[msg["eid"]]["jsons"].pop(msg["data"], None)
+                scoped_eid = scope_eid_for_handler(self, msg["eid"])
+                p_data = self.state[scoped_eid]["jsons"].pop(msg["data"], None)
                 event = {
                     "event_type": "close",
                     "target": msg["data"],
@@ -110,18 +111,20 @@ class AnySocketHandlerOrWrapper(BaseWebSocketHandler):
         elif cmd == "save":
             # save localStorage window metadata
             if "data" in msg and "eid" in msg:
-                msg["eid"] = escape_eid(msg["eid"])
-                self.state[msg["eid"]] = copy.deepcopy(self.state[msg["prev_eid"]])
-                self.state[msg["eid"]]["reload"] = msg["data"]
-                self.eid = msg["eid"]
+                scoped_eid = scope_eid_for_handler(self, msg["eid"])
+                scoped_prev_eid = scope_eid_for_handler(self, msg["prev_eid"])
+                self.state[scoped_eid] = copy.deepcopy(self.state[scoped_prev_eid])
+                self.state[scoped_eid]["reload"] = msg["data"]
+                self.eid = scoped_eid
                 serialize_env(self.state, [self.eid], env_path=self.env_path)
 
         elif cmd == "delete_env":
             if "eid" in msg:
                 logging.info(f"closing environment {msg['eid']}")
-                del self.state[msg["eid"]]
+                scoped_eid = scope_eid_for_handler(self, msg["eid"])
+                del self.state[scoped_eid]
                 if self.env_path is not None:
-                    p = os.path.join(self.env_path, "{0}.json".format(msg["eid"]))
+                    p = os.path.join(self.env_path, "{0}.json".format(scoped_eid))
                     os.remove(p)
                 broadcast_envs(self)
 
@@ -133,19 +136,20 @@ class AnySocketHandlerOrWrapper(BaseWebSocketHandler):
 
         elif cmd == "forward_to_vis":
             packet = msg.get("data")
-            environment = self.state[packet["eid"]]
+            scoped_eid = scope_eid_for_handler(self, packet["eid"])
+            environment = self.state[scoped_eid]
             if packet.get("pane_data") is not False:
                 packet["pane_data"] = environment["jsons"][packet["target"]]
             send_to_sources(self, msg.get("data"))
 
         elif cmd == "layout_item_update":
-            eid = msg.get("eid")
+            eid = scope_eid_for_handler(self, msg.get("eid"))
             win = msg.get("win")
             self.state[eid]["reload"][win] = msg.get("data")
 
         elif cmd == "pop_embeddings_pane":
             packet = msg.get("data")
-            eid = packet["eid"]
+            eid = scope_eid_for_handler(self, packet["eid"])
             win = packet["target"]
             p = self.state[eid]["jsons"][win]
             p["content"]["selected"] = None

--- a/py/visdom/server/handlers/web_handlers.py
+++ b/py/visdom/server/handlers/web_handlers.py
@@ -34,12 +34,13 @@ from visdom.utils.shared_utils import get_rand_id
 from visdom.utils.server_utils import (
     check_auth,
     extract_eid,
+    scope_eid_for_handler,
+    unscope_eid_for_handler,
     window,
     register_window,
     gather_envs,
     broadcast_envs,
     serialize_env,
-    escape_eid,
     compare_envs,
     load_env,
     broadcast,
@@ -79,7 +80,7 @@ class PostHandler(BaseHandler):
                 "but it is no longer officially supported."
             )
 
-        eid = extract_eid(req)
+        eid = extract_eid(req, handler=self)
         p = window(req)
 
         register_window(self, p, eid)
@@ -96,7 +97,7 @@ class ExistsHandler(BaseHandler):
 
     @staticmethod
     def wrap_func(handler, args):
-        eid = extract_eid(args)
+        eid = extract_eid(args, handler=handler)
         if eid in handler.state and args["win"] in handler.state[eid]["jsons"]:
             handler.write("true")
         else:
@@ -318,7 +319,7 @@ class UpdateHandler(BaseHandler):
 
     @staticmethod
     def wrap_func(handler, args):
-        eid = extract_eid(args)
+        eid = extract_eid(args, handler=handler)
 
         if args["win"] not in handler.state[eid]["jsons"]:
             # Append to a window that doesn't exist attempts to create
@@ -390,7 +391,7 @@ class CloseHandler(BaseHandler):
 
     @staticmethod
     def wrap_func(handler, args):
-        eid = extract_eid(args)
+        eid = extract_eid(args, handler=handler)
         win = args.get("win")
 
         keys = list(handler.state[eid]["jsons"].keys()) if win is None else [win]
@@ -417,7 +418,7 @@ class DeleteEnvHandler(BaseHandler):
 
     @staticmethod
     def wrap_func(handler, args):
-        eid = extract_eid(args)
+        eid = extract_eid(args, handler=handler)
         if eid is not None:
             del handler.state[eid]
             if handler.env_path is not None:
@@ -442,7 +443,11 @@ class EnvStateHandler(BaseHandler):
     @staticmethod
     def wrap_func(handler, args):
         # TODO if an env is provided return the state of that env
-        all_eids = list(handler.state.keys())
+        all_eids = gather_envs(
+            handler.state,
+            env_path=handler.app.env_path,
+            handler=handler,
+        )
         handler.write(json.dumps(all_eids))
 
     @check_auth
@@ -462,8 +467,8 @@ class ForkEnvHandler(BaseHandler):
 
     @staticmethod
     def wrap_func(handler, args):
-        prev_eid = escape_eid(args.get("prev_eid"))
-        eid = escape_eid(args.get("eid"))
+        prev_eid = scope_eid_for_handler(handler, args.get("prev_eid"))
+        eid = scope_eid_for_handler(handler, args.get("eid"))
 
         assert prev_eid in handler.state, "env to be forked doesn't exit"
 
@@ -471,7 +476,8 @@ class ForkEnvHandler(BaseHandler):
         serialize_env(handler.state, [eid], env_path=handler.app.env_path)
         broadcast_envs(handler)
 
-        handler.write(eid)
+        user_eid = unscope_eid_for_handler(handler, eid)
+        handler.write(user_eid if user_eid is not None else eid)
 
     @check_auth
     def post(self):
@@ -493,7 +499,7 @@ class EnvHandler(BaseHandler):
 
     @check_auth
     def get(self, eid):
-        items = gather_envs(self.state, env_path=self.env_path)
+        items = gather_envs(self.state, env_path=self.env_path, handler=self)
         active = "" if eid not in items else eid
         self.render(
             "index.html",
@@ -511,9 +517,15 @@ class EnvHandler(BaseHandler):
         if "sid" in msg_args:
             sid = msg_args["sid"]
             if sid in self.subs:
-                load_env(self.state, args, self.subs[sid], env_path=self.env_path)
+                scoped_args = scope_eid_for_handler(self, args)
+                load_env(
+                    self.state,
+                    scoped_args,
+                    self.subs[sid],
+                    env_path=self.env_path,
+                )
         if "eid" in msg_args:
-            eid = msg_args["eid"]
+            eid = scope_eid_for_handler(self, msg_args["eid"])
             if eid not in self.state:
                 self.state[eid] = {"jsons": {}, "reload": {}}
                 broadcast_envs(self)
@@ -530,7 +542,7 @@ class CompareHandler(BaseHandler):
 
     @check_auth
     def get(self, eids):
-        items = gather_envs(self.state)
+        items = gather_envs(self.state, env_path=self.env_path, handler=self)
         eids = eids.split("+")
         # Filter out eids that don't exist
         eids = [x for x in eids if x in items]
@@ -549,7 +561,8 @@ class CompareHandler(BaseHandler):
             tornado.escape.to_basestring(self.request.body)
         )["sid"]
         if sid in self.subs:
-            compare_envs(self.state, args.split("+"), self.subs[sid], self.env_path)
+            scoped_eids = [scope_eid_for_handler(self, eid) for eid in args.split("+")]
+            compare_envs(self.state, scoped_eids, self.subs[sid], self.env_path)
 
 
 class SaveHandler(BaseHandler):
@@ -564,9 +577,11 @@ class SaveHandler(BaseHandler):
     @staticmethod
     def wrap_func(handler, args):
         envs = args["data"]
-        envs = [escape_eid(eid) for eid in envs]
+        envs = [scope_eid_for_handler(handler, eid) for eid in envs]
         # this drops invalid env ids
         ret = serialize_env(handler.state, envs, env_path=handler.env_path)
+        if handler.login_enabled:
+            ret = [unscope_eid_for_handler(handler, eid) or eid for eid in ret]
         handler.write(json.dumps(ret))
 
     @check_auth
@@ -587,7 +602,7 @@ class DataHandler(BaseHandler):
 
     @staticmethod
     def wrap_func(handler, args):
-        eid = extract_eid(args)
+        eid = extract_eid(args, handler=handler)
 
         if "data" in args:
             # Load data from client
@@ -631,7 +646,7 @@ class IndexHandler(BaseHandler):
         self.wrap_socket = app.wrap_socket
 
     def get(self, args, **kwargs):
-        items = gather_envs(self.state, env_path=self.env_path)
+        items = gather_envs(self.state, env_path=self.env_path, handler=self)
         if (not self.login_enabled) or self.current_user:
             """self.current_user is an authenticated user provided by Tornado,
             available when we set self.get_current_user in BaseHandler,
@@ -662,6 +677,7 @@ class IndexHandler(BaseHandler):
             password == self.user_credential["password"]
         ):
             self.set_secure_cookie("user_password", username + password)
+            self.set_secure_cookie("visdom_user", username)
         else:
             self.set_status(400)
 

--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -75,6 +75,82 @@ def hash_password(password):
     return hashlib.sha256(password.encode("utf-8")).hexdigest()
 
 
+USER_SCOPE_PREFIX = "__user__"
+USER_SCOPE_SEPARATOR = "__"
+
+
+def _sanitize_user_scope(username):
+    if username is None:
+        return None
+    return "".join(
+        c if (c.isalnum() or c in "._-") else "_" for c in username
+    ) or "anonymous"
+
+
+def get_username_from_handler(handler):
+    """Best-effort extraction of authenticated username from secure cookies."""
+    if not getattr(handler, "login_enabled", False):
+        return None
+
+    username_cookie = None
+    try:
+        username_cookie = handler.get_secure_cookie("visdom_user")
+    except Exception:
+        username_cookie = None
+
+    if username_cookie:
+        if isinstance(username_cookie, bytes):
+            return username_cookie.decode("utf-8")
+        return username_cookie
+
+    # Backward compatibility with older cookie format: username + sha256(password)
+    try:
+        legacy_cookie = handler.get_secure_cookie("user_password")
+    except Exception:
+        legacy_cookie = None
+
+    if not legacy_cookie:
+        return None
+
+    if isinstance(legacy_cookie, bytes):
+        legacy_cookie = legacy_cookie.decode("utf-8")
+    # sha256 digest has fixed length 64; strip it if possible.
+    if len(legacy_cookie) > 64:
+        return legacy_cookie[:-64]
+    return None
+
+
+def get_user_scope(handler):
+    username = get_username_from_handler(handler)
+    return _sanitize_user_scope(username)
+
+
+def scope_eid_for_handler(handler, eid):
+    if eid is None:
+        eid = "main"
+    escaped_eid = escape_eid(eid)
+    if not getattr(handler, "login_enabled", False):
+        return escaped_eid
+    scope = get_user_scope(handler)
+    if scope is None:
+        return escaped_eid
+    return f"{USER_SCOPE_PREFIX}{scope}{USER_SCOPE_SEPARATOR}{escaped_eid}"
+
+
+def unscope_eid_for_handler(handler, scoped_eid):
+    if scoped_eid is None:
+        return None
+    if not getattr(handler, "login_enabled", False):
+        return scoped_eid
+    scope = get_user_scope(handler)
+    if scope is None:
+        return None
+    prefix = f"{USER_SCOPE_PREFIX}{scope}{USER_SCOPE_SEPARATOR}"
+    if scoped_eid.startswith(prefix):
+        return scoped_eid[len(prefix) :]
+    return None
+
+
 # ------- File management helprs ----- #
 
 
@@ -142,10 +218,12 @@ def escape_eid(eid):
     return eid.replace("/", "_")
 
 
-def extract_eid(args):
+def extract_eid(args, handler=None):
     """Extract eid from args. If eid does not exist in args,
     it returns 'main'."""
     eid = "main" if args.get("eid") is None else args.get("eid")
+    if handler is not None:
+        return scope_eid_for_handler(handler, eid)
     return escape_eid(eid)
 
 
@@ -227,12 +305,21 @@ def window(args):
     return p
 
 
-def gather_envs(state, env_path=DEFAULT_ENV_PATH):
+def gather_envs(state, env_path=DEFAULT_ENV_PATH, handler=None):
     if env_path is not None:
         items = [i.replace(".json", "") for i in os.listdir(env_path) if ".json" in i]
     else:
         items = []
-    return sorted(list(set(items + list(state.keys()))))
+    merged = sorted(list(set(items + list(state.keys()))))
+    if handler is None or not getattr(handler, "login_enabled", False):
+        return merged
+
+    visible = []
+    for eid in merged:
+        user_eid = unscope_eid_for_handler(handler, eid)
+        if user_eid is not None:
+            visible.append(user_eid)
+    return sorted(list(set(visible)))
 
 
 def compare_envs(state, eids, socket, env_path=DEFAULT_ENV_PATH):
@@ -365,8 +452,9 @@ def broadcast_envs(handler, target_subs=None):
     if target_subs is None:
         target_subs = handler.subs.values()
     for sub in target_subs:
+        envs = gather_envs(handler.state, env_path=handler.env_path, handler=sub)
         sub.write_message(
-            json.dumps({"command": "env_update", "data": list(handler.state.keys())})
+            json.dumps({"command": "env_update", "data": envs})
         )
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds authenticated user environment isolation as a backend skeleton, so each logged-in user gets a separate internal namespace for environments while keeping the same client-facing environment names.

Main updates:

- Added user scoping helpers and visibility filtering in server utilities.
- Wired scoped environment handling through HTTP handlers.
- Wired scoped environment handling through WebSocket handlers.
- Adjusted app initialization so login mode is known before state loading.
- Prevented auto-creation of shared main environment when login is enabled.

## Motivation and Context
 Visdom supports login, but environments were still keyed globally, which can cause collisions and cross-user visibility in authenticated deployments.

This change is required to establish a safe isolation baseline:

- Internal environment IDs are namespaced per authenticated user.
- Environment listings are filtered to what the current user owns.
- Responses remain unscoped to preserve frontend behavior.

If this links to your opened issue, add:

Fixes #1116

## How Has This Been Tested?
Testing environment:

OS: Windows
Python: 3.13.7
Dependencies installed: tornado, pillow, requests, six, jsonpatch, numpy, scipy, networkx, websocket-client

Validation performed:

1. Syntax and compile checks on modified backend files passed.
2. Fast scope smoke test passed for:
- scope and unscope behavior
- per-user environment visibility filtering
- legacy non-auth behavior compatibility
3. Live server smoke checks (non-auth) passed:
- POST /env_state returned 200
- POST /events returned 200
- Read-after-write confirmed environment presence
4. Auth flow checks passed:
- unauthenticated access to env_state blocked
- login succeeded and auth cookies set
- authenticated create/list/save operations returned success
- scoped file persisted under user-scoped environment name on disk


## Screenshots (if appropriate):

No UI screenshots were added. This change is backend behavior focused.

Types of changes
-  Bug fix (non-breaking change which fixes an issue)
-  New feature (non-breaking change which adds functionality)
 - Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
- I adapted the version number under py/visdom/VERSION according to [Semantic Versioning](vscode-file://vscode-app/c:/Users/Harry%20Oghonyon/AppData/Local/Programs/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
 - My code follows the code style of this project.
-  My change requires a change to the documentation.
-  I have updated the documentation accordingly.
