### PR TITLE
Fix properties box not updating (#693)

### DIFF
--- a/js/panes/PropertiesPane.js
+++ b/js/panes/PropertiesPane.js
@@ -16,25 +16,14 @@ import PropertyItem from './PropertyItem';
 function PropertiesPane(props) {
   const { sendPaneMessage } = useContext(ApiContext);
   const { envID, id, content, onFocus } = props;
-  
-  console.log('🔄 PropertiesPane rendering');
-  console.log('📦 Received content prop:', content);
-  
+
   const [localContent, setLocalContent] = useState(content);
-  
+
   useEffect(() => {
-    console.log('📥 useEffect triggered - content changed!');
-    console.log('Old content:', localContent);
-    console.log('New content:', content);
     setLocalContent(content);
   }, [content]);
-  
-  useEffect(() => {
-    console.log('🎨 localContent state updated:', localContent);
-  }, [localContent]);
 
   const updateValue = (propId, value) => {
-    console.log('✏️ Updating property:', propId, value);
     onFocus(id, () => {
       sendPaneMessage(
         {
@@ -49,7 +38,6 @@ function PropertiesPane(props) {
   };
 
   const handleDownload = () => {
-    console.log('💾 Downloading properties:', localContent);
     let blob = new Blob([JSON.stringify(localContent)], {
       type: 'application/json',
     });

--- a/js/panes/PropertiesPane.js
+++ b/js/panes/PropertiesPane.js
@@ -7,7 +7,7 @@
  *
  */
 
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 
 import ApiContext from '../api/ApiContext';
 import Pane from './Pane';
@@ -16,12 +16,25 @@ import PropertyItem from './PropertyItem';
 function PropertiesPane(props) {
   const { sendPaneMessage } = useContext(ApiContext);
   const { envID, id, content, onFocus } = props;
+  
+  console.log('🔄 PropertiesPane rendering');
+  console.log('📦 Received content prop:', content);
+  
+  const [localContent, setLocalContent] = useState(content);
+  
+  useEffect(() => {
+    console.log('📥 useEffect triggered - content changed!');
+    console.log('Old content:', localContent);
+    console.log('New content:', content);
+    setLocalContent(content);
+  }, [content]);
+  
+  useEffect(() => {
+    console.log('🎨 localContent state updated:', localContent);
+  }, [localContent]);
 
-  // private events
-  // --------------
-
-  // send updates in PropertyItem directly to all observers / sources
   const updateValue = (propId, value) => {
+    console.log('✏️ Updating property:', propId, value);
     onFocus(id, () => {
       sendPaneMessage(
         {
@@ -35,9 +48,9 @@ function PropertiesPane(props) {
     });
   };
 
-  // download button saves the settings as json
   const handleDownload = () => {
-    let blob = new Blob([JSON.stringify(content)], {
+    console.log('💾 Downloading properties:', localContent);
+    let blob = new Blob([JSON.stringify(localContent)], {
       type: 'application/json',
     });
     let url = window.URL.createObjectURL(blob);
@@ -47,15 +60,12 @@ function PropertiesPane(props) {
     link.click();
   };
 
-  // rendering
-  // ---------
-
   return (
     <Pane {...props} handleDownload={handleDownload}>
       <div className="content-properties">
         <table className="table table-bordered table-condensed table-properties">
           <tbody>
-            {content.map((prop, propId) => (
+            {localContent.map((prop, propId) => (
               <tr key={propId}>
                 <td className="table-properties-name">{prop.name}</td>
                 <td className="table-properties-value">


### PR DESCRIPTION
## Description
This PR fixes issue #693 where the properties window would not update immediately when `viz.properties()` was called. The user had to refresh the browser to see the updated values.

## Root Cause
The PropertiesPane component was using props directly without local state tracking. When the content prop updated, React did not trigger a re-render.

## Solution
- Added `useState` hook to track local content state
- Added `useEffect` hook to monitor content prop changes
- When content changes, local state updates and triggers re-render

## Code Changes
- `js/panes/PropertiesPane.js`: Added useState and useEffect hooks

## Testing
- Created test script with initial properties
- Updated properties after 5 seconds
- Verified browser updates without refresh

## Screenshot
<img width="1919" height="1034" alt="Screenshot 2026-03-30 131920" src="https://github.com/user-attachments/assets/dbb69c39-9993-4890-95f0-b637648a3665" />


