### PR TITLE
Clarify heatmap documentation for columnnames and rownames

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -1276,9 +1276,14 @@ class Visdom(object):
         opts["height"] = opts.get("height", img.shape[img.ndim - 2])
 
         nchannels = img.shape[0] if img.ndim == 3 else 1
+
         if nchannels == 1:
             img = np.squeeze(img)
             img = img[np.newaxis, :, :].repeat(3, axis=0)
+
+        elif nchannels not in (3, 4):
+            raise ValueError("Image should have 1, 3 or 4 channels")
+
 
         if "float" in str(img.dtype):
             if img.max() <= 1:

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -1831,8 +1831,16 @@ class Visdom(object):
         - `opts.colormap`: colormap (`string`; default = `'Viridis'`)
         - `opts.xmin`    : clip minimum value (`number`; default = `X:min()`)
         - `opts.xmax`    : clip maximum value (`number`; default = `X:max()`)
-        - `opts.columnnames`: `list` containing x-axis labels
-        - `opts.rownames`: `list` containing y-axis labels
+        - `opts.columnnames`: list or array containing x-axis values (numeric or strings)
+        - `opts.rownames`: list or array containing y-axis values (numeric or strings)
+        Example:
+        viz.heatmap(
+            X=np.array([[1,2],[3,4]]),
+            opts=dict(
+                columnnames=[0.0, 0.5],
+                rownames=[10, 20]
+            )
+        )
         - `opts.nancolor`: if not None, color for plotting nan
                            (`string`; default = `None`)
         """

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -1831,8 +1831,8 @@ class Visdom(object):
         - `opts.colormap`: colormap (`string`; default = `'Viridis'`)
         - `opts.xmin`    : clip minimum value (`number`; default = `X:min()`)
         - `opts.xmax`    : clip maximum value (`number`; default = `X:max()`)
-        - `opts.columnnames`: list or array containing x-axis values (numeric or strings)
-        - `opts.rownames`: list or array containing y-axis values (numeric or strings)
+        - `opts.columnnames`: list containing x-axis values (numbers or strings)
+        - `opts.rownames`: list containing y-axis values (numbers or strings)
         Example:
         viz.heatmap(
             X=np.array([[1,2],[3,4]]),

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -1281,9 +1281,6 @@ class Visdom(object):
             img = np.squeeze(img)
             img = img[np.newaxis, :, :].repeat(3, axis=0)
 
-        elif nchannels not in (3, 4):
-            raise ValueError("Image should have 1, 3 or 4 channels")
-
 
         if "float" in str(img.dtype):
             if img.max() <= 1:


### PR DESCRIPTION
## Description
Clarifies documentation for the heatmap() function.

`opts.columnnames` and `opts.rownames` already support numeric arrays that map directly to Plotly's x and y axis values. The previous documentation referred to them as "labels", which could imply strings only.

This update clarifies that numeric arrays are supported and adds an example demonstrating custom axis values.

## Motivation and Context
Addresses confusion mentioned in issue #937 regarding axis values for heatmaps.

## Types of changes
- [x] Code refactor or cleanup (documentation improvement)