### PR TITLE
Fix: incorrect update flag in ApiProvider.js breaking incremental updates

### DIFF
--- a/js/api/ApiProvider.js
+++ b/js/api/ApiProvider.js
@@ -114,7 +114,7 @@ const ApiProvider = ({ children }) => {
       case 'window_update':
         apiHandlers.current.onWindowMessage({
           cmd: cmd,
-          update: cmd.commmand == 'window_update',
+          update: cmd.command == 'window_update',
         });
         break;
       case 'reload':
@@ -127,7 +127,7 @@ const ApiProvider = ({ children }) => {
       case 'layout_update':
         apiHandlers.current.onLayoutMessage({
           cmd: cmd.data,
-          update: cmd.commmand == 'layout_update',
+          update: cmd.command == 'layout_update',
         });
         break;
       case 'env_update':


### PR DESCRIPTION
Fixes #1126

### Summary
Fixes a typo in `ApiProvider.js` where `cmd.commmand` (3 m's) was used instead of `cmd.command`.

### Impact
- Restores correct handling of:
  - `window_update`
  - `layout_update`
- Enables incremental updates instead of full re-renders
- Improves frontend performance

### Root Cause
The update flag always evaluated to false due to accessing a non-existent property (`cmd.commmand`).

### Changes
- Replaced `cmd.commmand` with `cmd.command`

## Summary by Sourcery

Bug Fixes:
- Correct the command property check when setting the update flag for window_update and layout_update messages to restore incremental update behavior.