### PR TITLE
Fix lazy env JSON path resolution

### DIFF
--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -244,7 +244,7 @@ def compare_envs(state, eids, socket, env_path=DEFAULT_ENV_PATH):
         if eid in state:
             envs[eid] = state.get(eid)
         elif env_path is not None:
-            p = os.path.join(env_path, eid.strip(), ".json")
+            p = os.path.join(env_path, "{}.json".format(eid.strip()))
             if os.path.exists(p):
                 with open(p, "r") as fn:
                     env = tornado.escape.json_decode(fn.read())
@@ -382,7 +382,7 @@ def load_env(state, eid, socket, env_path=DEFAULT_ENV_PATH):
     if eid in state:
         env = state.get(eid)
     elif env_path is not None:
-        p = os.path.join(env_path, eid.strip(), ".json")
+        p = os.path.join(env_path, "{}.json".format(eid.strip()))
         if os.path.exists(p):
             with open(p, "r") as fn:
                 env = tornado.escape.json_decode(fn.read())


### PR DESCRIPTION
## Summary

Fix lazy environment loading to use the same `<env>.json` file layout used elsewhere in Visdom.

## Changes
- update `compare_envs` to load envs from `os.path.join(env_path, "{}.json".format(eid.strip()))`
- update `load_env` to use the same path construction

## Why
Environments are serialized, deleted, and discovered as flat JSON files like `<env>.json`, but these two lazy-load paths were incorrectly constructing `<env>/.json`.

- closes: #1141

## Summary by Sourcery

Bug Fixes:
- Correct lazy loading paths in `compare_envs` and `load_env` to read environments from `<env>.json` files instead of `<env>/.json`.