### PR TITLE
Fix layout message payload mismatch and command typo in ApiProvider

### DIFF
--- a/js/api/ApiProvider.js
+++ b/js/api/ApiProvider.js
@@ -109,14 +109,14 @@ const ApiProvider = ({ children }) => {
           readonly: cmd.readonly,
         }));
         break;
-      case 'pane':
-      case 'window':
-      case 'window_update':
-        apiHandlers.current.onWindowMessage({
-          cmd: cmd,
-          update: cmd.commmand == 'window_update',
-        });
-        break;
+     case 'pane':
+case 'window':
+case 'window_update':
+  apiHandlers.current.onWindowMessage({
+    cmd: cmd,
+    update: cmd.command === 'window_update',
+  });
+  break;
       case 'reload':
         apiHandlers.current.onReloadMessage(cmd.data);
         break;
@@ -124,12 +124,12 @@ const ApiProvider = ({ children }) => {
         apiHandlers.current.onCloseMessage(cmd.data);
         break;
       case 'layout':
-      case 'layout_update':
-        apiHandlers.current.onLayoutMessage({
-          cmd: cmd.data,
-          update: cmd.commmand == 'layout_update',
-        });
-        break;
+case 'layout_update':
+  apiHandlers.current.onLayoutMessage({
+    data: cmd.data,
+    update: cmd.command === 'layout_update',
+  });
+  break;
       case 'env_update':
         apiHandlers.current.onEnvUpdate(cmd.data);
         break;

--- a/js/api/ApiProvider.js
+++ b/js/api/ApiProvider.js
@@ -109,27 +109,27 @@ const ApiProvider = ({ children }) => {
           readonly: cmd.readonly,
         }));
         break;
-     case 'pane':
-case 'window':
-case 'window_update':
-  apiHandlers.current.onWindowMessage({
-    cmd: cmd,
-    update: cmd.command === 'window_update',
-  });
-  break;
+      case 'pane':
+      case 'window':
+      case 'window_update':
+        apiHandlers.current.onWindowMessage({
+          cmd: cmd,
+          update: cmd.command === 'window_update',
+        });
+        break;
       case 'reload':
         apiHandlers.current.onReloadMessage(cmd.data);
         break;
       case 'close':
         apiHandlers.current.onCloseMessage(cmd.data);
         break;
-      case 'layout':
-case 'layout_update':
-  apiHandlers.current.onLayoutMessage({
-    data: cmd.data,
-    update: cmd.command === 'layout_update',
-  });
-  break;
+     case 'layout':
+     case 'layout_update':
+       apiHandlers.current.onLayoutMessage({
+         data: cmd.data,
+         update: cmd.command === 'layout_update',
+         });
+         break;
       case 'env_update':
         apiHandlers.current.onEnvUpdate(cmd.data);
         break;


### PR DESCRIPTION
## Issue
There is a mismatch between the payload sent from ApiProvider and what `onLayoutMessage` expects.

ApiProvider was sending:
{ cmd: ..., update: ... }

But main.js expects:
{ data: ..., update: ... }

This caused `data` to be undefined at runtime, breaking layout updates.

## Fix
- Renamed `cmd` → `data` in layout message handler
- Fixed typo `commmand` → `command` in both layout and window handlers
- Replaced `==` with strict equality `===`

## Result
- Layout updates now correctly pass data to `parseLayoutsFromServer`
- Prevents silent bugs due to typo in command field
- Improves consistency and reliability of message handling

## Summary by Sourcery

Fix message payload shape and command field handling for window and layout messages in ApiProvider to restore correct layout updates and improve reliability.

Bug Fixes:
- Align layout message payload with onLayoutMessage expectations so layout data is correctly passed through.
- Correct the command field typo in window and layout message handling to prevent silent failures in update detection.
- Use strict equality for command comparisons to avoid unexpected truthiness issues in message routing.