### PR TITLE
Fix lazy environment loading path (use <env>.json instead of directory path)

### DIFF
--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -244,7 +244,7 @@ def compare_envs(state, eids, socket, env_path=DEFAULT_ENV_PATH):
         if eid in state:
             envs[eid] = state.get(eid)
         elif env_path is not None:
-            p = os.path.join(env_path, eid.strip(), ".json")
+            p = os.path.join(env_path, f"{eid.strip()}.json")
             if os.path.exists(p):
                 with open(p, "r") as fn:
                     env = tornado.escape.json_decode(fn.read())
@@ -382,7 +382,7 @@ def load_env(state, eid, socket, env_path=DEFAULT_ENV_PATH):
     if eid in state:
         env = state.get(eid)
     elif env_path is not None:
-        p = os.path.join(env_path, eid.strip(), ".json")
+        p = os.path.join(env_path, f"{eid.strip()}.json")
         if os.path.exists(p):
             with open(p, "r") as fn:
                 env = tornado.escape.json_decode(fn.read())

--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -246,9 +246,12 @@ def compare_envs(state, eids, socket, env_path=DEFAULT_ENV_PATH):
         elif env_path is not None:
             p = os.path.join(env_path, f"{eid.strip()}.json")
             if os.path.exists(p):
-                with open(p, "r") as fn:
-                    env = tornado.escape.json_decode(fn.read())
-                    state[eid] = env
+               try:
+                    with open(p, "r") as fn:
+                        env = tornado.escape.json_decode(fn.read())
+                       state[eid] = env
+                except (OSError, ValueError) as e:
+                     logging.error(f"Failed to load environment {eid} from {p}: {e}")
                     envs[eid] = env
 
     res = copy.deepcopy(envs[list(envs.keys())[0]])


### PR DESCRIPTION
### Fix incorrect environment file path in lazy loading

Lazy environment loading constructs an incorrect file path:

    <env_path>/<eid>/.json

However, environments are stored as flat JSON files:

    <env_path>/<eid>.json

### Changes
- Updated path construction in:
  - compare_envs
  - load_env

### Impact
- Fixes failure to load environments not already in memory
- Aligns lazy loading logic with serialize_env and other parts of the codebase

This restores correct behavior when loading saved environments from disk.

## Summary by Sourcery

Bug Fixes:
- Correct environment file path construction in lazy loading helpers so they load <env>.json files instead of treating the environment ID as a directory.