### PR TITLE
fix: correct typo preventing window_update and layout_update

### DIFF
--- a/js/api/ApiProvider.js
+++ b/js/api/ApiProvider.js
@@ -114,7 +114,7 @@ const ApiProvider = ({ children }) => {
       case 'window_update':
         apiHandlers.current.onWindowMessage({
           cmd: cmd,
-          update: cmd.command == 'window_update',
+          update: cmd.command === 'window_update',
         });
         break;
       case 'reload':
@@ -127,7 +127,7 @@ const ApiProvider = ({ children }) => {
       case 'layout_update':
         apiHandlers.current.onLayoutMessage({
           cmd: cmd.data,
-          update: cmd.command == 'layout_update',
+          update: cmd.command === 'layout_update',
         });
         break;
       case 'env_update':

--- a/js/api/ApiProvider.js
+++ b/js/api/ApiProvider.js
@@ -114,7 +114,7 @@ const ApiProvider = ({ children }) => {
       case 'window_update':
         apiHandlers.current.onWindowMessage({
           cmd: cmd,
-          update: cmd.commmand == 'window_update',
+          update: cmd.command == 'window_update',
         });
         break;
       case 'reload':
@@ -127,7 +127,7 @@ const ApiProvider = ({ children }) => {
       case 'layout_update':
         apiHandlers.current.onLayoutMessage({
           cmd: cmd.data,
-          update: cmd.commmand == 'layout_update',
+          update: cmd.command == 'layout_update',
         });
         break;
       case 'env_update':


### PR DESCRIPTION
Fixes #1126

The update flag in `ApiProvider.js` was computed using `cmd.commmand` (3 m's) instead of `cmd.command`, causing `window_update` and `layout_update` incremental updates to never be applied.

**Changes:**
- Line 117: `cmd.commmand` → `cmd.command` (window_update)
- Line 130: `cmd.commmand` → `cmd.command` (layout_update)

## Summary by Sourcery

Fix incremental update handling for window and layout messages in the API provider.

Bug Fixes:
- Correct the update flag computation for window_update messages so they are applied incrementally.
- Correct the update flag computation for layout_update messages so they are applied incrementally.