### PR TITLE
port = FLAGS.port max_attempts = 10 attempt = 0  while attempt < max_…

### DIFF
--- a/py/visdom/server/run_server.py
+++ b/py/visdom/server/run_server.py
@@ -211,56 +211,46 @@ def main(print_func=None):
                         "line prompt.".format(cookie_var, enable_env_login)
                     )
                     sys.exit(1)
-                else:
-                    env_cookie = None
+               else:
                     set_cookie(env_cookie)
-
-                else:
-                    user_credential = None
 
             port = FLAGS.port
             max_attempts = 10
             attempt = 0
 
             while attempt < max_attempts:
-            try:
-                    port = FLAGS.port
-    max_attempts = 10
-    attempt = 0
+                try:
+                    start_server(
+                        port=port,
+                        hostname=FLAGS.hostname,
+                        base_url=base_url,
+                        env_path=FLAGS.env_path,
+                        readonly=FLAGS.readonly,
+                        print_func=print_func,
+                        user_credential=user_credential,
+                        use_frontend_client_polling=FLAGS.use_frontend_client_polling,
+                        bind_local=FLAGS.bind_local,
+                        eager_data_loading=FLAGS.eager_data_loading,
+                     )
+                    break  # success
 
-    while attempt < max_attempts:
-        try:
-            start_server(
-                port=port,
-                hostname=FLAGS.hostname,
-                base_url=base_url,
-                env_path=FLAGS.env_path,
-                readonly=FLAGS.readonly,
-                print_func=print_func,
-                user_credential=user_credential,
-                use_frontend_client_polling=FLAGS.use_frontend_client_polling,
-                bind_local=FLAGS.bind_local,
-                eager_data_loading=FLAGS.eager_data_loading,
-            )
-            break
+                except OSError as e:
+                    if getattr(e, "errno", None) == errno.EADDRINUSE:
+                        logging.warning(
+                            f"Port {port} is in use. Retrying with port {port + 1}..."
+                        )
+                         port += 1
+                         attempt += 1
 
-        except OSError as e:
-            if getattr(e, "errno", None) == errno.EADDRINUSE:
-                logging.warning(
-                    f"Port {port} is in use. Retrying with port {port + 1}..."
-                )
-                port += 1
-                attempt += 1
+                        if port > 65535:
+                            raise RuntimeError("No available ports found (exceeded 65535)")
 
-                if port > 65535:
-                    raise RuntimeError("No available ports found (exceeded 65535)")
-
-                if attempt == max_attempts:
-                    raise RuntimeError(
-                        f"Could not find a free port after {max_attempts} attempts"
-                    )
-            else:
-                raise
+                        if attempt == max_attempts:
+                            raise RuntimeError(
+                                f"Could not find a free port after {max_attempts} attempts"
+                            )
+                     else:
+                        raise
         break  # success
     except OSError:
         logging.warning(f"Port {port} is in use, trying {port + 1}...")
@@ -274,10 +264,10 @@ def main(print_func=None):
             raise RuntimeError(f"Could not find a free port after {max_attempts} attempts")
 
 
-    def download_scripts_and_run():
+   def download_scripts_and_run():
         download_scripts()
         main()
 
 
-        if __name__ == "__main__":
-            download_scripts_and_run()
+   if __name__ == "__main__":
+        download_scripts_and_run()

--- a/py/visdom/server/run_server.py
+++ b/py/visdom/server/run_server.py
@@ -15,6 +15,7 @@ import getpass
 import logging
 import os
 import sys
+import errno
 from tornado import ioloop
 from visdom.server.app import Application
 from visdom.server.defaults import (
@@ -210,31 +211,56 @@ def main(print_func=None):
                         "line prompt.".format(cookie_var, enable_env_login)
                     )
                     sys.exit(1)
+                else:
+                    env_cookie = None
+                    set_cookie(env_cookie)
+
+                else:
+                    user_credential = None
+
+            port = FLAGS.port
+            max_attempts = 10
+            attempt = 0
+
+            while attempt < max_attempts:
+            try:
+                    port = FLAGS.port
+    max_attempts = 10
+    attempt = 0
+
+    while attempt < max_attempts:
+        try:
+            start_server(
+                port=port,
+                hostname=FLAGS.hostname,
+                base_url=base_url,
+                env_path=FLAGS.env_path,
+                readonly=FLAGS.readonly,
+                print_func=print_func,
+                user_credential=user_credential,
+                use_frontend_client_polling=FLAGS.use_frontend_client_polling,
+                bind_local=FLAGS.bind_local,
+                eager_data_loading=FLAGS.eager_data_loading,
+            )
+            break
+
+        except OSError as e:
+            if getattr(e, "errno", None) == errno.EADDRINUSE:
+                logging.warning(
+                    f"Port {port} is in use. Retrying with port {port + 1}..."
+                )
+                port += 1
+                attempt += 1
+
+                if port > 65535:
+                    raise RuntimeError("No available ports found (exceeded 65535)")
+
+                if attempt == max_attempts:
+                    raise RuntimeError(
+                        f"Could not find a free port after {max_attempts} attempts"
+                    )
             else:
-                env_cookie = None
-            set_cookie(env_cookie)
-
-    else:
-        user_credential = None
-
-    port = FLAGS.port
-max_attempts = 10
-attempt = 0
-
-while attempt < max_attempts:
-    try:
-        start_server(
-            port=port,
-            hostname=FLAGS.hostname,
-            base_url=base_url,
-            env_path=FLAGS.env_path,
-            readonly=FLAGS.readonly,
-            print_func=print_func,
-            user_credential=user_credential,
-            use_frontend_client_polling=FLAGS.use_frontend_client_polling,
-            bind_local=FLAGS.bind_local,
-            eager_data_loading=FLAGS.eager_data_loading,
-        )
+                raise
         break  # success
     except OSError:
         logging.warning(f"Port {port} is in use, trying {port + 1}...")

--- a/py/visdom/server/run_server.py
+++ b/py/visdom/server/run_server.py
@@ -217,24 +217,41 @@ def main(print_func=None):
     else:
         user_credential = None
 
-    start_server(
-        port=FLAGS.port,
-        hostname=FLAGS.hostname,
-        base_url=base_url,
-        env_path=FLAGS.env_path,
-        readonly=FLAGS.readonly,
-        print_func=print_func,
-        user_credential=user_credential,
-        use_frontend_client_polling=FLAGS.use_frontend_client_polling,
-        bind_local=FLAGS.bind_local,
-        eager_data_loading=FLAGS.eager_data_loading,
-    )
+    port = FLAGS.port
+max_attempts = 10
+attempt = 0
+
+while attempt < max_attempts:
+    try:
+        start_server(
+            port=port,
+            hostname=FLAGS.hostname,
+            base_url=base_url,
+            env_path=FLAGS.env_path,
+            readonly=FLAGS.readonly,
+            print_func=print_func,
+            user_credential=user_credential,
+            use_frontend_client_polling=FLAGS.use_frontend_client_polling,
+            bind_local=FLAGS.bind_local,
+            eager_data_loading=FLAGS.eager_data_loading,
+        )
+        break  # success
+    except OSError:
+        logging.warning(f"Port {port} is in use, trying {port + 1}...")
+        port += 1
+        attempt += 1
+
+        if port > 65535:
+            raise RuntimeError("No available ports found (exceeded 65535)")
+
+        if attempt == max_attempts:
+            raise RuntimeError(f"Could not find a free port after {max_attempts} attempts")
 
 
-def download_scripts_and_run():
-    download_scripts()
-    main()
+    def download_scripts_and_run():
+        download_scripts()
+        main()
 
 
-if __name__ == "__main__":
-    download_scripts_and_run()
+        if __name__ == "__main__":
+            download_scripts_and_run()


### PR DESCRIPTION
## Add auto-retry mechanism for busy ports

### Problem
Visdom crashes with an OSError when the specified port is already in use.

### Solution
- Added retry mechanism (up to 10 attempts)
- Automatically tries the next available ports
- Logs informative messages for each retry
- Ensures port does not exceed 65535

### Impact
Improves user experience and prevents abrupt crashes, especially for beginners and multi-instance usage.

This follows the discussion in #1128.

## Summary by Sourcery

New Features:
- Automatically retry starting the server on subsequent ports when the requested port is busy, up to a fixed number of attempts, while enforcing the valid port range and logging retries.