### PR TITLE
Fix: correct comment to reflect message forwarding in Legacy.js

### DIFF
--- a/js/api/Legacy.js
+++ b/js/api/Legacy.js
@@ -76,10 +76,8 @@ class Poller {
           } else {
             let messages = result.messages;
             messages.forEach((msg) => {
-              // Must re-encode message as handle message expects json
-              // in this particular format from sockets
-              // TODO Could refactor message parsing out elsewhere.
-              this.onmessage({ data: msg });
+                // Forward message; msg is already in the JSON format expected by handleMessage
+                this.onmessage({ data: msg });
             });
           }
         },

--- a/js/api/Legacy.js
+++ b/js/api/Legacy.js
@@ -76,8 +76,8 @@ class Poller {
           } else {
             let messages = result.messages;
             messages.forEach((msg) => {
-                // Forward message; msg is already in the JSON format expected by handleMessage
-                this.onmessage({ data: msg });
+              // Forward message; msg is already in the JSON format expected by handleMessage
+              this.onmessage({ data: msg });
             });
           }
         },

--- a/js/api/Legacy.js
+++ b/js/api/Legacy.js
@@ -76,7 +76,7 @@ class Poller {
           } else {
             let messages = result.messages;
             messages.forEach((msg) => {
-              // Forward message; msg is already in the JSON format expected by handleMessage
+              // Forward message; msg is already a JSON-encoded string for the evt.data value expected by handleMessage
               this.onmessage({ data: msg });
             });
           }


### PR DESCRIPTION
Fixes a misleading comment in `Legacy.js` related to message handling in the polling mechanism.

Changes made:
Updated comment to correctly describe that messages are forwarded, not re-encoded
Removed outdated TODO comment


-No functional changes introduced
-This is a minor documentation/refactor improvement for better code clarity

## Summary by Sourcery

Documentation:
- Update inline documentation in Legacy.js to accurately describe message forwarding behavior and clean up an outdated TODO comment.