### PR TITLE
Fix editable install failure on Python 3.12 (replace pkg_resources with importlib.metadata)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,20 @@
-cypress/screenshots
-cypress/screenshots_init
-cypress/downloads
-cypress/fixtures
-node_modules
-build
-th/CMakeLists.txt
-th/build.luarocks
+# ---- Build / dist ----
+build/
 dist/
-visdom*.tgz
+*.tgz
 visdom.egg-info/
 setup.cfg
+
+# ---- Node / frontend ----
+node_modules/
+
+# ---- Cypress ----
+cypress/screenshots/
+cypress/screenshots_init/
+cypress/downloads/
+cypress/fixtures/
+
+# ---- Static generated files ----
 py/visdom/static/fonts/
 py/visdom/static/css/
 py/visdom/static/js/*.min.js
@@ -18,6 +23,18 @@ py/visdom/static/js/*.js.map
 py/visdom/static/js/mathjax/
 py/visdom/static/js/sjcl.js
 py/visdom/static/version.built
-__pycache__/
 py/visdom/static/js/layout_bin_packer.js
 py/visdom/extra_deps/**/*
+
+# ---- Python ----
+__pycache__/
+*.pyc
+
+# ---- Virtual environments ----
+venv/
+env/
+.venv/
+
+# ---- OS ----
+.DS_Store
+Thumbs.db

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel"]
+requires = [
+  "setuptools>=40.8.0",
+  "wheel",
+  "importlib_metadata; python_version < '3.8'"
+]
 build-backend = "setuptools.build_meta"
+

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@
 import os
 from io import open
 from setuptools import setup, find_packages
-from pkg_resources import get_distribution, DistributionNotFound
+from importlib.metadata import version as get_metadata_version, PackageNotFoundError
 
 
 try:
@@ -26,8 +26,8 @@ except Exception:
 
 def get_dist(pkgname):
     try:
-        return get_distribution(pkgname)
-    except DistributionNotFound:
+        return get_metadata_version(pkgname)
+    except PackageNotFoundError:
         return None
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,12 @@ from setuptools import setup, find_packages
 try:
     from importlib.metadata import version as get_metadata_version, PackageNotFoundError
 except ImportError:
-    from importlib_metadata import version as get_metadata_version, PackageNotFoundError
-
+    try:
+        from importlib_metadata import version as get_metadata_version, PackageNotFoundError
+    except ImportError:
+        raise ImportError(
+            "importlib.metadata is not available. Install 'importlib_metadata' for Python < 3.8."
+        )
 
 try:
     import torch
@@ -29,6 +33,12 @@ except Exception:
 
 
 class Dist:
+    """
+    Minimal shim for pkg_resources.Distribution.
+
+    Only the `.version` attribute is used in this codebase.
+    Other attributes from pkg_resources.Distribution are not supported.
+    """
     def __init__(self, version):
         self.version = version
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,11 @@
 import os
 from io import open
 from setuptools import setup, find_packages
-from importlib.metadata import version as get_metadata_version, PackageNotFoundError
+
+try:
+    from importlib.metadata import version as get_metadata_version, PackageNotFoundError
+except ImportError:
+    from importlib_metadata import version as get_metadata_version, PackageNotFoundError
 
 
 try:
@@ -24,9 +28,14 @@ except Exception:
     pass  # User doesn't have torch
 
 
+class Dist:
+    def __init__(self, version):
+        self.version = version
+
+
 def get_dist(pkgname):
     try:
-        return get_metadata_version(pkgname)
+        return Dist(get_metadata_version(pkgname))
     except PackageNotFoundError:
         return None
 


### PR DESCRIPTION
## Description
This PR fixes an editable installation failure on Python 3.12 caused by the use of `pkg_resources` in `setup.py`.

The dependency on `pkg_resources` is replaced with `importlib.metadata`, and a minimal `pyproject.toml` is added to ensure compatibility with PEP 517 build isolation.

## Motivation and Context
Fixes #1195

Editable installation (`pip install -e .`) fails on Python 3.12 with:

ModuleNotFoundError: No module named 'pkg_resources'

This occurs because `pkg_resources` is not available in isolated build environments created by pip (PEP 517).

This change removes the dependency on `pkg_resources` and ensures proper build configuration using `pyproject.toml`.

## How Has This Been Tested?
Tested locally on Windows with Python 3.12.

Steps:
1. Created a virtual environment
2. Installed dependencies using pip
3. Ran `pip install -e .`

Before fix:
- Installation failed with pkg_resources error

After fix:
- Installation succeeded in editable mode

Also verified that the Visdom server runs correctly after installation (`python -m visdom.server`).

## Screenshots (if appropriate):
### Before fix (installation error)
<img width="779" height="207" alt="image" src="https://github.com/user-attachments/assets/d16c31bc-48e2-4e97-b906-404e026a4910" />

### After fix (successful installation)
<img width="929" height="373" alt="image" src="https://github.com/user-attachments/assets/84634623-9e2d-4464-90e7-a49ff6989ca3" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/97f6bb59-1756-4ad9-914f-aa45a1ad23af" />



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
- [ ] I adapted the version number under `py/visdom/VERSION` according to Semantic Versioning
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

## Summary by Sourcery

Fix editable installs and build isolation compatibility by updating metadata resolution in setup configuration and declaring a PEP 517 build backend.

Bug Fixes:
- Resolve editable installation failures on Python 3.12 by replacing the distribution lookup with a metadata-based check that does not rely on pkg_resources.

Build:
- Declare setuptools build backend and minimum build requirements in pyproject.toml to support PEP 517 build isolation environments.