### PR TITLE
Feature: Add GIF helper using text pane (#685)

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -1523,7 +1523,7 @@ class Visdom(object):
         return self.text(text=videodata, win=win, env=env, opts=opts)
     
 
-    def gif(self, gif_path, win=None, opts=None):
+    def gif(self, gif_path, win=None, env=None, opts=None):
         """
         Display a GIF image using text pane with base64 encoding.
         """
@@ -1535,7 +1535,7 @@ class Visdom(object):
 
         html = '<img src="data:image/gif;base64,{}" />'.format(encoded)
 
-        return self.text(html, win=win, opts=opts)   
+        return self.text(text=html, win=win, env=env, opts=opts)
          
     def update_window_opts(self, win, opts, env=None):
         """

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -1521,7 +1521,22 @@ class Visdom(object):
             base64.b64encode(bytestr).decode("utf-8"),
         )
         return self.text(text=videodata, win=win, env=env, opts=opts)
+    
 
+    def gif(self, gif_path, win=None, opts=None):
+        """
+        Display a GIF image using text pane with base64 encoding.
+        """
+
+        import base64
+
+        with open(gif_path, "rb") as f:
+            encoded = base64.b64encode(f.read()).decode("utf-8")
+
+        html = '<img src="data:image/gif;base64,{}" />'.format(encoded)
+
+        return self.text(html, win=win, opts=opts)   
+         
     def update_window_opts(self, win, opts, env=None):
         """
         This function allows pushing new options to an existing plot window


### PR DESCRIPTION
## Description
This PR adds a simple helper function to display GIF images in Visdom.

Currently, GIFs can be displayed using the text pane by manually embedding HTML with base64 encoding. This PR introduces a convenient `viz.gif()` function that simplifies this process for users.

## Motivation and Context
Issue #685 highlights the need for better support for visualizing GIFs, especially for tasks like comparing model outputs or tracking progress.

Instead of modifying existing components like ImagePane, this PR follows the suggested workaround and provides a clean helper function.

## Changes
- Added `gif()` helper function in `py/visdom/__init__.py`
- Uses base64 encoding to render GIFs via HTML in the text pane
- No changes made to existing functionality

## How Has This Been Tested?
- Started Visdom server locally
- Used `viz.gif("test.gif")` to render a GIF
- Verified:
  - GIF displays correctly in browser
  - Animation plays smoothly
  - No errors occur

## Screenshots
<img width="1918" height="1029" alt="Screenshot 2026-04-16 175346" src="https://github.com/user-attachments/assets/64c20992-4043-4021-8323-f5b97d00cbbd" />


## Summary by Sourcery

New Features:
- Introduce a gif() helper method that renders GIF files via base64-encoded HTML in a text window.