### PR TITLE
fix: add port retry mechanism for server startup with logging and failure handling

### DIFF
--- a/py/visdom/server/run_server.py
+++ b/py/visdom/server/run_server.py
@@ -49,10 +49,26 @@ def start_server(
         use_frontend_client_polling=use_frontend_client_polling,
         eager_data_loading=eager_data_loading,
     )
-    if bind_local:
-        app.listen(port, max_buffer_size=1024**3, address="127.0.0.1")
-    else:
-        app.listen(port, max_buffer_size=1024**3)
+    initial_port = port
+    max_attempts = 10
+    attempt = 0
+
+    while attempt < max_attempts:
+      try:
+        if bind_local:
+            app.listen(port, max_buffer_size=1024**3, address="127.0.0.1")
+        else:
+            app.listen(port, max_buffer_size=1024**3)
+        break
+      except OSError:
+        logging.warning(f"Port {port} unavailable, trying next port...")
+        port += 1
+        attempt += 1
+
+    if attempt == max_attempts:
+     raise RuntimeError(
+        f"Failed to bind server after {max_attempts} attempts starting from port {initial_port}"
+     )
     logging.info("Application Started")
     logging.info(f"Working directory: {os.path.abspath(env_path)}")
 

--- a/py/visdom/server/run_server.py
+++ b/py/visdom/server/run_server.py
@@ -52,6 +52,7 @@ def start_server(
     initial_port = port
     max_attempts = 10
     attempt = 0
+    bound = False
 
     while attempt < max_attempts:
       try:
@@ -59,13 +60,14 @@ def start_server(
             app.listen(port, max_buffer_size=1024**3, address="127.0.0.1")
         else:
             app.listen(port, max_buffer_size=1024**3)
+        bound = True
         break
       except OSError:
         logging.warning(f"Port {port} unavailable, trying next port...")
         port += 1
         attempt += 1
 
-    if attempt == max_attempts:
+    if not bound:
      raise RuntimeError(
         f"Failed to bind server after {max_attempts} attempts starting from port {initial_port}"
      )

--- a/py/visdom/server/run_server.py
+++ b/py/visdom/server/run_server.py
@@ -61,6 +61,7 @@ def start_server(
         else:
             app.listen(port, max_buffer_size=1024**3)
         bound = True
+        logging.info(f"Server successfully bound to port {port}")
         break
       except OSError:
         logging.warning(f"Port {port} unavailable, trying next port...")


### PR DESCRIPTION
## Description
This PR improves the reliability of server startup in `run_server.py` by introducing a retry mechanism for port binding.

Instead of attempting to bind to a single port once, the server now retries binding on subsequent ports if the initial port is unavailable. Logging has been added for each retry attempt, and a clear error is raised if all attempts fail.

## Motivation and Context
Previously, if the specified port was already in use, the server would fail immediately without attempting recovery. This could interrupt workflows when restarting the server or running multiple services locally.

This change improves usability and robustness by:
- Retrying port binding on subsequent ports
- Providing logging for better visibility into retry attempts
- Ensuring a clear failure message when all attempts are exhausted
- Preserving existing behavior for both local (`bind_local`) and default modes

## How Has This Been Tested?
- Started the server on an available port to confirm normal behavior remains unchanged
- Simulated port conflicts by running another process on the default port and verified that:
  - The server retries with the next available ports
  - Warning logs are printed for each retry attempt
  - The server successfully starts on an available port
- Verified that when all retry attempts are exhausted, a RuntimeError is raised with a clear message
- Ensured no regression in functionality by running the server before and after changes and comparing behavior

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
- [ ] I adapted the version number under `py/visdom/VERSION` according to Semantic Versioning
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Summary by Sourcery

Improve robustness of server startup by adding a retry mechanism for port binding with clear failure reporting.

Bug Fixes:
- Handle server startup failures when the requested port is already in use by retrying on subsequent ports instead of failing immediately.

Enhancements:
- Add configurable retry loop for binding to incremental ports, with warning logs for each failed attempt and a final runtime error if all attempts are exhausted.