### PR TITLE
plot panes now resize immediately upon dragging corner

### DIFF
--- a/js/panes/PlotPane.js
+++ b/js/panes/PlotPane.js
@@ -74,6 +74,12 @@ var PlotPane = (props) => {
     newPlot();
   });
 
+  useEffect(() => {
+    if (plotlyRef.current) {
+      Plotly.Plots.resize(plotlyRef.current);
+    }
+  }, [props.width, props.height]);
+  
   // rendering
   // ---------
 


### PR DESCRIPTION
Plot resize behavior is now responsive by triggering Plotly’s resize when pane dimensions change in PlotPane.js.


https://github.com/user-attachments/assets/3f0f1599-c319-49e7-95f4-4b5e41ea2d26

<hr>

-  Closes : #1227

## Summary by Sourcery

Bug Fixes:
- Ensure plot panes resize correctly in response to width and height changes so the rendered plot matches the pane size.