### PR TITLE
refactor(tornado): use IOLoop.current() instead of deprecated IOLoop.instance()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,20 @@
-cypress/screenshots
-cypress/screenshots_init
-cypress/downloads
-cypress/fixtures
-node_modules
-build
-th/CMakeLists.txt
-th/build.luarocks
+# ---- Build / dist ----
+build/
 dist/
-visdom*.tgz
+*.tgz
 visdom.egg-info/
 setup.cfg
+
+# ---- Node / frontend ----
+node_modules/
+
+# ---- Cypress ----
+cypress/screenshots/
+cypress/screenshots_init/
+cypress/downloads/
+cypress/fixtures/
+
+# ---- Static generated files ----
 py/visdom/static/fonts/
 py/visdom/static/css/
 py/visdom/static/js/*.min.js
@@ -18,6 +23,18 @@ py/visdom/static/js/*.js.map
 py/visdom/static/js/mathjax/
 py/visdom/static/js/sjcl.js
 py/visdom/static/version.built
-__pycache__/
 py/visdom/static/js/layout_bin_packer.js
 py/visdom/extra_deps/**/*
+
+# ---- Python ----
+__pycache__/
+*.pyc
+
+# ---- Virtual environments ----
+venv/
+env/
+.venv/
+
+# ---- OS ----
+.DS_Store
+Thumbs.db

--- a/py/visdom/server/run_server.py
+++ b/py/visdom/server/run_server.py
@@ -64,7 +64,7 @@ def start_server(
         print("You can navigate to http://%s:%s%s" % (hostname, port, base_url))
     else:
         print_func(port)
-    ioloop.IOLoop.instance().start()
+    ioloop.IOLoop.current().start()
     app.subs = []
     app.sources = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@
 import os
 from io import open
 from setuptools import setup, find_packages
-from pkg_resources import get_distribution, DistributionNotFound
+from importlib.metadata import version as get_metadata_version, PackageNotFoundError
 
 
 try:
@@ -26,8 +26,8 @@ except Exception:
 
 def get_dist(pkgname):
     try:
-        return get_distribution(pkgname)
-    except DistributionNotFound:
+        return get_metadata_version(pkgname)
+    except PackageNotFoundError:
         return None
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,11 @@
 import os
 from io import open
 from setuptools import setup, find_packages
-from importlib.metadata import version as get_metadata_version, PackageNotFoundError
+
+try:
+    from importlib.metadata import version as get_metadata_version, PackageNotFoundError
+except ImportError:
+    from importlib_metadata import version as get_metadata_version, PackageNotFoundError
 
 
 try:
@@ -24,9 +28,14 @@ except Exception:
     pass  # User doesn't have torch
 
 
+class Dist:
+    def __init__(self, version):
+        self.version = version
+
+
 def get_dist(pkgname):
     try:
-        return get_metadata_version(pkgname)
+        return Dist(get_metadata_version(pkgname))
     except PackageNotFoundError:
         return None
 


### PR DESCRIPTION
Fixes #1234

## Description
This PR replaces the deprecated `IOLoop.instance()` with `IOLoop.current()` in the server startup.

`IOLoop.instance()` is deprecated in modern Tornado versions. While it still works, `IOLoop.current()` is the recommended API and ensures compatibility with asyncio-based event loops and future Tornado releases.

## Motivation and Context
Using deprecated APIs can lead to issues in future updates. This change aligns the codebase with Tornado best practices.

## How Has This Been Tested?
- Installed visdom using `pip install -e .`
- Started server using `python -m visdom.server`
- Verified server starts successfully without errors
- Verified UI loads at http://localhost:8097

## Screenshots
<img width="439" height="107" alt="Server startup" src="https://github.com/user-attachments/assets/795ba55d-7bac-49e9-9f14-435c10328cec" />


## Types of changes
- [x] Code refactor or cleanup (non-breaking change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have tested the change locally.

## Summary by Sourcery

Modernize Tornado server startup and packaging utilities to use non-deprecated APIs and standard build configuration.

Enhancements:
- Replace deprecated Tornado IOLoop.instance() usage with IOLoop.current() in server startup to align with current Tornado practices.
- Refactor package version lookup in setup.py to use importlib.metadata/importlib_metadata instead of pkg_resources.

Build:
- Add a minimal pyproject.toml declaring setuptools build backend and requirements for PEP 517/518 compliant builds.