### PR TITLE
fix: correct workflow job name typos

### DIFF
--- a/.github/workflows/process-changes.yml
+++ b/.github/workflows/process-changes.yml
@@ -138,7 +138,7 @@ jobs:
           name: cypress-screenshots-visual
           path: cypress/screenshots
 
-  funcitonal-test:
+  functional-test:
     name: "Functional Test (Websocket)"
     runs-on: ubuntu-latest
     needs: install-and-build
@@ -164,7 +164,7 @@ jobs:
           name: cypress-screenshots-functional-${{ matrix.python }}
           path: cypress/screenshots
 
-  funcitonal-test-polling:
+  functional-test-polling:
     name: 'Functional Test (Polling)'
     runs-on: ubuntu-latest
     needs: install-and-build


### PR DESCRIPTION
## Description
This PR fixes typos in workflow job names  in `process-changes.yml`.

## Motivation and Context
The job names contained a typo ("funcitonal" instead of "functional"), which reduces clarity in CI outputs.  

## How Has This Been Tested?
- Verified the workflow YAML syntax after changes
- Ensured job names display correctly in the GitHub Actions UI

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
- [ ] I adapted the version number under `py/visdom/VERSION` according to Semantic Versioning
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Summary by Sourcery

CI:
- Fix typos in functional test job IDs in the process-changes GitHub Actions workflow to align with their display names.