### PR TITLE
Fix WebSocketClosedError when sending to closed socket

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -742,6 +742,10 @@ class Visdom(object):
         if not self.send:
             return msg, endpoint
 
+        if self.use_socket and not self.socket_alive:
+            logger.warn("Socket not alive, switching to HTTP")
+            self.use_socket = False
+
         if "win" in msg and msg["win"] is None and create:
             msg["win"] = "window_" + get_rand_id()
 

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -743,8 +743,7 @@ class Visdom(object):
             return msg, endpoint
 
         if self.use_socket and not self.socket_alive:
-            logger.warn("Socket not alive, switching to HTTP")
-            self.use_socket = False
+            logger.warning("Socket not alive, falling back to HTTP for this request")
 
         if "win" in msg and msg["win"] is None and create:
             msg["win"] = "window_" + get_rand_id()


### PR DESCRIPTION
Fixes #934

This PR prevents crashes when attempting to send messages over a closed WebSocket.

Changes:
- Checks if the socket is alive before sending data
- Avoids WebSocketClosedError
- Falls back to HTTP when socket is not available

This improves stability when WebSocket connections close unexpectedly.

## Summary by Sourcery

Bug Fixes:
- Prevent crashes caused by sending over a closed or dead WebSocket by detecting socket liveness and disabling socket use when necessary.