### PR TITLE
fix: add timeout to wait-on in CI workflow

### DIFF
--- a/.github/workflows/process-changes.yml
+++ b/.github/workflows/process-changes.yml
@@ -104,7 +104,6 @@ jobs:
           wait-on: 'http://localhost:8098'
           # Timeout set to 10 minutes to allow server startup in CI environments
           wait-on-timeout: 600
-          wait-on-timeout: 600
           spec: cypress/integration/*.init.js
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/process-changes.yml
+++ b/.github/workflows/process-changes.yml
@@ -102,6 +102,7 @@ jobs:
           install: false
           start: visdom -port 8098 -env_path /tmp
           wait-on: 'http://localhost:8098'
+          wait-on-timeout: 600
           spec: cypress/integration/*.init.js
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/process-changes.yml
+++ b/.github/workflows/process-changes.yml
@@ -102,6 +102,8 @@ jobs:
           install: false
           start: visdom -port 8098 -env_path /tmp
           wait-on: 'http://localhost:8098'
+          # Timeout set to 10 minutes to allow server startup in CI environments
+          wait-on-timeout: 600
           wait-on-timeout: 600
           spec: cypress/integration/*.init.js
 


### PR DESCRIPTION
## Description
Adds a timeout to `wait-on` steps in the CI workflow to prevent jobs from hanging indefinitely.

## Motivation and Context
Currently, if the Visdom server fails to start, the workflow waits indefinitely for the endpoint to become available.  
This can cause CI jobs to hang and waste resources.

Adding a timeout ensures that jobs fail gracefully when the server does not start within a reasonable time.

## How Has This Been Tested?
- Verified workflow syntax after adding timeout
- Ensured no change in behavior when server starts successfully
- Confirmed that timeout prevents indefinite waiting in failure scenarios

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
- [ ] I adapted the version number under `py/visdom/VERSION` according to Semantic Versioning
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.