### PR TITLE
Replace deprecated logger.warn with logger.warning

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -145,7 +145,7 @@ def _title2str(opts):
     if opts.get("title"):
         if isnum(opts.get("title")):
             title = str(opts.get("title"))
-            logger.warning("Numerical title %s has been casted to a string" % title)
+            logger.warning("Numerical title %s has been cast to a string" % title)
             opts["title"] = title
             return opts
         else:

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -145,7 +145,7 @@ def _title2str(opts):
     if opts.get("title"):
         if isnum(opts.get("title")):
             title = str(opts.get("title"))
-            logger.warn("Numerical title %s has been casted to a string" % title)
+            logger.warning("Numerical title %s has been casted to a string" % title)
             opts["title"] = title
             return opts
         else:
@@ -316,7 +316,7 @@ def _assert_opts(opts):
     remove_nones = ["title"]
     for to_remove in remove_nones:
         if to_remove in opts and opts[to_remove] is None:
-            logger.warn(
+            logger.warning(
                 "None-incompatible opt {} was provided None value "
                 "and was thus ignored".format(to_remove)
             )
@@ -509,7 +509,7 @@ class Visdom(object):
         elif send and use_polling:
             self.setup_polling()
         elif send and not use_incoming_socket:
-            logger.warn(
+            logger.warning(
                 "Without the incoming socket you cannot receive events from "
                 "the server or register event handlers to your Visdom client."
             )
@@ -521,7 +521,7 @@ class Visdom(object):
             time_spent += inc
             inc *= 2
         if time_spent > 5:
-            logger.warn(
+            logger.warning(
                 "Visdom python client failed to establish socket to get "
                 "messages from the server. This feature is optional and "
                 "can be disabled by initializing Visdom with "
@@ -573,7 +573,7 @@ class Visdom(object):
                         self.socket_alive = True
                         self.socket_connection_achieved = True
                     else:
-                        logger.warn(
+                        logger.warning(
                             "Visdom server failed handshake, may not "
                             "be properly connected"
                         )
@@ -624,7 +624,7 @@ class Visdom(object):
                         self.socket_alive = True
                         self.socket_connection_achieved = True
                     else:
-                        logger.warn(
+                        logger.warning(
                             "Visdom server failed handshake, may not "
                             "be properly connected"
                         )
@@ -633,7 +633,7 @@ class Visdom(object):
                     try:
                         handler(message)
                     except Exception as e:
-                        logger.warn(
+                        logger.warning(
                             "Visdom failed to handle a handler for {}: {}"
                             "".format(message, e)
                         )


### PR DESCRIPTION
Replaces deprecated logger.warn with logger.warning across the codebase.

This aligns with the standard Python logging API and avoids deprecation warnings.

## Summary by Sourcery

Bug Fixes:
- Prevent deprecation warnings by using logger.warning instead of the deprecated logger.warn across warning logs in the Visdom client.