### PR TITLE
fix: replace deprecated IOLoop.instance() with IOLoop.current()

### DIFF
--- a/py/visdom/server/run_server.py
+++ b/py/visdom/server/run_server.py
@@ -64,7 +64,7 @@ def start_server(
         print("You can navigate to http://%s:%s%s" % (hostname, port, base_url))
     else:
         print_func(port)
-    ioloop.IOLoop.instance().start()
+    ioloop.IOLoop.current().start()
     app.subs = []
     app.sources = []
 


### PR DESCRIPTION
## Description
Replaced the deprecated `ioloop.IOLoop.instance().start()` with `ioloop.IOLoop.current().start()` in `py/visdom/server/run_server.py`.

## Motivation and Context
This change aligns the server startup logic with the modern Tornado API, removing a deprecation warning and improving forward compatibility with future Tornado releases. 

Fixes #1234

## How Has This Been Tested?
I tested this locally to ensure the server still boots correctly and that the deprecation warning is resolved.

**Steps taken:**
1. Installed the local repository from source (`pip install -e .`).
2. Ran the server using `python -m visdom.server`.
3. Verified in the terminal output that the server successfully reached `INFO:root:Application Started`.
4. Verified that no `IOLoop.instance()` deprecation warnings were thrown in the console.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Summary by Sourcery

Bug Fixes:
- Replace deprecated ioloop.IOLoop.instance().start() with ioloop.IOLoop.current().start() to remove deprecation warnings and improve compatibility with newer Tornado versions.