### PR TITLE
chore: changed dependabot PRs target to dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   # 1. JavaScript / npm
   - package-ecosystem: "npm"
     directory: "/"
-    target-branch: "master"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -27,7 +27,7 @@ updates:
   # 2. Python / pip
   - package-ecosystem: "pip"
     directory: "/"
-    target-branch: "master"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -50,7 +50,7 @@ updates:
   # 3. GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "master"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
Updated the Dependabot configuration to target the `dev` branch instead of `master` for all automated dependency update pull requests.

Fixes #1282 

The following ecosystems were updated:

* npm
* pip
* GitHub Actions

Added:

```yaml id="0y6mgk"
target-branch: "dev"
```

to each update configuration block in `.github/dependabot.yml`.

## Motivation and Context

Previously, Dependabot opened dependency update PRs directly against `master`, which bypassed the normal development and testing workflow.

This change aligns Dependabot with the project's branching strategy by ensuring that:

* dependency updates are first integrated into `dev`
* CI and testing can run before changes reach `master`
* the production/stable branch remains isolated from unverified dependency updates

Fixes the issue regarding Dependabot PRs targeting the wrong branch.

## How Has This Been Tested?

* Verified the updated `.github/dependabot.yml` syntax and structure.
* Confirmed that all configured ecosystems now specify:

```yaml id="0i8m42"
target-branch: "dev"
```

* Checked that existing schedules, labels, commit message prefixes, and grouping rules remain unchanged.
* Ensured no other Dependabot behavior was modified unintentionally.

## Screenshots (if appropriate):

N/A

## Types of changes

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:

* [ ] I adapted the version number under `py/visdom/VERSION` according to [[Semantic Versioning](https://semver.org/)](https://semver.org/)
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.

## Summary by Sourcery

Build:
- Change Dependabot target branch from master to dev for npm, pip, and GitHub Actions dependency updates.