### PR TITLE
fix: change dependabot target branch to dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   # 1. JavaScript / npm
   - package-ecosystem: "npm"
     directory: "/"
-    target-branch: "master"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -27,7 +27,7 @@ updates:
   # 2. Python / pip
   - package-ecosystem: "pip"
     directory: "/"
-    target-branch: "master"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -50,7 +50,7 @@ updates:
   # 3. GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "master"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
Fixes #1282 

### Description

Updated the Dependabot configuration to ensure all automated dependency update pull requests target the `dev` branch instead of `master`.

### Changes Made

* Added/updated `target-branch: "dev"` for:

  * npm
  * pip
  * github-actions

### Verification

* Verified `.github/dependabot.yml` syntax remains valid
* Confirmed all update blocks now point to `dev`
* No unnecessary code or configuration changes were made

### Impact

Future Dependabot PRs will now be opened against the `dev` branch, aligning dependency updates with the active development workflow.

## Summary by Sourcery

Build:
- Retarget Dependabot npm, pip, and GitHub Actions updates to the dev branch.