### PR TITLE
Docs: Clarify environments for local development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,40 @@ own code changes, if any). In the visdom source folder, run:
 ```
 pip uninstall visdom && pip install -e .
 ```
+
+> **Note for local development**
+>
+> Running:
+>
+> ```bash
+> python -m visdom.server
+> ```
+>
+> may still import an already installed `visdom` package from
+> `site-packages` instead of the checked-out repository source.
+>
+> This can cause confusing behavior where:
+>
+> - frontend changes compile successfully
+> - rebuilt `main.js` contains updated code
+> - the server restarts normally
+> - but the UI still shows old behavior
+>
+> To verify the active source:
+>
+> ```bash
+> python -c "import visdom; print(visdom.__file__)"
+> ```
+>
+> The path should point to your local repository instead of
+> `site-packages`.
+>
+> If needed, prioritize the local source manually:
+>
+> ```bash
+> export PYTHONPATH=$PWD/py:$PYTHONPATH
+> ```
+
 For some pip installs, this approach does not always properly link the visdom
 module. In that case, try running `python setup.py install` instead.
 


### PR DESCRIPTION
## Description

Added contributor documentation for local development setup issues where:

```bash
python -m visdom.server
```

may import an already installed `visdom` package from `site-packages` instead of the checked-out repository source.

The added note explains:
- symptoms contributors may observe
- how to verify the active import source
- how to prioritize the local repository using `PYTHONPATH`

---

## Motivation and Context

This improves contributor/development experience by documenting a confusing local setup issue that can cause frontend changes to appear ignored even after rebuilding assets and restarting the server.

---

## How Has This Been Tested?

- Verified the issue locally by observing that frontend changes were not reflected despite successful webpack rebuilds.
- Confirmed the active runtime source using:

```bash
python -c "import visdom; print(visdom.__file__)"
```

- Verified that setting:

```bash
export PYTHONPATH=$PWD/py:$PYTHONPATH
```

correctly prioritized the local repository source and reflected frontend changes immediately.

---

## Screenshots (if appropriate):

N/A

---

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactor or cleanup (changes to existing code for improved readability or performance)

---

## Checklist:

- [ ] I adapted the version number under `py/visdom/VERSION` according to Semantic Versioning
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.


 fixes #1287