### PR TITLE
fix(plotlyplot): decode Plotly typed-array JSON for frontend compatibility

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -60,7 +60,9 @@ try:
         perplexity = (
             50
             if num_entities >= 150
-            else num_entities // 3 if num_entities >= 21 else 7
+            else num_entities // 3
+            if num_entities >= 21
+            else 7
         )
         Y = bhtsne.run_bh_tsne(
             X, initial_dims=X.shape[1], perplexity=perplexity, verbose=True

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -60,9 +60,7 @@ try:
         perplexity = (
             50
             if num_entities >= 150
-            else num_entities // 3
-            if num_entities >= 21
-            else 7
+            else num_entities // 3 if num_entities >= 21 else 7
         )
         Y = bhtsne.run_bh_tsne(
             X, initial_dims=X.shape[1], perplexity=perplexity, verbose=True
@@ -179,9 +177,11 @@ def _axisformat(xy, opts):
         return {
             "type": opts.get(xy + "type"),
             "title": opts.get(xy + "label"),
-            "range": [opts.get(xy + "tickmin"), opts.get(xy + "tickmax")]
-            if has_ticks
-            else None,
+            "range": (
+                [opts.get(xy + "tickmin"), opts.get(xy + "tickmax")]
+                if has_ticks
+                else None
+            ),
             "tickvals": opts.get(xy + "tickvals"),
             "ticktext": opts.get(xy + "ticklabels"),
             "dtick": opts.get(xy + "tickstep"),
@@ -209,17 +209,21 @@ def _axisformat3d(xyz, opts):
         return {
             "type": opts.get(xyz + "type"),
             "title": opts.get(xyz + "label"),
-            "range": [opts.get(xyz + "tickmin"), opts.get(xyz + "tickmax")]
-            if has_ticks
-            else None,
+            "range": (
+                [opts.get(xyz + "tickmin"), opts.get(xyz + "tickmax")]
+                if has_ticks
+                else None
+            ),
             "tickvals": opts.get(xyz + "tickvals"),
             "ticktext": opts.get(xyz + "ticklabels"),
             "nticks": (
-                (opts.get(xyz + "tickmax") - opts.get(xyz + "tickmin"))
-                / opts.get(xyz + "tickstep")
-            )
-            if has_step
-            else None,
+                (
+                    (opts.get(xyz + "tickmax") - opts.get(xyz + "tickmin"))
+                    / opts.get(xyz + "tickstep")
+                )
+                if has_step
+                else None
+            ),
             "tickfont": opts.get(xyz + "tickfont"),
         }
 
@@ -1124,7 +1128,7 @@ class Visdom(object):
                 # The title is now officially under a 'text' subproperty. Previously, the property
                 # itself could also directly reference the title.
                 # Although this latter behavior is now deprecated, we support both possibilities.
-    ``                opts["title"] = (
+                opts["title"] = (
                     title_prop["text"] if "text" in title_prop else title_prop
                 )
 
@@ -1702,9 +1706,9 @@ class Visdom(object):
                     "x": nan2none(X.take(0, 1)[ind].tolist()),
                     "y": nan2none(X.take(1, 1)[ind].tolist()),
                     "name": trace_name,
-                    "type": "scatter3d"
-                    if is3d
-                    else ("scattergl" if use_gl else "scatter"),
+                    "type": (
+                        "scatter3d" if is3d else ("scattergl" if use_gl else "scatter")
+                    ),
                     "mode": opts.get("mode"),
                     "text": L[ind].tolist() if L is not None else None,
                     "textposition": "right",

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -257,6 +257,30 @@ def _opts2layout(opts, is3d=False):
     return _scrub_dict(layout)
 
 
+def _decode_typed_arrays(obj):
+    """Recursively convert Plotly typed-array dicts {bdata, dtype} to plain Python lists.
+
+    Newer versions of plotly-py (>= 5.12) encode numpy arrays as a compact
+    binary format when building JSON:  {"bdata": "<base64>", "dtype": "f8"}.
+    The Plotly.js version bundled with Visdom does not recognise this format,
+    so any trace field that uses it is silently ignored by the browser — causing
+    large histograms (and any other plot whose data is a large numpy array) to
+    appear completely empty.
+
+    This function walks the decoded figure dict and converts every such object
+    back to a plain Python list so that Plotly.js can render it correctly.
+    """
+    if isinstance(obj, dict):
+        if "bdata" in obj and "dtype" in obj:
+            raw = b64.b64decode(obj["bdata"])
+            arr = np.frombuffer(raw, dtype=np.dtype(obj["dtype"]))
+            return arr.tolist()
+        return {k: _decode_typed_arrays(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [_decode_typed_arrays(item) for item in obj]
+    return obj
+
+
 def _markerColorCheck(mc, X, Y, L):
     assert isndarray(mc), "mc should be a numpy ndarray"
     assert mc.shape[0] == L or (
@@ -1084,6 +1108,13 @@ class Visdom(object):
                 json.dumps(figure, cls=plotly.utils.PlotlyJSONEncoder)
             )
 
+            # Newer plotly-py versions encode numpy arrays as typed-array
+            # objects {"bdata": "<base64>", "dtype": "f8"} for efficiency.
+            # The Plotly.js bundled with Visdom does not support this format,
+            # so we convert any such objects back to plain Python lists.
+            # See: https://github.com/fossasia/visdom/issues/927
+            figure_dict = _decode_typed_arrays(figure_dict)
+
             # If opts title is not added, the title is not added to the top right of the window.
             # We add the paramater to opts manually if it exists.
             opts = dict()
@@ -1093,8 +1124,7 @@ class Visdom(object):
                 # The title is now officially under a 'text' subproperty. Previously, the property
                 # itself could also directly reference the title.
                 # Although this latter behavior is now deprecated, we support both possibilities.
-                # Docs reference: https://plot.ly/python/reference/#layout-title-text
-                opts["title"] = (
+    ``                opts["title"] = (
                     title_prop["text"] if "text" in title_prop else title_prop
                 )
 


### PR DESCRIPTION
## Description

Newer versions of `plotly-py` serialize large NumPy arrays using typed-array objects of the form:

```json
{"bdata": "...", "dtype": "..."}
```

The Plotly.js version bundled with Visdom does not support this format, causing histograms and other plots with large datasets to render as empty graphs in the browser.

This patch adds recursive decoding for Plotly typed-array objects and converts them back into plain Python lists before sending figure data to the frontend, restoring compatibility with the bundled Plotly.js renderer.

## Motivation and Context

This change fixes rendering failures for histograms and other plots using large NumPy arrays.

The issue occurs because newer versions of `plotly-py` automatically optimize array serialization using typed-array encoding, while the older Plotly.js version bundled with Visdom cannot interpret that format.

As a result:
- smaller datasets render correctly
- larger datasets silently fail and appear as empty plots in the browser

This patch restores compatibility without changing existing plotting APIs or frontend behavior.

Fixes #927

## How Has This Been Tested?

Tested locally using Visdom from source with multiple histogram dataset sizes:

- Small dataset (`1,000` samples)
- Original failing case (`10,000` samples)
- Large stress-test dataset (`50,000` samples)

Verification steps:
- Ran Visdom server locally
- Generated histogram plots using NumPy arrays
- Confirmed plots render correctly in the browser
- Confirmed previously failing large datasets no longer render as empty graphs

Also verified that existing histogram rendering behavior remains unchanged for smaller datasets.

## Screenshots (if appropriate):

<img width="1470" height="619" alt="Screenshot 2026-05-11 at 12 22 20 AM" src="https://github.com/user-attachments/assets/58583ee8-caeb-4a7a-a76f-38626b67e86e" />


- Verified rendering for:
  - `1,000` sample histogram
  - `10,000` sample histogram (previously failing case)
  - `50,000` sample histogram stress test

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:

- [ ] I adapted the version number under `py/visdom/VERSION` according to Semantic Versioning
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Summary by Sourcery

Ensure Plotly figures using NumPy typed-array encoding are decoded to plain lists before being sent to the frontend so that large datasets render correctly with the bundled Plotly.js.

Bug Fixes:
- Fix empty Plotly plots in the browser when using newer plotly-py versions that serialize large NumPy arrays as typed-array objects.

Enhancements:
- Add a recursive decoder that converts Plotly typed-array objects in figure data back into plain Python lists for compatibility with the existing Plotly.js renderer.