### PR TITLE
Feat : Add Save All Environments feature to the UI

### DIFF
--- a/js/api/ApiProvider.js
+++ b/js/api/ApiProvider.js
@@ -236,6 +236,12 @@ const ApiProvider = ({ children }) => {
     });
   };
 
+  const sendSaveAll = () => {
+    sendSocketMessage({
+      cmd: 'save_all',
+    });
+  };
+
   // Update the pane layout item in the backend.
   const sendPaneLayoutUpdate = (
     envID,
@@ -297,6 +303,7 @@ const ApiProvider = ({ children }) => {
         sendPaneClose,
         sendPaneLayoutUpdate,
         sendPaneMessage,
+        sendSaveAll,
         sessionInfo,
         setConnected,
         toggleOnlineState,

--- a/js/topbar/EnvControls.js
+++ b/js/topbar/EnvControls.js
@@ -13,7 +13,7 @@ import React, { useContext, useState } from 'react';
 import ApiContext from '../api/ApiContext';
 
 function EnvControls(props) {
-  const { connected, sessionInfo } = useContext(ApiContext);
+  const { connected, sessionInfo, sendSaveAll } = useContext(ApiContext);
   const readonly = sessionInfo.readonly;
   const {
     envList,
@@ -112,6 +112,16 @@ function EnvControls(props) {
           onBlur={() => setConfirmClear(false)}
         >
           <span className="glyphicon glyphicon-erase" />
+        </button>
+        <button
+          data-toggle="tooltip"
+          title="Save All Environments"
+          data-placement="bottom"
+          className="btn btn-default"
+          disabled={!(connected && !readonly)}
+          onClick={sendSaveAll}
+        >
+          <span className="glyphicon glyphicon-floppy-disk" />
         </button>
         <button
           data-toggle="tooltip"

--- a/py/visdom/server/handlers/socket_handlers.py
+++ b/py/visdom/server/handlers/socket_handlers.py
@@ -118,7 +118,9 @@ class AnySocketHandlerOrWrapper(BaseWebSocketHandler):
                 serialize_env(self.state, [self.eid], env_path=self.env_path)
 
         elif cmd == "save_all":
-            serialize_all(self.state, env_path=self.env_path)
+            tornado.ioloop.IOLoop.current().run_in_executor(
+                None, serialize_all, self.state, self.env_path
+            )
 
         elif cmd == "delete_env":
             if "eid" in msg:

--- a/py/visdom/server/handlers/socket_handlers.py
+++ b/py/visdom/server/handlers/socket_handlers.py
@@ -28,6 +28,7 @@ from visdom.utils.server_utils import (
     check_auth,
     broadcast_envs,
     serialize_env,
+    serialize_all,
     send_to_sources,
     broadcast,
     escape_eid,
@@ -115,6 +116,9 @@ class AnySocketHandlerOrWrapper(BaseWebSocketHandler):
                 self.state[msg["eid"]]["reload"] = msg["data"]
                 self.eid = msg["eid"]
                 serialize_env(self.state, [self.eid], env_path=self.env_path)
+
+        elif cmd == "save_all":
+            serialize_all(self.state, env_path=self.env_path)
 
         elif cmd == "delete_env":
             if "eid" in msg:


### PR DESCRIPTION
## Description
Adds a Save All Environments button to the Visdom UI. Clicking this button sends a request to save all currently open environments at once,

---

## Motivation and Context
This change addresses issue #730.

When working with many environments during experimentation, users currently need to click the save button for each environment separately. The new button allows all open environments to be persisted with a single click.

---

## How Has This Been Tested?
1. Started the Visdom server locally.
2. Opened multiple environments in the UI.
3. Added plots and text to several environments.
4. Clicked the new "Save All Environments" button.
5. Restarted the Visdom server.
6. Verified that all environments were restored successfully.

---

## Video:

Before :


https://github.com/user-attachments/assets/b869d23e-00fc-4efd-9e57-0f616a7ea157



--- 

After :

https://github.com/user-attachments/assets/27f9f086-7b88-493f-a343-e813c5924462


---

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Summary by Sourcery

Add a UI control and backend command to save all open environments at once from the Visdom interface.

New Features:
- Add a Save All Environments button to the top bar, enabled when connected and not in read-only mode.
- Introduce a websocket command to trigger saving all environments on the server side.