### PR TITLE
Fix: bump download-artifact to v8 in prepare/action.yml

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -62,7 +62,7 @@ runs:
 
       # load artifacts from previous runs
       - name: "Load built js-files"
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: pr-build
           path: ./py/visdom/static/js/

--- a/.github/workflows/process-changes.yml
+++ b/.github/workflows/process-changes.yml
@@ -119,7 +119,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: ./.github/actions/prepare
 
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           name: cypress-init-screenshots
           path: cypress/screenshots_init


### PR DESCRIPTION
---
  ### Description

  Bump actions/download-artifact from v7 to v8 in .github/actions/prepare/action.yml to match the version in process-changes.yml updated by Dependabot PR #1338.

  ### Motivation and Context

  Dependabot PR #1338 bumped actions/download-artifact from v7 to v8 in process-changes.yml but missed the same dependency in the custom composite action
  .github/actions/prepare/action.yml. This keeps all usages consistent and avoids potential version mismatch issues.

  Fixes #1345 

 ### How Has This Been Tested?

  - Verified CI passes on PR #1338 with download-artifact@v8
  - This is a matching version bump in a composite action used by the same workflow

  ### Types of changes

  - Bug fix (non-breaking change which fixes an issue)

###  Checklist:

  - My code follows the code style of this project.

## Summary by Sourcery

Align artifact download actions to use the latest v8 version across CI workflows and the prepare composite action.

Bug Fixes:
- Resolve version mismatch of actions/download-artifact by updating remaining references from v7 to v8 in CI configuration.

CI:
- Update actions/download-artifact from v7 to v8 in the prepare composite action and process-changes workflow to keep CI dependencies consistent.