### PR TITLE
Fix: bump setup-node to v6 in prepare/action.yml

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -14,7 +14,7 @@ runs:
   using: "composite"
   steps:
       - name: "Setup Node" 
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '16'
 

--- a/.github/workflows/process-changes.yml
+++ b/.github/workflows/process-changes.yml
@@ -13,7 +13,7 @@ jobs:
     - name: "Checkout Repository"
       uses: actions/checkout@v6
     - name: "Install Node"
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v6
       with:
           node-version: 16
     - name: "Install Dependencies"

--- a/.github/workflows/update-js-build-files.yml
+++ b/.github/workflows/update-js-build-files.yml
@@ -18,7 +18,7 @@ jobs:
         # see: https://stackoverflow.com/questions/57921401/push-to-origin-from-github-action/58393457#58393457
         # with:
         #   token: ${{ secrets.PAT }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: '16'
       - run: ELECTRON_SKIP_BINARY_DOWNLOAD=1 npm install


### PR DESCRIPTION
###  Description

  Bump actions/setup-node from v3 to v6 in .github/actions/prepare/action.yml to match the version in process-changes.yml and update-js-build-files.yml updated by
  Dependabot PR #1339.

---

  ### Motivation and Context

  Dependabot PR #1339 bumped actions/setup-node from v3 to v6 in process-changes.yml and update-js-build-files.yml but missed the same dependency in the custom
  composite action .github/actions/prepare/action.yml. This keeps all usages consistent and avoids potential version mismatch issues.

  Fixes #1347

---

  ### How Has This Been Tested?

  - Verified CI passes on PR #1339 with setup-node@v6
  - This is a matching version bump in a composite action used by the same workflow

  ### Types of changes

  - Bug fix (non-breaking change which fixes an issue)

  ### Checklist:

  - My code follows the code style of this project.
 