### PR TITLE
fix: atomic env writes and optional periodic autosave

### DIFF
--- a/py/visdom/server/run_server.py
+++ b/py/visdom/server/run_server.py
@@ -65,6 +65,7 @@ def start_server(
     use_frontend_client_polling=False,
     bind_local=False,
     eager_data_loading=False,
+    autosave_interval=0,
 ):
     logging.info("Server started")
     app = Application(
@@ -84,6 +85,14 @@ def start_server(
     logging.info(f"Working directory: {os.path.abspath(env_path)}")
 
     atexit.register(serialize_all, app.state, env_path=env_path)
+
+    if autosave_interval > 0 and env_path is not None:
+        autosave_cb = ioloop.PeriodicCallback(
+            lambda: serialize_all(app.state, env_path=env_path),
+            int(autosave_interval * 1000),
+        )
+        autosave_cb.start()
+        logging.info(f"Autosave enabled every {autosave_interval}s")
 
     if "HOSTNAME" in os.environ and hostname == DEFAULT_HOSTNAME:
         hostname = os.environ["HOSTNAME"]
@@ -171,6 +180,13 @@ def main(print_func=None):
         action="store_true",
         help="Load data from filesystem when starting server (and not lazily upon first request).",
     )
+    parser.add_argument(
+        "-autosave_interval",
+        metavar="autosave_interval",
+        type=float,
+        default=0,
+        help="Periodically save all environments every N seconds (0 = disabled).",
+    )
     FLAGS = parser.parse_args()
 
     # Process base_url
@@ -256,6 +272,7 @@ def main(print_func=None):
         use_frontend_client_polling=FLAGS.use_frontend_client_polling,
         bind_local=FLAGS.bind_local,
         eager_data_loading=FLAGS.eager_data_loading,
+        autosave_interval=FLAGS.autosave_interval,
     )
 
 

--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -118,6 +118,26 @@ class LazyEnvData(Mapping):
         return len(self._raw_dict)
 
 
+def atomic_write_json(path, data):
+    """Write *data* as JSON to *path* via a temp file and atomic rename.
+
+    The temp file is placed alongside the destination so that os.replace()
+    operates within the same filesystem and is atomic on POSIX. On Windows
+    os.replace() is as safe as the platform allows.
+    """
+    tmp_path = path + ".tmp"
+    try:
+        with open(tmp_path, "w") as fn:
+            fn.write(json.dumps(data))
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
 def serialize_env(state, eids, env_path=DEFAULT_ENV_PATH):
     env_ids = [i for i in eids if i in state]
     if env_path is not None:
@@ -127,12 +147,12 @@ def serialize_env(state, eids, env_path=DEFAULT_ENV_PATH):
                     continue
             env_path_file = os.path.join(env_path, "{0}.json".format(env_id))
             try:
-                with open(env_path_file, "w") as fn:
-                    if isinstance(state[env_id], LazyEnvData):
-                        state[env_id].lazy_load_data()
-                        fn.write(json.dumps(state[env_id]._raw_dict))
-                    else:
-                        fn.write(json.dumps(state[env_id]))
+                if isinstance(state[env_id], LazyEnvData):
+                    state[env_id].lazy_load_data()
+                    data_to_save = state[env_id]._raw_dict
+                else:
+                    data_to_save = state[env_id]
+                atomic_write_json(env_path_file, data_to_save)
             except OSError as e:
                 if (
                     e.errno != errno.ENAMETOOLONG
@@ -143,14 +163,13 @@ def serialize_env(state, eids, env_path=DEFAULT_ENV_PATH):
                 env_path_file = os.path.join(
                     env_path, "hash_{0}.json".format(hashed_id)
                 )
-                with open(env_path_file, "w") as fn:
-                    if isinstance(state[env_id], LazyEnvData):
-                        state[env_id].lazy_load_data()
-                        data_to_save = copy.deepcopy(state[env_id]._raw_dict)
-                    else:
-                        data_to_save = copy.deepcopy(state[env_id])
-                    data_to_save["name"] = env_id
-                    fn.write(json.dumps(data_to_save))
+                if isinstance(state[env_id], LazyEnvData):
+                    state[env_id].lazy_load_data()
+                    data_to_save = copy.deepcopy(state[env_id]._raw_dict)
+                else:
+                    data_to_save = copy.deepcopy(state[env_id])
+                data_to_save["name"] = env_id
+                atomic_write_json(env_path_file, data_to_save)
 
     return env_ids
 

--- a/test/test_persistence.py
+++ b/test/test_persistence.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+
+# Copyright 2017-present, The Visdom Authors
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from visdom.utils.server_utils import atomic_write_json, serialize_env, LazyEnvData
+
+
+class TestAtomicWriteJson(unittest.TestCase):
+    def test_writes_correct_data(self):
+        with tempfile.TemporaryDirectory() as env_path:
+            path = os.path.join(env_path, "env.json")
+            atomic_write_json(path, {"jsons": {}, "reload": {}})
+            with open(path) as fn:
+                self.assertEqual(json.load(fn), {"jsons": {}, "reload": {}})
+
+    def test_no_tmp_file_left_after_success(self):
+        with tempfile.TemporaryDirectory() as env_path:
+            path = os.path.join(env_path, "env.json")
+            atomic_write_json(path, {"jsons": {}, "reload": {}})
+            self.assertFalse(os.path.exists(path + ".tmp"))
+
+    def test_existing_file_preserved_when_replace_fails(self):
+        with tempfile.TemporaryDirectory() as env_path:
+            path = os.path.join(env_path, "env.json")
+            atomic_write_json(path, {"original": True})
+
+            with patch("visdom.utils.server_utils.os.replace", side_effect=OSError):
+                with self.assertRaises(OSError):
+                    atomic_write_json(path, {"replacement": True})
+
+            with open(path) as fn:
+                self.assertEqual(json.load(fn), {"original": True})
+
+    def test_tmp_file_cleaned_up_when_replace_fails(self):
+        with tempfile.TemporaryDirectory() as env_path:
+            path = os.path.join(env_path, "env.json")
+            atomic_write_json(path, {"original": True})
+
+            with patch("visdom.utils.server_utils.os.replace", side_effect=OSError):
+                with self.assertRaises(OSError):
+                    atomic_write_json(path, {"replacement": True})
+
+            self.assertFalse(os.path.exists(path + ".tmp"))
+
+
+class TestSerializeEnv(unittest.TestCase):
+    def _make_state(self):
+        return {
+            "main": {
+                "jsons": {"win1": {"id": "win1", "type": "text", "content": "hello"}},
+                "reload": {"win1": {"x": 0, "y": 0}},
+            }
+        }
+
+    def test_keeps_legacy_json_format(self):
+        state = self._make_state()
+        with tempfile.TemporaryDirectory() as env_path:
+            saved = serialize_env(state, ["main"], env_path=env_path)
+
+            self.assertEqual(saved, ["main"])
+            with open(os.path.join(env_path, "main.json")) as fn:
+                on_disk = json.load(fn)
+            self.assertEqual(on_disk, state["main"])
+
+    def test_skips_unloaded_lazy_env(self):
+        with tempfile.TemporaryDirectory() as env_path:
+            env_file = os.path.join(env_path, "main.json")
+            with open(env_file, "w") as fn:
+                fn.write(json.dumps({"jsons": {}, "reload": {}}))
+
+            state = {"main": LazyEnvData(env_file)}
+            # LazyEnvData that has never been loaded should be skipped
+            saved = serialize_env(state, ["main"], env_path=env_path)
+            self.assertEqual(saved, ["main"])
+
+    def test_writes_atomically(self):
+        """serialize_env must not leave a .tmp file behind on success."""
+        state = self._make_state()
+        with tempfile.TemporaryDirectory() as env_path:
+            serialize_env(state, ["main"], env_path=env_path)
+            self.assertFalse(
+                os.path.exists(os.path.join(env_path, "main.json.tmp"))
+            )
+
+    def test_tmp_file_on_disk_does_not_prevent_normal_load(self):
+        """A leftover .tmp file from a previous crash must not shadow the good env."""
+        state = self._make_state()
+        with tempfile.TemporaryDirectory() as env_path:
+            serialize_env(state, ["main"], env_path=env_path)
+
+            # Simulate a .tmp file left by a previous interrupted write
+            tmp_path = os.path.join(env_path, "main.json.tmp")
+            with open(tmp_path, "w") as fn:
+                fn.write('{"jsons": "corrupt"}')
+
+            env_file = os.path.join(env_path, "main.json")
+            with open(env_file) as fn:
+                recovered = json.load(fn)
+            self.assertEqual(recovered, state["main"])
+
+    def test_only_requested_envs_are_saved(self):
+        state = {
+            "main": {"jsons": {}, "reload": {}},
+            "other": {"jsons": {}, "reload": {}},
+        }
+        with tempfile.TemporaryDirectory() as env_path:
+            saved = serialize_env(state, ["main"], env_path=env_path)
+
+            self.assertIn("main", saved)
+            self.assertNotIn("other", saved)
+            self.assertTrue(os.path.exists(os.path.join(env_path, "main.json")))
+            self.assertFalse(os.path.exists(os.path.join(env_path, "other.json")))
+
+
+class TestAutosaveInterval(unittest.TestCase):
+    def test_start_server_accepts_autosave_interval_kwarg(self):
+        """start_server signature must accept autosave_interval without error."""
+        import inspect
+        from visdom.server.run_server import start_server
+
+        params = inspect.signature(start_server).parameters
+        self.assertIn("autosave_interval", params)
+        self.assertEqual(params["autosave_interval"].default, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1332.

## Problem

If the server process is interrupted (crash, OOM, SIGKILL) while writing an environment JSON, the file can be left partially written. On the next startup, `load_state` / `LazyEnvData` would then read a truncated or invalid JSON, silently losing that environment's state.

There is also no way to limit how much work is lost between an unclean exit and the previous explicit save or server shutdown.

## Changes

**`py/visdom/utils/server_utils.py`**

- Add `atomic_write_json(path, data)`: writes JSON to `path + ".tmp"` first, then calls `os.replace()` to rename it into place. On POSIX this rename is atomic; on Windows it is as safe as the platform allows. If the rename fails the temp file is cleaned up and the original is left untouched.
- Update `serialize_env()` to use `atomic_write_json()` for both the normal write path and the long-filename hash-fallback path. The observable output format is unchanged.

**`py/visdom/server/run_server.py`**

- Add `-autosave_interval` CLI argument (float, default `0` = disabled).
- When `autosave_interval > 0`, start a `PeriodicCallback` that calls `serialize_all()` every N seconds. Combined with the existing `atexit` flush on clean shutdown, state loss on an unclean exit is bounded to at most one autosave interval.

No behaviour changes when `-autosave_interval` is not passed.

## Testing

- `python -m pytest test/test_persistence.py test/test_caption.py -v` — 18 tests, all pass
- New tests cover: correct data written, no `.tmp` file left on success, original file preserved when `os.replace` fails, temp file cleaned up on failure, legacy JSON format preserved, only requested envs saved, `.tmp` leftover on disk does not shadow a good env file, `autosave_interval` parameter present with default 0.

## Compatibility

- Existing env JSON files are read and written in the same format.
- `LazyEnvData` and the load path are untouched.
- `autosave_interval=0` (the default) leaves all existing behaviour identical.