### PR TITLE
fix: guard broadcasts against closed sockets and bound polling queue

### DIFF
--- a/py/visdom/server/handlers/socket_handlers.py
+++ b/py/visdom/server/handlers/socket_handlers.py
@@ -37,6 +37,10 @@ from visdom.utils.server_utils import (
 )
 from visdom.server.defaults import MAX_SOCKET_WAIT
 
+# Maximum number of messages buffered per polling client.
+# Oldest messages are dropped automatically once the limit is reached.
+MAX_POLLING_QUEUE = 200
+
 
 # TODO move the logic that actually parses environments and layouts to
 # new classes in the data_model folder.
@@ -193,7 +197,7 @@ class AnySocketWrapper(AnySocketHandlerOrWrapper):
     def initialize(self, app):
         super().initialize(app)
 
-        self.messages = deque()
+        self.messages = deque(maxlen=MAX_POLLING_QUEUE)
         self.last_read_time = time.time()
         self.open()
         try:
@@ -230,8 +234,8 @@ class AnySocketWrapper(AnySocketHandlerOrWrapper):
 
     def get_messages(self):
         to_send = []
-        messages = self.messages
-        self.messages = []
+        messages = list(self.messages)
+        self.messages.clear()
         for message in messages:
             if isinstance(message, dict):
                 # Not all messages are being formatted the same way (JSON)
@@ -257,8 +261,7 @@ class VisSocketHandlerOrWrapper(AnySocketHandlerOrWrapper):
         self.write_message(json.dumps({"command": "alive", "data": "vis_alive"}))
 
     def on_close(self):
-        if self in list(self.sources.values()):
-            self.sources.pop(self.sid, None)
+        self.sources.pop(self.sid, None)
 
     def on_message(self, message):
         msg = tornado.escape.json_decode(tornado.escape.to_basestring(message))
@@ -323,11 +326,9 @@ class SocketHandlerOrWrapper(AnySocketHandlerOrWrapper):
 
     def initialize(self, app):
         super().initialize(app)
-        self.broadcast_layouts()
 
     def on_close(self):
-        if self in list(self.subs.values()):
-            self.subs.pop(self.sid, None)
+        self.subs.pop(self.sid, None)
 
 
 class SocketHandler(SocketHandlerOrWrapper):

--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -24,6 +24,7 @@ import time
 import re
 import errno
 import tornado.escape
+import tornado.websocket
 from collections import OrderedDict
 
 MAX_ENV_NAME_LEN = 25
@@ -456,17 +457,22 @@ def compare_envs(state, eids, socket, env_path=DEFAULT_ENV_PATH):
 
 def broadcast_envs(handler, target_subs=None):
     if target_subs is None:
-        target_subs = handler.subs.values()
+        target_subs = list(handler.subs.values())
+    msg = json.dumps({"command": "env_update", "data": list(handler.state.keys())})
     for sub in target_subs:
-        sub.write_message(
-            json.dumps({"command": "env_update", "data": list(handler.state.keys())})
-        )
+        try:
+            sub.write_message(msg)
+        except tornado.websocket.WebSocketClosedError:
+            pass
 
 
 def send_to_sources(handler, msg):
-    target_sources = handler.sources.values()
-    for source in target_sources:
-        source.write_message(json.dumps(msg))
+    encoded = json.dumps(msg)
+    for source in list(handler.sources.values()):
+        try:
+            source.write_message(encoded)
+        except tornado.websocket.WebSocketClosedError:
+            pass
 
 
 def load_env(state, eid, socket, env_path=DEFAULT_ENV_PATH):
@@ -507,13 +513,19 @@ def load_env(state, eid, socket, env_path=DEFAULT_ENV_PATH):
 
 
 def broadcast(self, msg, eid):
-    for s in self.subs:
-        if isinstance(self.subs[s].eid, dict):
-            if eid in self.subs[s].eid:
-                self.subs[s].write_message(msg)
-        else:
-            if self.subs[s].eid == eid:
-                self.subs[s].write_message(msg)
+    for s in list(self.subs):
+        sub = self.subs.get(s)
+        if sub is None:
+            continue
+        try:
+            if isinstance(sub.eid, dict):
+                if eid in sub.eid:
+                    sub.write_message(msg)
+            else:
+                if sub.eid == eid:
+                    sub.write_message(msg)
+        except tornado.websocket.WebSocketClosedError:
+            pass
 
 
 def register_window(self, p, eid):

--- a/test/test_websocket.py
+++ b/test/test_websocket.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+
+# Copyright 2017-present, The Visdom Authors
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import unittest
+from collections import deque
+from unittest.mock import MagicMock, patch
+
+import tornado.websocket
+
+from visdom.server.handlers.socket_handlers import (
+    AnySocketWrapper,
+    MAX_POLLING_QUEUE,
+)
+from visdom.utils.server_utils import broadcast, broadcast_envs
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_wrapper():
+    """Return an AnySocketWrapper with a minimal app stub."""
+    app = MagicMock()
+    app.state = {"main": {"jsons": {}, "reload": {}}}
+    app.subs = {}
+    app.sources = {}
+    app.port = 8097
+    app.env_path = None
+    app.login_enabled = False
+    app.readonly = False
+
+    wrapper = AnySocketWrapper.__new__(AnySocketWrapper)
+    wrapper.polling = True
+    wrapper.app = app
+    wrapper.state = app.state
+    wrapper.subs = app.subs
+    wrapper.sources = app.sources
+    wrapper.port = app.port
+    wrapper.env_path = app.env_path
+    wrapper.login_enabled = app.login_enabled
+    wrapper.readonly = app.readonly
+    wrapper.messages = deque(maxlen=MAX_POLLING_QUEUE)
+    wrapper.last_read_time = 0.0
+    wrapper.eid = "main"
+    wrapper.sid = "test-sid"
+    return wrapper
+
+
+def _make_handler_stub(subs=None, sources=None, state=None):
+    """Return a minimal handler-like object for broadcast tests."""
+    h = MagicMock()
+    h.subs = subs if subs is not None else {}
+    h.sources = sources if sources is not None else {}
+    h.state = state if state is not None else {"main": {"jsons": {}, "reload": {}}}
+    return h
+
+
+# ---------------------------------------------------------------------------
+# Bounded polling queue
+# ---------------------------------------------------------------------------
+
+class TestPollingQueue(unittest.TestCase):
+    def test_queue_is_bounded_at_max_polling_queue(self):
+        wrapper = _make_wrapper()
+        for i in range(MAX_POLLING_QUEUE + 50):
+            wrapper.write_message(json.dumps({"n": i}))
+
+        self.assertEqual(len(wrapper.messages), MAX_POLLING_QUEUE)
+
+    def test_oldest_messages_dropped_when_full(self):
+        wrapper = _make_wrapper()
+        for i in range(MAX_POLLING_QUEUE + 10):
+            wrapper.write_message(json.dumps({"n": i}))
+
+        # The first message in the queue should be n=10 (oldest 10 were dropped)
+        first = json.loads(list(wrapper.messages)[0])
+        self.assertEqual(first["n"], 10)
+
+    def test_get_messages_drains_queue(self):
+        wrapper = _make_wrapper()
+        wrapper.write_message('{"a": 1}')
+        wrapper.write_message('{"b": 2}')
+
+        messages = wrapper.get_messages()
+        self.assertEqual(len(messages), 2)
+        self.assertEqual(len(wrapper.messages), 0)
+
+    def test_get_messages_preserves_maxlen_on_deque(self):
+        """get_messages() must not replace the bounded deque with a plain list."""
+        wrapper = _make_wrapper()
+        wrapper.write_message("msg")
+        wrapper.get_messages()
+
+        # Queue should still be a deque with maxlen after draining
+        self.assertIsInstance(wrapper.messages, deque)
+        self.assertEqual(wrapper.messages.maxlen, MAX_POLLING_QUEUE)
+
+
+# ---------------------------------------------------------------------------
+# Duplicate subscription prevention
+# ---------------------------------------------------------------------------
+
+class TestSubscriptionRegistration(unittest.TestCase):
+    def test_duplicate_registration_is_ignored(self):
+        """open() must not register the same object twice."""
+        wrapper = _make_wrapper()
+        # The wrapper is already set up as if open() ran;
+        # manually simulate a second open() call
+        subs = wrapper.subs
+        if wrapper.sid not in subs:
+            subs[wrapper.sid] = wrapper
+        if wrapper not in list(subs.values()):
+            subs[wrapper.sid] = wrapper
+
+        # Regardless of how many times we try, only one entry exists
+        self.assertEqual(len([v for v in subs.values() if v is wrapper]), 1)
+
+
+# ---------------------------------------------------------------------------
+# on_close() cleanup
+# ---------------------------------------------------------------------------
+
+class TestOnClose(unittest.TestCase):
+    def test_on_close_removes_from_subs(self):
+        """SocketHandlerOrWrapper.on_close() must remove the sub by key."""
+        from visdom.server.handlers.socket_handlers import SocketHandlerOrWrapper
+
+        handler = SocketHandlerOrWrapper.__new__(SocketHandlerOrWrapper)
+        handler.sid = "sub-1"
+        handler.subs = {"sub-1": handler}
+
+        handler.on_close()
+        self.assertNotIn("sub-1", handler.subs)
+
+    def test_on_close_tolerates_missing_sid(self):
+        """on_close() must not raise if sid is already gone."""
+        from visdom.server.handlers.socket_handlers import SocketHandlerOrWrapper
+
+        handler = SocketHandlerOrWrapper.__new__(SocketHandlerOrWrapper)
+        handler.sid = "gone"
+        handler.subs = {}
+
+        # Should not raise
+        handler.on_close()
+
+    def test_vis_on_close_removes_from_sources(self):
+        """VisSocketHandlerOrWrapper.on_close() must remove source by key."""
+        from visdom.server.handlers.socket_handlers import VisSocketHandlerOrWrapper
+
+        handler = VisSocketHandlerOrWrapper.__new__(VisSocketHandlerOrWrapper)
+        handler.sid = "src-1"
+        handler.sources = {"src-1": handler}
+
+        handler.on_close()
+        self.assertNotIn("src-1", handler.sources)
+
+
+# ---------------------------------------------------------------------------
+# broadcast() guards against closed WebSocket
+# ---------------------------------------------------------------------------
+
+class TestBroadcastGuard(unittest.TestCase):
+    def _make_sub(self, eid="main", raise_on_write=False):
+        sub = MagicMock()
+        sub.eid = eid
+        if raise_on_write:
+            sub.write_message.side_effect = tornado.websocket.WebSocketClosedError()
+        return sub
+
+    def test_broadcast_does_not_raise_on_closed_socket(self):
+        sub = self._make_sub(raise_on_write=True)
+        handler = _make_handler_stub(subs={"s1": sub})
+        # Must not propagate WebSocketClosedError
+        broadcast(handler, '{"command":"test"}', "main")
+
+    def test_broadcast_delivers_to_open_sockets(self):
+        good = self._make_sub(eid="main")
+        dead = self._make_sub(eid="main", raise_on_write=True)
+        handler = _make_handler_stub(subs={"g": good, "d": dead})
+
+        broadcast(handler, '{"command":"test"}', "main")
+
+        good.write_message.assert_called_once()
+
+    def test_broadcast_envs_does_not_raise_on_closed_socket(self):
+        sub = MagicMock()
+        sub.write_message.side_effect = tornado.websocket.WebSocketClosedError()
+        handler = _make_handler_stub(subs={"s1": sub})
+        # Must not propagate
+        broadcast_envs(handler)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_websocket.py
+++ b/test/test_websocket.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python3
-
+# SPDX-License-Identifier: Apache-2.0
 # Copyright 2017-present, The Visdom Authors
-# All rights reserved.
-#
-# This source code is licensed under the license found in the
-# LICENSE file in the root directory of this source tree.
 
 import json
 import unittest
@@ -108,18 +104,23 @@ class TestPollingQueue(unittest.TestCase):
 
 class TestSubscriptionRegistration(unittest.TestCase):
     def test_duplicate_registration_is_ignored(self):
-        """open() must not register the same object twice."""
-        wrapper = _make_wrapper()
-        # The wrapper is already set up as if open() ran;
-        # manually simulate a second open() call
-        subs = wrapper.subs
-        if wrapper.sid not in subs:
-            subs[wrapper.sid] = wrapper
-        if wrapper not in list(subs.values()):
-            subs[wrapper.sid] = wrapper
+        """Calling open() twice on the same handler registers it only once."""
+        from visdom.server.handlers.socket_handlers import AnySocketHandlerOrWrapper
 
-        # Regardless of how many times we try, only one entry exists
-        self.assertEqual(len([v for v in subs.values() if v is wrapper]), 1)
+        handler = AnySocketHandlerOrWrapper.__new__(AnySocketHandlerOrWrapper)
+        handler.subs = {}
+        handler.sources = {}
+
+        with patch(
+            "visdom.server.handlers.socket_handlers.get_rand_id",
+            return_value="fixed-sid",
+        ):
+            handler.open("subs")
+            handler.open("subs")
+
+        self.assertEqual(len(handler.subs), 1)
+        self.assertIn("fixed-sid", handler.subs)
+        self.assertIs(handler.subs["fixed-sid"], handler)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1331.

## Problem

Three distinct reliability issues in the websocket/polling transport layer:

**1. Unguarded `write_message()` in broadcast functions**

`broadcast()`, `broadcast_envs()`, and `send_to_sources()` iterate over subscriber dicts and call `write_message()` without catching `WebSocketClosedError`. If a client disconnects between the time it is selected for broadcast and the time `write_message()` executes, the exception propagates uncaught to the HTTP handler that triggered the broadcast (e.g. `PostHandler.post()`), causing that request to fail with a 500. The Python Visdom client then sees an HTTP error rather than a successful plot call.

**2. Unbounded polling message queue**

`AnySocketWrapper.messages` was an unbounded `deque()`. A polling client that stops polling but does not disconnect properly (network pause, browser tab backgrounded) accumulates messages until the 15-second monitor evicts it. Under high-frequency update workloads this can grow significantly.

Additionally `get_messages()` replaced `self.messages` with a plain `list` (`self.messages = []`), which would discard the `maxlen` constraint on every poll cycle — making a bounded deque useless after the first drain.

**3. Spurious layout broadcast on every new subscriber connection**

`SocketHandlerOrWrapper.initialize()` called `self.broadcast_layouts()` (to *all* subscribers) every time a new subscriber connected. For WebSocket connections this sent an unnecessary layout update to every already-connected browser. For polling connections it caused the new client to receive layouts twice: once from `initialize()` and once from `open()`, which already calls `self.broadcast_layouts([self])` to send layouts to the new subscriber only.

## Changes

**`py/visdom/server/handlers/socket_handlers.py`**

- Add `MAX_POLLING_QUEUE = 200` constant
- `AnySocketWrapper.initialize()`: `deque(maxlen=MAX_POLLING_QUEUE)` instead of unbounded `deque()`
- `AnySocketWrapper.get_messages()`: drain with `list()` + `.clear()` instead of reassigning `self.messages`, preserving the bounded deque
- `SocketHandlerOrWrapper.initialize()`: remove the `self.broadcast_layouts()` call; `open()` already handles sending layouts to the connecting subscriber
- `VisSocketHandlerOrWrapper.on_close()` and `SocketHandlerOrWrapper.on_close()`: use `dict.pop(sid, None)` directly instead of an O(n) value scan followed by O(1) key removal

**`py/visdom/utils/server_utils.py`**

- Add `import tornado.websocket`
- `broadcast()`: iterate over a snapshot (`list(self.subs)`), add `self.subs.get(s)` null check, and catch `WebSocketClosedError` per subscriber
- `broadcast_envs()`: iterate over a snapshot, encode message once, catch `WebSocketClosedError` per subscriber
- `send_to_sources()`: same pattern

## Testing

```
python -m pytest test/test_websocket.py test/test_caption.py -v
```

19 tests, all pass. New tests cover:
- Bounded queue capacity and oldest-message eviction
- `get_messages()` preserves the bounded deque after draining
- `on_close()` correct key removal and tolerance for already-removed sid
- `broadcast()` and `broadcast_envs()` do not raise on a closed socket and continue delivering to healthy subscribers

## Compatibility

- No message format changes
- No API changes
- Polling and WebSocket paths behave identically to before except for the three defects fixed above
- `MAX_POLLING_QUEUE = 200` is a conservative limit; a polling client receiving 200 queued messages in a single poll cycle was already effectively stalled