### PR TITLE
 fix: raise validation error when pane title is boolean or invalid non-string type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,3 @@ py/visdom/static/version.built
 __pycache__/
 py/visdom/static/js/layout_bin_packer.js
 py/visdom/extra_deps/**/*
-.venv
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ py/visdom/static/version.built
 __pycache__/
 py/visdom/static/js/layout_bin_packer.js
 py/visdom/extra_deps/**/*
+.venv
+.vscode

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -62,9 +62,7 @@ try:
         perplexity = (
             50
             if num_entities >= 150
-            else num_entities // 3
-            if num_entities >= 21
-            else 7
+            else num_entities // 3 if num_entities >= 21 else 7
         )
         Y = bhtsne.run_bh_tsne(
             X, initial_dims=X.shape[1], perplexity=perplexity, verbose=True
@@ -112,7 +110,7 @@ def isstr(s):
 
 
 def isnum(n):
-    return isinstance(n, numbers.Number)
+    return isinstance(n, numbers.Number) and not isinstance(n, bool)
 
 
 def isndarray(n):
@@ -444,7 +442,7 @@ def _assert_opts(opts):
         assert isnum(opts.get("fps")), "fps should be a number"
         assert opts.get("fps") > 0, "fps must be greater than 0"
 
-    if opts.get("title"):
+    if "title" in opts and opts.get("title") is not None:
         assert isstr(opts.get("title")), "title should be a string"
 
 

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -59,11 +59,12 @@ try:
         num_entities = len(X)
 
         # the number of entities provided must be at least 3x the perplexity
-        perplexity = (
-            50
-            if num_entities >= 150
-            else num_entities // 3 if num_entities >= 21 else 7
-        )
+        if num_entities >= 150:
+            perplexity = 50
+        elif num_entities >= 21:
+            perplexity = num_entities // 3
+        else:
+            perplexity = 7
         Y = bhtsne.run_bh_tsne(
             X, initial_dims=X.shape[1], perplexity=perplexity, verbose=True
         )


### PR DESCRIPTION
## Description
- Refined `isnum(n)` in `py/visdom/__init__.py` to exclude booleans (`not isinstance(n, bool)`), since Python's `bool` is a subclass of `int` and was previously treated as a valid number.
- Updated the title check in `_assert_opts(opts)` to check if `"title" in opts` instead of `if opts.get("title"):`. This prevents falsy values like `False`, `0`, or `[]` from bypassing validation.

## Motivation and Context
Fixes #1369.
Pane titles should always be strings. However, because `False` is falsy in Python, passing `opts=dict(title=False)` bypassed the string check in `_assert_opts`, causing type issues down the line.

## How Has This Been Tested?
- Verified manually in the python interpreter that passing `opts=dict(title=False)` to a plot method (like `viz.line`) now correctly throws `AssertionError: title should be a string`.
- Verified that numerical titles (like `title=123`) are still successfully cast to `"123"` with a warning (retaining the existing helper behaviour).
- Formatted Python changes using the project-enforced `black py` (v23.1.0) formatting checks.

## Screenshots (if appropriate):
Server logs
<img width="1251" height="397" alt="image" src="https://github.com/user-attachments/assets/ef941918-c233-46ff-83a7-e2b601f8dcea" />

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
- [ ] I adapted the version number under `py/visdom/VERSION` according to Semantic Versioning
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Summary by Sourcery

Strengthen option validation for plot pane titles to reject invalid non-string values, including booleans.

Bug Fixes:
- Prevent boolean values from being treated as valid numeric inputs by excluding bool from the generic number check.
- Ensure pane titles are validated whenever a title key is provided, even when its value is falsy.