### PR TITLE
fix(ci): use fetch/reset instead of rebase for static JS build workflow

### DIFF
--- a/.github/workflows/update-js-build-files.yml
+++ b/.github/workflows/update-js-build-files.yml
@@ -26,13 +26,14 @@ jobs:
         with:
           node-version: '16'
       - run: ELECTRON_SKIP_BINARY_DOWNLOAD=1 npm install
-      - run: npm run build
       - run: |
+          git fetch origin ${{ github.ref_name }}
+          git reset --hard origin/${{ github.ref_name }}
+          npm run build
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git add -f py/visdom/static/js/main.js py/visdom/static/js/main.js.map
           git diff --cached --quiet && echo "No changes to commit" && exit 0
           git commit -m "update static/js files"
-          git pull --rebase --autostash
           git push
 


### PR DESCRIPTION
 ## Description

  Replace `git pull --rebase --autostash` with `git fetch` + `git reset --hard` in the static JS build workflow.

  `main.js` and `main.js.map` are generated build artifacts  rebasing them causes conflicts when the branch advances during a build. Instead, reset to the latest remote state and rebuild from scratch, similar to how [Kitsu handles build artifacts](https://github.com/cgwire/kitsu/blob/main/.github/workflows/release.yml).


  ## Motivation and Context

## Fixes #1433
  When multiple PRs merge close together, `git pull --rebase --autostash` conflicts on minified JS files. These files can always be regenerated from `js/**` source, so rebasing them is unnecessary.


## Screenshot of Issue
<img width="1062" height="340" alt="image" src="https://github.com/user-attachments/assets/5114ae5d-ba01-4362-adef-713e96c690ae" />


  ## How Has This Been Tested?

  - Verified workflow YAML is valid
  - Reviewed logic against similar workflows (cgwire/kitsu)
  - Confirmed generated assets are rebuilt from source instead of rebased

  ## Types of changes

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

  ## Checklist

  - [ ] I adapted the version number under `py/visdom/VERSION` according to Semantic Versioning
  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.