### PR TITLE
fix: use functional state updater in closePane to prevent stale state

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -322,24 +322,20 @@ const App = () => {
     if (sessionInfo.readonly) {
       return;
     }
-    let newPanes = Object.assign({}, storeData.panes);
-    delete newPanes[paneID];
     if (!keepPosition) {
       localStorage.removeItem(keyLS(paneID));
       sendPaneClose(paneID, selection.envIDs[0]);
     }
 
     if (setState) {
-      // Make sure we remove the pane from our layout.
-      let newLayout = storeData.layout.filter(
-        (paneLayout) => paneLayout.i !== paneID
-      );
-
-      setStoreData((prev) => ({
-        ...prev,
-        layout: newLayout,
-        panes: newPanes,
-      }));
+      setStoreData((prev) => {
+        let newPanes = Object.assign({}, prev.panes);
+        delete newPanes[paneID];
+        let newLayout = prev.layout.filter(
+          (paneLayout) => paneLayout.i !== paneID
+        );
+        return { ...prev, panes: newPanes, layout: newLayout };
+      });
       setFocusedPaneID(focusedPaneID === paneID ? null : focusedPaneID);
       callbacks.current.push('relayout');
     }


### PR DESCRIPTION
##  Description

  Use prev inside setStoreData updater in closePane() instead of reading storeData from the closure.

---

##  Motivation and Context

  When a pane is closed, the server broadcasts the close command back to all clients. This triggers closePane() a second time, but the second call captures stale storeData from its closure (React hasn't re-rendered yet). The stale copy overwrites current state, causing panes to reappear or layout inconsistencies.

---

## Result 


https://github.com/user-attachments/assets/1705cb8f-889b-4fb4-ad58-40f7799ab102



## How Has This Been Tested?

  - Created multiple panes, closed one  only the target pane disappears
  - No duplicate panes appear after closing

---

 ## Types of changes

  - Bug fix (non-breaking change which fixes an issue)
  - New feature (non-breaking change which adds functionality)
  - Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - Code refactor or cleanup (changes to existing code for improved readability or performance)

---

 ## Checklist:

  - I adapted the version number under py/visdom/VERSION according to https://semver.org/
  - My code follows the code style of this project.
  - My change requires a change to the documentation.
  - I have updated the documentation accordingly.