### PR TITLE
Stabilize Cypress visual fixed env cleanup

### DIFF
--- a/cypress/integration/screenshots.init.js
+++ b/cypress/integration/screenshots.init.js
@@ -27,7 +27,11 @@ describe(`Take compare-view screenshots`, () => {
 
       var envs = [];
       for (var i = 0; i < num_runs; i++) {
-        var env = run + '_' + i + '_fixed';
+        envs.push(run + '_' + i + '_fixed');
+      }
+      cy.delete_envs(envs);
+      for (var i = 0; i < num_runs; i++) {
+        var env = envs[i];
         cy.run(run, {
           env: env,
           open: false,
@@ -35,7 +39,6 @@ describe(`Take compare-view screenshots`, () => {
           args: [run],
           asyncrun: i != num_runs - 1,
         });
-        envs.push(env);
       }
       cy.close_envs();
       for (var i = 0; i < num_runs; i++) {
@@ -54,6 +57,7 @@ describe(`Take screenshot for PlotPane functions`, () => {
     var run = 'line_smoothing';
     var env1 = run + '_1_fixed';
     var env2 = run + '_2_fixed';
+    cy.delete_envs([env1, env2]);
     cy.run('plot_line_basic', {
       env: env1,
       args: ["'Line smoothing'", 100],

--- a/cypress/integration/screenshots.js
+++ b/cypress/integration/screenshots.js
@@ -94,7 +94,11 @@ describe(`Compare with compare-view screenshots`, () => {
 
       var envs = [];
       for (var i = 0; i < num_runs; i++) {
-        var env = run + '_' + i + '_fixed';
+        envs.push(run + '_' + i + '_fixed');
+      }
+      cy.delete_envs(envs);
+      for (var i = 0; i < num_runs; i++) {
+        var env = envs[i];
         cy.run(run, {
           env: env,
           open: false,
@@ -102,7 +106,6 @@ describe(`Compare with compare-view screenshots`, () => {
           args: [run],
           asyncrun: i != num_runs - 1,
         });
-        envs.push(env);
       }
       cy.close_envs();
       for (var i = 0; i < num_runs; i++) {
@@ -155,6 +158,7 @@ describe(`Compare screenshots for plotpane functions`, () => {
     var run = 'line_smoothing';
     var env1 = run + '_1_fixed';
     var env2 = run + '_2_fixed';
+    cy.delete_envs([env1, env2]);
     cy.run('plot_line_basic', {
       env: env1,
       args: ["'Line smoothing'", 100],

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -48,11 +48,24 @@ Cypress.Commands.add('run', (name, opts) => {
   }
 });
 
-Cypress.Commands.add('close_envs', () => {
-    cy.get('body').then($body => {
+const clearEnvSelection = (remainingAttempts = 4) => {
+    return cy.get('body').then($body => {
         if ($body.find('.rc-tree-select-selection__clear').length > 0) {
-            cy.get('.rc-tree-select-selection__clear').click()
+            return cy
+                .get('.rc-tree-select-selection__clear')
+                .click({force: true})
         }
+        if (remainingAttempts > 0) {
+            return cy.wait(250).then(() => {
+                return clearEnvSelection(remainingAttempts - 1)
+            })
+        }
+    })
+}
+
+Cypress.Commands.add('close_envs', () => {
+    return cy.get('.rc-tree-select', {timeout: 10000}).then(() => {
+        return clearEnvSelection()
     })
 });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -56,6 +56,17 @@ Cypress.Commands.add('close_envs', () => {
     })
 });
 
+Cypress.Commands.add('delete_envs', (names) => {
+    names.forEach((name) => {
+        cy.request({
+            method: 'POST',
+            url: '/delete_env',
+            body: {eid: name},
+            failOnStatusCode: false,
+        });
+    });
+});
+
 Cypress.Commands.add('open_env', (name) => {
     cy.get('.rc-tree-select').click()
     cy.get('.rc-tree-select-tree').then($tree => {
@@ -66,4 +77,3 @@ Cypress.Commands.add('open_env', (name) => {
     cy.get('.rc-tree-select-tree').contains(name).click()
     cy.get('.rc-tree-select').click({force: true}) // ignore any elements that might cover the list at this point
 });
-


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

### Summary

- Add a Cypress helper that deletes Visdom environments through the existing
  `POST /delete_env` endpoint.
- Clear deterministic `*_fixed` environments before recreating compare-view
  visual test environments.
- Clear the deterministic line-smoothing environments before recreating them.
- Make `cy.close_envs()` wait for the env selector before clearing the selected
  environment, which avoids a polling-mode race where `main` can remain
  selected across specs.

### Why

Related to #1197.

The visual baseline and visual comparison specs both use deterministic Visdom
environment names such as `plot_line_basic_0_fixed`. `cy.close_envs()` only
clears the UI selection and does not delete server-side environments.

When `npm run test:init` and `npm run test:visual` are run locally against the
same server and `env_path`, the comparison run can reuse or update the fixed
environments from the baseline run. That produces large compare-view pixel
diffs unrelated to the UI under test.

The polling functional workflow also exposed a race in `cy.close_envs()`: the
helper checked once for `.rc-tree-select-selection__clear` before the polling UI
finished rendering the selected `main` environment. Waiting for the selector and
retrying the clear control keeps the helper aligned with the UI state.

### Verification

Local:

- `SHELL=/bin/bash PATH="$PWD/.venv/bin:$PATH" CYPRESS_VERIFY_TIMEOUT=120000 npx cypress run --config 'ignoreTestFiles=screenshots.*'`
  - Passed: 136/136 before the upstream export spec was merged.
- `SHELL=/bin/bash PATH="$PWD/.venv/bin:$PATH" CYPRESS_VERIFY_TIMEOUT=120000 npm run test:init`
  - Passed: 75/75 on a clean server/env path.
- Before this patch, same-server `npm run test:visual` after `test:init`
  failed 27 cases, mostly compare-view.
- A fresh-server control reduced visual failures to 4 and made compare-view
  pass, confirming the compare-view cluster was server environment carryover.
- After the env-deletion patch, dirty-server `npm run test:visual` had all
  compare-view and line-smoothing cases pass.
- `SHELL=/bin/bash PATH="$PWD/.venv/bin:$PATH" npx cypress run --spec "cypress/integration/basic.js,cypress/integration/export.js" --config video=false`
  - Passed: 9/9 with frontend client polling enabled on the local server.
- `npm run lint`
  - Passed.

GitHub Actions on this PR:

- `Functional Test (Polling)` passed.
- `Functional Test (Websocket)` passed for Python 3.10, 3.11, and 3.12.
- `Initialize Visual Regression Test` passed.
- `Visual Regression Test` passed.
- JS/Python linters and install/build passed.

### Residual

This does not claim to fix every Windows rendering issue in #1197. Residual
plain screenshot pixel diffs remain and should be handled separately:

- `plot_scatter_append`
- `plot_scatter_custom_marker`
- `plot_scatter_add_trace`
- `plot_surface_contour`
- `misc_video_tensor`
