### PR TITLE
fix(ci) : use aria-label selector in export test to fix polling mode flakiness

### DIFF
--- a/cypress/integration/export.js
+++ b/cypress/integration/export.js
@@ -26,6 +26,7 @@ describe('Test Export Env as HTML', () => {
   };
 
   it('Export button is disabled when no env is open', () => {
+    cy.get('.rc-tree-select-selection__clear').should('exist');
     cy.close_envs();
     cy.get(exportButton).should('be.disabled');
   });

--- a/cypress/integration/export.js
+++ b/cypress/integration/export.js
@@ -1,4 +1,4 @@
-const exportButton = 'button[data-original-title="Export as HTML"]';
+const exportButton = 'button[aria-label="Export as HTML"]';
 
 beforeEach(() => {
   cy.visit('/');


### PR DESCRIPTION
## Description

  Fix flaky export.js Cypress test in polling mode by replacing the data-original-title selector with aria-label.

---

  ## Fixes

  The export.js test introduced in #1198 uses button[data-original-title="Export as HTML"] to locate the export button. data-original-title is set lazily by Bootstrap's tooltip plugin  in polling mode, the tooltip hasn't initialized when Cypress queries the DOM, causing a 4000ms timeout. aria-label="Export as HTML" is set directly in the JSX and is available immediately.

---

  ## How Has This Been Tested?

  - Verified the aria-label attribute exists on the Export button in js/topbar/ViewControls.js
  - The fix targets the exact failure seen in CI: Functional Test (Polling) > export.js > "Export button is disabled when no env is open"

---

 ## Types of changes

  - Bug fix (non-breaking change which fixes an issue)

--

  Checklist:

  - I adapted the version number under py/visdom/VERSION according to https://semver.org/
  - My code follows the code style of this project.
  - My change requires a change to the documentation.
  - I have updated the documentation accordingly.

## Summary by Sourcery

Fix flaky Cypress export test by using a stable aria-label selector for the export button and ensuring the env-clear control is present before asserting the button state.

Bug Fixes:
- Use the export button's aria-label attribute instead of the lazily-set data-original-title to locate it in Cypress tests, avoiding polling-related timeouts.
- Ensure the tree-select clear control is present before closing environments in the export button disabled-state test to reduce flakiness.