### PR TITLE
fix: delete trace by name crashes server when two traces share the same name

### DIFF
--- a/py/visdom/server/handlers/web_handlers.py
+++ b/py/visdom/server/handlers/web_handlers.py
@@ -183,8 +183,8 @@ class UpdateHandler(BaseHandler):
 
         # Delete a trace
         if args.get("delete"):
-            for idx in idxs:
-                del pdata[idx]
+            idxs_set = set(idxs)
+            p["content"]["data"] = [e for i, e in enumerate(pdata) if i not in idxs_set]
             return p
 
         # add new heatmap data if plot has been deleted previously


### PR DESCRIPTION
## Description
Replace the in-place `del pdata[idx]` loop in `UpdateHandler.update()` with a list comprehension that rebuilds the trace list excluding the deleted positions.


## Motivation and Context

When a plot window contains two or more traces with the same name, calling `update="remove"` to delete that trace by name crashed the server with HTTP 500.

The bug was in the delete loop in `web_handlers.py`:
  ```python
  # before
  for idx in idxs:
      del pdata[idx]
```
`idxs` holds the list positions of all matching traces, collected before any deletion happens. Each `del pdata[idx]` physically removes an element and shifts everything after it forward by one — so by the time the second index is used, it points to the wrong element or past the end of the list, raising `IndexError`.

The fix collects the positions into a set and rebuilds the list in a single pass, which is safe regardless of how many traces share the same name.  

Fixes #1461 .

## How Has This Been Tested?
Started the Visdom server locally and ran a test script that:
  
1. Creates a line plot with three traces — `keep_me`, `dup_trace`, `dup_trace`
2. POSTs a delete-by-name request for `dup_trace`
3. Asserts the server returns HTTP 200 (previously returned 500)
4. Verifies visually in the browser that only `keep_me` remains

Before the fix: server returned 500 with IndexError: list assignment index out of range.
After the fix: server returns 200 and only the non-matching trace survives.

## Screenshots (if appropriate):

**Before Fix**:
<img width="1384" height="470" alt="image" src="https://github.com/user-attachments/assets/69b0f6a1-efe4-4ef7-8263-e3ca539c14d8" />

**After Fix**:
<img width="1384" height="201" alt="image" src="https://github.com/user-attachments/assets/27b56131-5c45-4cf6-a996-ce00291ff608" />


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Summary by Sourcery

Bug Fixes:
- Prevent server crashes when deleting a trace by name in plots that contain multiple traces with the same name by rebuilding the trace list instead of deleting elements in-place.