### PR TITLE
[SECURITY] Fix auth bypass in polling socket handler

### DIFF
--- a/py/visdom/server/handlers/socket_handlers.py
+++ b/py/visdom/server/handlers/socket_handlers.py
@@ -390,6 +390,7 @@ def WrapSocketWrapper(BaseWrapper):
             self.login_enabled = app.login_enabled
             self.app = app
 
+        @check_auth
         def post(self):
             """Either write a message to the socket, or query what's there"""
             args = tornado.escape.json_decode(


### PR DESCRIPTION
## Problem
A vulnerability was discovered where `dangerouslySetInnerHTML` in `EmbeddingsPane` and `TextPane` could be exploited to run XSS payloads. However, these components process raw `innerHTML` by design. The expected security model relies on strict backend authentication to prevent malicious inputs from ever being broadcasted.

The root cause vulnerability existed in the backend polling socket wrapper. The `WrappedSocketWrap.post()` method was missing the `@check_auth` decorator. This critical omission allowed unauthenticated users to send arbitrary POST requests containing malicious data, which the server would then blindly broadcast to all connected clients (leading to XSS).

## Solution
Added the missing `@check_auth` decorator to `WrappedSocketWrap.post` in `py/visdom/server/handlers/socket_handlers.py`. This ensures that polling clients cannot bypass authentication, closing the vulnerability without breaking the intentional, rich-HTML rendering capabilities of `TextPane` and `EmbeddingsPane`.

## Summary by Sourcery

Bug Fixes:
- Require authentication for the polling socket POST endpoint by adding the missing auth check decorator.