### PR TITLE
feat: Migrate misc and text E2E test suites to Playwright

### DIFF
--- a/playwright/support/helpers.js
+++ b/playwright/support/helpers.js
@@ -8,6 +8,28 @@
  */
 
 const { spawn, spawnSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+function getPythonExecutable() {
+  const isWin = process.platform === 'win32';
+  const pyRelativePath = isWin ? ['Scripts', 'python.exe'] : ['bin', 'python'];
+  const fallback = isWin ? 'python' : 'python3';
+
+  if (process.env.VIRTUAL_ENV) {
+    return path.join(process.env.VIRTUAL_ENV, ...pyRelativePath);
+  }
+  const rootDir = path.join(__dirname, '..', '..');
+  const localVenv = path.join(rootDir, '.venv', ...pyRelativePath);
+  if (fs.existsSync(localVenv)) {
+    return localVenv;
+  }
+  const localVenvAlt = path.join(rootDir, 'venv', ...pyRelativePath);
+  if (fs.existsSync(localVenvAlt)) {
+    return localVenvAlt;
+  }
+  return fallback;
+}
 
 async function runDemo(page, name, opts = {}) {
   const saveto = opts.env || `${name}_${Math.floor(Math.random() * 1e6)}`;
@@ -26,19 +48,27 @@ async function runDemo(page, name, opts = {}) {
     spawnArgs.push('-seed', String(opts.seed));
   }
   if (opts.args && opts.args.length > 0) {
-    spawnArgs.push('-arg', ...opts.args.map(String));
+    spawnArgs.push('-args', ...opts.args.map(String));
   }
 
+  const pythonBin = getPythonExecutable();
+
   if (opts.asyncrun) {
-    const child = spawn('python', spawnArgs, {
+    const child = spawn(pythonBin, spawnArgs, {
       stdio: 'ignore',
       detached: true,
     });
     child.unref();
   } else {
-    spawnSync('python', spawnArgs, {
-      stdio: 'ignore',
+    const result = spawnSync(pythonBin, spawnArgs, {
+      stdio: 'pipe',
+      encoding: 'utf-8',
     });
+    if (result.status !== 0) {
+      throw new Error(
+        `Failed to run demo '${name}'. Exit code: ${result.status}.\nStderr: ${result.stderr}\nStdout: ${result.stdout}`
+      );
+    }
   }
 
   if (opts.open === undefined || opts.open) {
@@ -60,12 +90,12 @@ async function closeEnvs(page) {
 async function expandAllEnvGroups(page) {
   const closedGroups = page.locator('.rc-tree-select-tree-switcher_close');
   let count = await closedGroups.count();
-  while (count > 0) {
-    for (let i = 0; i < count; i++) {
-      await closedGroups.nth(i).click({ force: true });
-      await page.waitForTimeout(150);
-    }
+  let attempts = 0;
+  while (count > 0 && attempts < 50) {
+    await closedGroups.first().click({ force: true });
+    await page.waitForTimeout(150);
     count = await closedGroups.count();
+    attempts++;
   }
 }
 

--- a/playwright/tests/misc.spec.js
+++ b/playwright/tests/misc.spec.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2017-present, The Visdom Authors
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+const { test, expect } = require('@playwright/test');
+const { runDemo } = require('../support/helpers');
+
+test.describe('Misc Tests', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('plot_special_graph', async ({ page }) => {
+    await runDemo(page, 'plot_special_graph');
+
+    await expect(page.locator('svg line')).toHaveCount(6);
+    await expect(page.locator('svg path')).toHaveCount(6);
+    await expect(page.locator('svg text')).toHaveCount(12);
+    await expect(page.locator('svg g')).toHaveCount(6);
+  });
+});

--- a/playwright/tests/text.spec.js
+++ b/playwright/tests/text.spec.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2017-present, The Visdom Authors
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+const { test, expect } = require('@playwright/test');
+const { runDemo } = require('../support/helpers');
+
+test.describe('Text Pane', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('text_basic', async ({ page }) => {
+    await runDemo(page, 'text_basic');
+    const pane = page.locator('.layout .react-grid-item').first();
+    await expect(pane).toContainText('Hello World!');
+  });
+
+  test('text_update', async ({ page }) => {
+    await runDemo(page, 'text_update');
+    const pane = page.locator('.layout .react-grid-item').first();
+    await expect(pane).toContainText('Hello World! More text should be here');
+    await expect(pane).toContainText('And here it is');
+  });
+
+  test('check download button', async ({ page }) => {
+    await runDemo(page, 'text_update');
+    const pane = page.locator('.layout .react-grid-item').first();
+    const saveBtn = pane.locator('button[title="save"]').first();
+
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      saveBtn.click(),
+    ]);
+
+    expect(download.suggestedFilename()).toBe('visdom_text.txt');
+  });
+
+  test('text_callbacks', async ({ page }) => {
+    await runDemo(page, 'text_callbacks', { asyncrun: true });
+
+    const content = page.locator('.window .content').first();
+    await content.waitFor({ state: 'visible' });
+
+    const bar = page.locator('.bar').first();
+    await bar.click();
+
+    const layoutWrapper = page.locator('.no-focus');
+
+    const text = 'checking callback :(';
+    for (let char of text) {
+      await layoutWrapper.focus();
+      await page.keyboard.type(char);
+      await page.waitForTimeout(50);
+    }
+
+    await layoutWrapper.focus();
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(50);
+
+    await layoutWrapper.focus();
+    await page.keyboard.type(')');
+
+    await expect(content).toContainText('checking callback :)');
+  });
+
+  test('text_close', async ({ page }) => {
+    await runDemo(page, 'text_close');
+    await expect(page.locator('.layout .window')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
This PR migrates the E2E tests for the `misc` (special graph plotting) and `text` (text pane basics, updates, downloads, and callbacks) suites from Cypress to Playwright.
As part of this migration, I also cleaned up and resolved a few E2E testing issues in `playwright/support/helpers.js`:
- **Python path resolver**: Added `getPythonExecutable()` to automatically search for local `.venv` or `venv` folders. This fixes `spawn python ENOENT` errors if the virtual environment is not explicitly activated in the running terminal.
- **Directory expansion hang**: Fixed a loop in `expandAllEnvGroups()` where index-based iteration caused Playwright to hang. Since expanding directories dynamically changes switcher classes, we now safely click the first closed directory in a simple loop.
- **Handling text input callbacks**: Visdom's text pane uses global keyup events and updates the component via WebSockets on every character, causing it to lose focus. I updated the callback test to focus the pane header and type character-by-character, keeping focus on the wrapper element.

Successor of #https://github.com/fossasia/visdom/pull/1541

## Motivation and Context
Continues the transition from Cypress to Playwright to make E2E runs faster, more stable, and easier to debug.

## How Has This Been Tested?
Tested locally in the workspace
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
