### PR TITLE
Remove leftover debug print statements from RegionSelected update handler

### DIFF
--- a/py/visdom/server/handlers/web_handlers.py
+++ b/py/visdom/server/handlers/web_handlers.py
@@ -132,13 +132,11 @@ class UpdateHandler(BaseHandler):
                 p["content"]["selected"] = args["data"]["selected"]
             elif args["data"]["update_type"] == "RegionSelected":
                 p["content"]["selected"] = None
-                print(len(p["content"]["data"]))
                 p["old_content"].append(p["content"]["data"])
                 if len(p["old_content"]) > max_old_content:
                     p["old_content"] = p["old_content"][-max_old_content:]
                 p["content"]["has_previous"] = True
                 p["content"]["data"] = args["data"]["points"]
-                print(len(p["content"]["data"]))
             return p
         if p["type"] == "image_history":
             utype = args["data"][0]["type"]


### PR DESCRIPTION
## Description

This pull request removes two leftover debug `print()` statements from the `RegionSelected` branch of `UpdateHandler.update`.

## Motivation and Context

The debug statements printed the length of the data array to the server console every time a `RegionSelected` update was processed. Since they are not required for normal operation, removing them prevents unnecessary console output.

Fixes #1525

## How Has This Been Tested?

* Reviewed the code changes to ensure only the two debug `print()` statements were removed.
* Verified that no functional logic was modified.

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist

* [ ] I adapted the version number under `py/visdom/VERSION` according to Semantic Versioning.
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
