### PR TITLE
feat: allow disabling embeddings event registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ The function accepts the following arguments:
 - `labels`: a list of corresponding labels for the tensors provided for `features`
 - `data_getter=fn`: (optional) a function that takes as a parameter an index into the features array and returns a summary representation of the tensor. If this is set, `data_type` must also be set.
 - `data_type=str`: (optional) currently the only acceptable value here is `"html"`
+- `opts.register_embedding_events`: (optional) set to `False` to skip registering the default Python client event handler for hover previews and lasso drilldown. This leaves embeddings interaction events for external server or frontend code to handle.
 
 We currently assume that there are no more than 10 unique labels, in the future we hope to provide a colormap in opts for other cases.
 

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -1675,12 +1675,10 @@ class Visdom(object):
             endpoint="events",
         )
 
-        # Register the handlers for managing this embeddings pane
-        # TODO allow disabling this in a way that pushes onus for calculating
-        # to the server or frontend client
-        self._register_embeddings(
-            features, labels, points, data_getter, data_type, win, env, opts
-        )
+        if opts.get("register_embedding_events", True):
+            self._register_embeddings(
+                features, labels, points, data_getter, data_type, win, env, opts
+            )
         return win
 
     @pytorch_wrap


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add `opts.register_embedding_events` to `vis.embeddings()`

- Allow users to opt out of the default Python client event handler registration.
- Preserve existing default behavior when option is not set.
- Add documentation and tests for both default and opt-out behaviors.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix `TODO` comment
```
# allow disabling this in a way that pushes onus for calculating
        # to the server or frontend client
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, experiments you ran to see how -->
<!--- your change affects existing areas of the code and their behaviors, etc. -->
<!--- One method of testing is to run the `demo.py` script from the examples -->
<!--- both on your branch and a clean branch and ensure that none of the functionality -->
<!--- appears different. Be sure to install from source when testing. -->
N/A

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
