### PR TITLE
fix: guard smoothing against traces missing x values in plotlyplot

### DIFF
--- a/js/panes/PlotPane.js
+++ b/js/panes/PlotPane.js
@@ -183,7 +183,7 @@ var PlotPane = (props) => {
           smooth_d.showlegend = false;
 
           // turn off smoothing for smoothvalue of 3 or too small arrays
-          if (windowSize < 5 || smooth_d.x.length <= 5) {
+          if (windowSize < 5 || !smooth_d.x || smooth_d.x.length <= 5) {
             d.opacity = 1.0;
 
             return smooth_d;


### PR DESCRIPTION
## Description
Guard the Plotly-pane smoothing code against traces that have no `x` values.

## Motivation and Context
`viz.plotlyplot()` forwards Plotly figures as-is, and a `mode='lines'` trace with only `y` (no `x`) is valid, common Plotly usage. Enabling smoothing on such a trace throws `TypeError: Cannot read properties of undefined (reading 'length')` in `PlotPane.js` and it shows a blank page.

## How Has This Been Tested?
1. Start the server 
2. Run the following script:
```python3 
import plotly.graph_objects as go
from visdom import Visdom

viz = Visdom(env="plotbug")

fig = go.Figure(data=go.Scatter(y=[1, 2, 3, 4, 5, 6, 7, 8], mode="lines"))
fig.update_layout(title="line with no x")
win = viz.plotlyplot(fig, win="plotbug")
```

## Screenshots (if appropriate):

Before Fix:

https://github.com/user-attachments/assets/cbf48ee8-c6d0-4f80-b0db-54c2d88bf6c6

After Fix: 

https://github.com/user-attachments/assets/df8868f4-23f4-46a0-88e5-65f6d65770c0



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
