### PR TITLE
fix: env with trailing whitespace treated as two different env

### DIFF
--- a/py/tests/unit/data_model.py
+++ b/py/tests/unit/data_model.py
@@ -18,7 +18,7 @@ import tempfile
 import unittest
 
 from visdom.data_model import JSONStore, DataStore
-from visdom.utils.server_utils import LazyEnvData
+from visdom.utils.server_utils import LazyEnvData, extract_eid
 
 
 def _env(win_id="win_0"):

--- a/py/tests/unit/data_model.py
+++ b/py/tests/unit/data_model.py
@@ -123,6 +123,28 @@ class TestJSONStore(unittest.TestCase):
         self.assertEqual(ret, [])
         self.assertFalse(self.backend.env_exists("lazy"))
 
+    def test_whitespace_differing_eids_no_longer_collide(self):
+        """'main' and 'main ' must not silently overwrite each other on disk.
+
+        Regression test: the in-memory state dict is keyed by
+        ``extract_eid(args)``, while JSONStore derives filenames via its own
+        whitespace-stripping ``_safe_eid``. Before ``escape_eid`` also
+        stripped whitespace, two distinct in-memory envs differing only by
+        surrounding whitespace would collide on disk (whichever saved last
+        would clobber the other). Now both normalise to the same id, so this
+        is expected, intentional behaviour rather than an accidental clobber.
+        """
+        eid_a = extract_eid({"eid": "main"})
+        eid_b = extract_eid({"eid": "main "})
+        self.assertEqual(eid_a, eid_b)  # they are now (correctly) one env
+
+        self.backend.save_env(eid_a, _env("winA"))
+        self.backend.save_env(eid_b, _env("winB"))
+        # Only one file exists on disk, holding the last write - not two
+        # environments silently fighting over the same filename.
+        self.assertEqual(self.backend.list_envs(), ["main"])
+        self.assertEqual(self.backend.load_env("main")["jsons"], _env("winB")["jsons"])
+
     def test_save_writes_materialised_lazy_env(self):
         """A LazyEnvData that has been loaded is persisted by save."""
         self.backend.save_env("lazy", _env())

--- a/py/tests/unit/server_utils.py
+++ b/py/tests/unit/server_utils.py
@@ -49,6 +49,29 @@ class TestEscapeEid(unittest.TestCase):
     def test_empty_string(self):
         self.assertEqual(escape_eid(""), "")
 
+    def test_leading_whitespace_stripped(self):
+        self.assertEqual(escape_eid("  main"), "main")
+
+    def test_trailing_whitespace_stripped(self):
+        self.assertEqual(escape_eid("main  "), "main")
+
+    def test_surrounding_whitespace_stripped(self):
+        self.assertEqual(escape_eid("  main  "), "main")
+
+    def test_whitespace_only_differing_ids_collapse_to_same_value(self):
+        """'main' and 'main ' must normalise identically.
+
+        JSONStore strips whitespace before deriving an on-disk filename, so
+        if escape_eid did not also strip, these two eids would stay distinct
+        in the in-memory state dict while silently colliding on disk.
+        """
+        self.assertEqual(escape_eid("main"), escape_eid("main "))
+        self.assertEqual(escape_eid("main"), escape_eid(" main"))
+
+    def test_internal_whitespace_preserved(self):
+        """Only leading/trailing whitespace is stripped, not internal."""
+        self.assertEqual(escape_eid("my env"), "my env")
+
 
 class TestExtractEid(unittest.TestCase):
     """Tests for extract_eid() — extracts and escapes eid from args dict."""
@@ -64,6 +87,9 @@ class TestExtractEid(unittest.TestCase):
 
     def test_escapes_value(self):
         self.assertEqual(extract_eid({"eid": "a/b"}), "a_b")
+
+    def test_whitespace_stripped(self):
+        self.assertEqual(extract_eid({"eid": "main "}), "main")
 
 
 class TestHashPassword(unittest.TestCase):

--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -358,9 +358,9 @@ def compare_envs(state, eids, socket, store, show_all=False):
                     for dataIdx, data in enumerate(destWidJson["content"]["data"]):
                         if "name" not in data:
                             break  # stop working with this plot, not right format
-                        destWidJson["content"]["data"][dataIdx]["name"] = (
-                            "{}_{}".format(eidNums[eid], data["name"])
-                        )
+                        destWidJson["content"]["data"][dataIdx][
+                            "name"
+                        ] = "{}_{}".format(eidNums[eid], data["name"])
                 else:
                     if "name" not in destWidJson["content"]["data"][0]:
                         continue  # Skip windows with unnamed data
@@ -422,7 +422,9 @@ def compare_envs(state, eids, socket, store, show_all=False):
         border: 1px solid black;
     }}
     </style>
-    <table> {} </table>""".format(" ".join(tableRows))
+    <table> {} </table>""".format(
+        " ".join(tableRows)
+    )
 
     res["jsons"]["window_compare_legend"] = {
         "command": "window",

--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -125,9 +125,22 @@ def escape_eid(eid):
     """Replace forward slashes and other problematic characters
     with underscores and backslashes with hyphen, to avoid recognizing them as
     directories or breaking URLs and filenames.
+
+    Also strips surrounding whitespace. As ``JSONStore`` independently 
+    strips whitespace before deriving an on-disk filename from an eid, 
+    so two in-memory eids that differ only by leading/trailing whitespace 
+    (e.g. ``"main"`` and ``"main "``) would otherwise stay distinct in ``self.state`` 
+    while silently colliding on disk - whichever one is saved last clobbers the other. 
+    Stripping here, at the single choke point every eid passes through (HTTP handlers, 
+    websocket handlers, and the storage layer all call this), keeps the in-memory key 
+    and the on-disk filename in agreement.
     """
     return (
-        eid.replace("/", "_").replace("\\", "_").replace("\n", "-").replace("\r", "-")
+        eid.strip()
+        .replace("/", "_")
+        .replace("\\", "_")
+        .replace("\n", "-")
+        .replace("\r", "-")
     )
 
 

--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -39,7 +39,6 @@ from visdom.utils.shared_utils import (
     NanSafeEncoder,
 )
 
-
 # ---- Vaguely server-security related functions ---- #
 
 
@@ -126,13 +125,13 @@ def escape_eid(eid):
     with underscores and backslashes with hyphen, to avoid recognizing them as
     directories or breaking URLs and filenames.
 
-    Also strips surrounding whitespace. As ``JSONStore`` independently 
-    strips whitespace before deriving an on-disk filename from an eid, 
-    so two in-memory eids that differ only by leading/trailing whitespace 
-    (e.g. ``"main"`` and ``"main "``) would otherwise stay distinct in ``self.state`` 
-    while silently colliding on disk - whichever one is saved last clobbers the other. 
-    Stripping here, at the single choke point every eid passes through (HTTP handlers, 
-    websocket handlers, and the storage layer all call this), keeps the in-memory key 
+    Also strips surrounding whitespace. As ``JSONStore`` independently
+    strips whitespace before deriving an on-disk filename from an eid,
+    so two in-memory eids that differ only by leading/trailing whitespace
+    (e.g. ``"main"`` and ``"main "``) would otherwise stay distinct in ``self.state``
+    while silently colliding on disk - whichever one is saved last clobbers the other.
+    Stripping here, at the single choke point every eid passes through (HTTP handlers,
+    websocket handlers, and the storage layer all call this), keeps the in-memory key
     and the on-disk filename in agreement.
     """
     return (
@@ -359,9 +358,9 @@ def compare_envs(state, eids, socket, store, show_all=False):
                     for dataIdx, data in enumerate(destWidJson["content"]["data"]):
                         if "name" not in data:
                             break  # stop working with this plot, not right format
-                        destWidJson["content"]["data"][dataIdx][
-                            "name"
-                        ] = "{}_{}".format(eidNums[eid], data["name"])
+                        destWidJson["content"]["data"][dataIdx]["name"] = (
+                            "{}_{}".format(eidNums[eid], data["name"])
+                        )
                 else:
                     if "name" not in destWidJson["content"]["data"][0]:
                         continue  # Skip windows with unnamed data
@@ -423,9 +422,7 @@ def compare_envs(state, eids, socket, store, show_all=False):
         border: 1px solid black;
     }}
     </style>
-    <table> {} </table>""".format(
-        " ".join(tableRows)
-    )
+    <table> {} </table>""".format(" ".join(tableRows))
 
     res["jsons"]["window_compare_legend"] = {
         "command": "window",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes trailing whitespace issue in env name, currently "test" and "test  " are treated as two different env, this PR fixes this and now "test" and "test   " are treated as same env

## Motivation and Context
fix whitespace name issue in env name

## How Has This Been Tested?

executed this script before and after:
```
from visdom import Visdom
import torch

vis = Visdom(env="test   ")

X = torch.tensor([1, 2, 3, 4, 5])
Y = torch.tensor([10, 20, 15, 30, 25])

vis.bar(
    X=X,
    opts={
        "title": "test3",
        "xlabel": "X",
        "ylabel": "Y"
    },
    win="test"
)

vis.save(["test   "])  
```
and 
```
from visdom import Visdom
import torch

vis = Visdom(env="test")

X = torch.tensor([1, 2, 3, 4, 5])
Y = torch.tensor([10, 20, 15, 30, 25])

vis.bar(
    X=X,
    opts={
        "title": "test3",
        "xlabel": "X",
        "ylabel": "Y"
    },
    win="test"
)

vis.save(["test"])
```

and 

```
from visdom import Visdom
import torch

vis = Visdom(env="                      test    ")

X = torch.tensor([1, 2, 3, 4, 5])
Y = torch.tensor([10, 20, 15, 30, 25])

vis.bar(
    X=X,
    opts={
        "title": "test4",
        "xlabel": "X",
        "ylabel": "Y"
    },
    win="test"
)

vis.save(["                                 test    "])
```

before fix: 3 different envs are created with name `test`

## Screenshots :

before fix:
env with same name but having trailing whitespace
<img width="543" height="390" alt="image" src="https://github.com/user-attachments/assets/34dab52e-77e9-46ee-ab26-5e9e4f14c462" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Summary by Sourcery

Normalize surrounding whitespace in environment names to prevent duplicate or conflicting environments.

Bug Fixes:
- Normalize leading and trailing whitespace in environment identifiers so names that differ only by surrounding whitespace resolve to the same environment.

Tests:
- Add coverage for whitespace normalization and prevention of inconsistent in-memory and on-disk environment identifiers.

## Summary by Sourcery

Prevent environment names with surrounding whitespace from being treated as separate environments.

Bug Fixes:
- Normalize leading and trailing whitespace in environment identifiers so names that differ only by surrounding whitespace resolve to the same environment.

Tests:
- Add unit and storage coverage confirming whitespace-normalized environment identifiers remain consistent in memory and on disk.