### PR TITLE
fix: pr_curve computes wrong AUC when precision/recall have tied recall values

### DIFF
--- a/py/tests/unit/client_metrics.py
+++ b/py/tests/unit/client_metrics.py
@@ -567,6 +567,59 @@ def test_pr_curve_from_precomputed_points_infers_the_baseline(capture_send):
     assert sent["payload"]["data"][1]["y"] == [0.4, 0.4]
 
 
+def test_pr_curve_auc_matches_sklearn_when_recall_ties(capture_send):
+    """Tied recall points must not skew the average precision.
+
+    ``precision_recall_curve`` returns several points sharing a recall value
+    for any data the classes overlap in. Sorting on recall alone leaves their
+    order to the sort's tie-breaking, which pairs a recall with the wrong
+    precision and quietly moves the area.
+    """
+    sklearn_metrics = pytest.importorskip("sklearn.metrics")
+
+    for seed in range(10):
+        rng = np.random.RandomState(seed)
+        size = rng.randint(15, 60)
+        y_true = rng.randint(0, 2, size=size)
+        if y_true.sum() in (0, size):
+            continue
+        # Rounding the scores forces the ties this is about.
+        y_score = np.round(
+            y_true * rng.uniform(0.3, 0.7, size=size) + rng.uniform(0, 1, size=size), 1
+        )
+        precision, recall, _ = sklearn_metrics.precision_recall_curve(y_true, y_score)
+
+        sent = capture_send(lambda v: v.pr_curve(precision=precision, recall=recall))
+
+        title = sent["payload"]["opts"]["title"]
+        auc = float(title.rsplit("AUC=", 1)[1].rstrip(")"))
+        expected = sklearn_metrics.average_precision_score(y_true, y_score)
+        assert auc == pytest.approx(expected, abs=5e-5)
+
+
+def test_roc_curve_auc_is_unaffected_by_the_pr_tiebreak(capture_send):
+    """ROC integrates a trapezoid, so its points keep their plain ordering."""
+    sklearn_metrics = pytest.importorskip("sklearn.metrics")
+
+    for seed in range(10):
+        rng = np.random.RandomState(seed)
+        size = rng.randint(15, 60)
+        y_true = rng.randint(0, 2, size=size)
+        if y_true.sum() in (0, size):
+            continue
+        y_score = np.round(
+            y_true * rng.uniform(0.3, 0.7, size=size) + rng.uniform(0, 1, size=size), 1
+        )
+        fpr, tpr, _ = sklearn_metrics.roc_curve(y_true, y_score)
+
+        sent = capture_send(lambda v: v.roc_curve(fpr=fpr, tpr=tpr))
+
+        title = sent["payload"]["opts"]["title"]
+        auc = float(title.rsplit("AUC=", 1)[1].rstrip(")"))
+        expected = sklearn_metrics.roc_auc_score(y_true, y_score)
+        assert auc == pytest.approx(expected, abs=5e-5)
+
+
 def test_pr_curve_omits_the_baseline_when_it_cannot_be_inferred(capture_send):
     """Precomputed points that do not start at recall 0 get the curve only."""
     sent = capture_send(

--- a/py/tests/unit/client_metrics.py
+++ b/py/tests/unit/client_metrics.py
@@ -605,14 +605,15 @@ def test_pr_curve_auc_matches_sklearn_when_recall_ties(capture_send):
     "dtype", [np.uint8, np.int16, np.float32], ids=["uint8", "int16", "float32"]
 )
 def test_pr_curve_breaks_recall_ties_whatever_the_precision_dtype(dtype):
-    """An unsigned precision array must not invert the tie-break.
+    """The tie-break must reorder the group, for signed and unsigned alike.
 
-    Negating an unsigned array wraps rather than changing sign, so ``0`` and
-    ``1`` would come back as ``0`` and ``255`` and order the tied group the
-    wrong way round.
+    The tied pair is given in ascending precision so that leaving it alone
+    fails: a sort on recall with no tie-break would keep it, and negating an
+    unsigned array wraps rather than changing sign, turning ``0``/``1`` into
+    ``0``/``255`` and keeping it just the same.
     """
     recall = np.array([0.0, 0.5, 0.5, 1.0])
-    precision = np.array([1, 1, 0, 0], dtype=dtype)
+    precision = np.array([1, 0, 1, 0], dtype=dtype)
 
     _, ordered = _coerce_curve_xy(
         recall, precision, "recall", "precision", y_tiebreak_descending=True

--- a/py/tests/unit/client_metrics.py
+++ b/py/tests/unit/client_metrics.py
@@ -589,12 +589,36 @@ def test_pr_curve_auc_matches_sklearn_when_recall_ties(capture_send):
         )
         precision, recall, _ = sklearn_metrics.precision_recall_curve(y_true, y_score)
 
-        sent = capture_send(lambda v: v.pr_curve(precision=precision, recall=recall))
+        sent = capture_send(
+            lambda v, precision=precision, recall=recall: v.pr_curve(
+                precision=precision, recall=recall
+            )
+        )
 
         title = sent["payload"]["opts"]["title"]
         auc = float(title.rsplit("AUC=", 1)[1].rstrip(")"))
         expected = sklearn_metrics.average_precision_score(y_true, y_score)
         assert auc == pytest.approx(expected, abs=5e-5)
+
+
+@pytest.mark.parametrize(
+    "dtype", [np.uint8, np.int16, np.float32], ids=["uint8", "int16", "float32"]
+)
+def test_pr_curve_breaks_recall_ties_whatever_the_precision_dtype(dtype):
+    """An unsigned precision array must not invert the tie-break.
+
+    Negating an unsigned array wraps rather than changing sign, so ``0`` and
+    ``1`` would come back as ``0`` and ``255`` and order the tied group the
+    wrong way round.
+    """
+    recall = np.array([0.0, 0.5, 0.5, 1.0])
+    precision = np.array([1, 1, 0, 0], dtype=dtype)
+
+    _, ordered = _coerce_curve_xy(
+        recall, precision, "recall", "precision", y_tiebreak_descending=True
+    )
+
+    assert list(ordered) == [1, 1, 0, 0]
 
 
 def test_roc_curve_auc_is_unaffected_by_the_pr_tiebreak(capture_send):
@@ -612,7 +636,7 @@ def test_roc_curve_auc_is_unaffected_by_the_pr_tiebreak(capture_send):
         )
         fpr, tpr, _ = sklearn_metrics.roc_curve(y_true, y_score)
 
-        sent = capture_send(lambda v: v.roc_curve(fpr=fpr, tpr=tpr))
+        sent = capture_send(lambda v, fpr=fpr, tpr=tpr: v.roc_curve(fpr=fpr, tpr=tpr))
 
         title = sent["payload"]["opts"]["title"]
         auc = float(title.rsplit("AUC=", 1)[1].rstrip(")"))

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -614,8 +614,23 @@ def _compute_pr_curve(y_true, y_score, pos_label=1):
     return precision, recall
 
 
-def _coerce_curve_xy(x, y, x_name, y_name):
-    """Validate and sort precomputed curve arrays by x."""
+def _coerce_curve_xy(x, y, x_name, y_name, y_tiebreak_descending=False):
+    """Validate and sort precomputed curve arrays by x, breaking ties in y.
+
+    A tied-``x`` group must be ordered to match how the curve was
+    actually traversed, or downstream area calculations that are
+    sensitive to point order (e.g. :func:`_average_precision`'s
+    precision-weighted sum) can silently compute the wrong value even
+    though a trapezoidal area (:func:`_trapz_area`, used for ROC) would
+    be unaffected either way.
+
+    For a precision-recall curve, precision only decreases as more
+    points are accepted at a fixed recall, so pass
+    ``y_tiebreak_descending=True`` to put the higher-precision point
+    first within each tied-recall group. ROC's fpr/tpr pairs need no
+    such tiebreak (tpr ascends within a tied-fpr group, matching a plain
+    ascending sort), so the default preserves that.
+    """
     x = np.asarray(x)
     y = np.asarray(y)
     if x.ndim != 1:
@@ -629,7 +644,8 @@ def _coerce_curve_xy(x, y, x_name, y_name):
             "{} and {} should have at least 2 points".format(x_name, y_name)
         )
 
-    order = np.argsort(x, kind="mergesort")
+    tiebreak = -y if y_tiebreak_descending else y
+    order = np.lexsort((tiebreak, x))
     return x[order], y[order]
 
 
@@ -3309,7 +3325,7 @@ class Visdom(object):
             if precision is None or recall is None:
                 raise ValueError("both precision and recall are required")
             recall, precision = _coerce_curve_xy(
-                recall, precision, "recall", "precision"
+                recall, precision, "recall", "precision", y_tiebreak_descending=True
             )
 
         _validate_curve_range(recall, "recall")

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -644,7 +644,9 @@ def _coerce_curve_xy(x, y, x_name, y_name, y_tiebreak_descending=False):
             "{} and {} should have at least 2 points".format(x_name, y_name)
         )
 
-    tiebreak = -y if y_tiebreak_descending else y
+    # Negating an unsigned array wraps instead of changing sign, which would
+    # order a tied group by ascending y, so widen before negating.
+    tiebreak = -y.astype(np.float64) if y_tiebreak_descending else y
     order = np.lexsort((tiebreak, x))
     return x[order], y[order]
 


### PR DESCRIPTION
## Description

`_coerce_curve_xy` sorted precomputed curve points with `np.argsort(x)`, which orders by `x` alone. For a precision-recall curve that leaves the order of a tied-recall group to the sort's tie-breaking, pairing a recall with the wrong precision and silently moving the area that `_average_precision` computes from it.

`sklearn.metrics.precision_recall_curve` returns several points sharing a recall value for any data whose classes overlap, so this is the normal case rather than an edge case.

The sort now breaks ties on `y`. `pr_curve` passes `y_tiebreak_descending=True`, since precision only decreases as more points are accepted at a fixed recall, so the higher-precision point must come first. `roc_curve` keeps the plain ascending order: it integrates a trapezoid, where a tied-`x` group contributes zero width whatever the order within it.

The tie-break value is widened with `.astype(np.float64)` before negation. Negating an unsigned array wraps rather than changing sign, so a `uint8` precision array of `0`/`1` would otherwise come back as `0`/`255` and order the tied group backwards.

## Motivation and Context

The AUC printed in the pane title is one of the few numbers a user reads directly off a visdom plot, and it was wrong with no error or warning to signal it.

Across ten random datasets, every one diverged from `sklearn.metrics.average_precision_score` — by under 1% in the mildest case and about 13% in the worst.

Fixes #1745

## How Has This Been Tested?

Environment: Windows 11, Python 3.12 (conda), installed from source with `pip install -e .`.

- Confirmed the bug still reproduces on current `dev`: 10/10 random trials diverged from `average_precision_score`
- After the fix: 0/30 PR-curve mismatches and 0/30 ROC mismatches, the latter confirming ROC is unaffected
- Added `test_pr_curve_auc_matches_sklearn_when_recall_ties`, verified to fail against the pre-fix code and pass with the fix
- Added `test_roc_curve_auc_is_unaffected_by_the_pr_tiebreak` as a guard against the tie-break regressing ROC
- Added `test_pr_curve_breaks_recall_ties_whatever_the_precision_dtype`, parametrized over `uint8`/`int16`/`float32`, verified to fail on `uint8` without the widening
- 118 tests in `py/tests/unit/client_metrics.py` pass; `black --check` clean
- Remaining failures in a full local run are pre-existing Windows `MAX_PATH` ones in `data_model.py` and friends, which also fail on a clean `dev` checkout here and pass on the Linux runners

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:

- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Summary by Sourcery

Fix precision-recall curve AUC calculations for tied recall values without changing ROC curve behavior.

Bug Fixes:
- Correct precision-recall AUC calculations when precomputed points contain tied recall values.
- Preserve ROC AUC behavior while ensuring tie handling works across precision dtypes, including unsigned arrays.

Enhancements:
- Improve curve point ordering by applying an appropriate secondary sort for tied x-values.

Tests:
- Add coverage comparing precision-recall AUC against scikit-learn with tied recalls.
- Add tests for tie ordering across signed, unsigned, and floating-point precision types.
- Add regression coverage confirming ROC AUC remains unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved precision-recall AUC calculations when multiple points share the same recall value, including support for unsigned, signed, and floating-point data.
  - Preserved correct ROC AUC results while applying precision-recall tie handling.
  - Added an option to skip preflight window checks for image and scatter updates, enabling more direct append workflows.

- **Tests**
  - Added regression coverage for tied-value precision-recall curves and append behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->