### PR TITLE
Visualize Optuna intermediate values and pruned trials

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,8 @@ See `example/train_keras_example.py` for a full working example.
 
 **Requirements:** `pip install visdom optuna`
 
+**Dashboard visualizations:** `pip install plotly`
+
 `visdom.integrations.OptunaCallback` implements Optuna's study callback
 protocol. After each trial finishes it records the trial's parameters, objective
 values and state as a Visdom experiment in a dedicated environment. Optuna is
@@ -600,6 +602,8 @@ callback = OptunaCallback(
     viz,
     dashboard_env="optuna_quadratic",
     objective_names=["loss"],
+    create_dashboard=True,
+    refresh_every=10,
 )
 
 
@@ -610,14 +614,21 @@ def objective(trial):
 
 study = optuna.create_study(study_name="quadratic", direction="minimize")
 study.optimize(objective, n_trials=100, callbacks=[callback])
+callback.update_dashboard(study)
 ```
 
-This first-stage integration records one experiment per trial, using names such
-as `optuna_quadratic_trial_000017`. Pass `raise_on_error=True` if a Visdom
-logging failure should stop optimization; by default it emits a warning and
-allows the study to continue. Single- and multi-objective studies are supported,
-and `COMPLETE`, `PRUNED` and `FAIL` states are preserved in the
-`optuna_state` tag.
+The integration records one experiment per trial, using names such as
+`optuna_quadratic_trial_000017`. With `create_dashboard=True`, the first trial
+creates summary, HParams, optimization history and timeline panes, plus
+parameter importance when Optuna can compute it. Later trials refresh the panes
+in `optuna_quadratic` every `refresh_every` successful writes. The explicit
+final `update_dashboard()` includes any trials left since the last scheduled
+refresh. Plotly is only needed for the Optuna visualization panes.
+
+Pass `raise_on_error=True` if a Visdom logging failure should stop optimization;
+by default it emits a warning and allows the study to continue. Single- and
+multi-objective studies are supported, and `COMPLETE`, `PRUNED` and `FAIL`
+states are preserved in the `optuna_state` tag.
 
 ## Details
 <img src="https://user-images.githubusercontent.com/19650074/198747904-7a8a580f-851a-45fb-8f45-94e54a910ee2.png"/>

--- a/README.md
+++ b/README.md
@@ -618,17 +618,29 @@ callback.update_dashboard(study)
 ```
 
 The integration records one experiment per trial, using names such as
-`optuna_quadratic_trial_000017`. With `create_dashboard=True`, the first trial
-creates summary, HParams, optimization history and timeline panes, plus
-parameter importance when Optuna can compute it. Later trials refresh the panes
-in `optuna_quadratic` every `refresh_every` successful writes. The explicit
-final `update_dashboard()` includes any trials left since the last scheduled
-refresh. Plotly is only needed for the Optuna visualization panes.
+`optuna_quadratic_trial_000017`. Intermediate values reported with
+`trial.report(value, step)` are stored as the `intermediate_value` metric in
+step order before the final objective value. With `create_dashboard=True`, the
+first trial creates summary, HParams, optimization history and timeline panes,
+plus intermediate-value and parameter-importance panes when Optuna can compute
+them. Later trials refresh the panes in `optuna_quadratic` every `refresh_every`
+successful writes. The explicit final `update_dashboard()` includes any trials
+left since the last scheduled refresh. Plotly is only needed for the Optuna
+visualization panes.
+
+The summary pane links directly to the best and latest terminal trial
+environments. The callback never opens a browser on its own.
 
 Pass `raise_on_error=True` if a Visdom logging failure should stop optimization;
 by default it emits a warning and allows the study to continue. Single- and
 multi-objective studies are supported, and `COMPLETE`, `PRUNED` and `FAIL`
-states are preserved in the `optuna_state` tag.
+states are preserved in the `optuna_state` tag. A pruned trial retains every
+intermediate value reported before pruning. Optuna remains responsible for the
+pruning decision: call `trial.report()` and `trial.should_prune()` inside the
+objective and raise `optuna.TrialPruned` when requested. Because Optuna invokes
+study callbacks after a trial reaches a terminal state, `OptunaCallback`
+records these values after the trial finishes rather than streaming them while
+the trial is running.
 
 ## Details
 <img src="https://user-images.githubusercontent.com/19650074/198747904-7a8a580f-851a-45fb-8f45-94e54a910ee2.png"/>

--- a/py/visdom/integrations/optuna.py
+++ b/py/visdom/integrations/optuna.py
@@ -224,20 +224,27 @@ class OptunaCallback:
             ("Failed", states["FAIL"]),
         ]
         if len(study.directions) == 1 and states["COMPLETE"]:
-            links.append(("Open best trial", self._trial_url(study.best_trial, study)))
-            rows.extend(
-                [
-                    ("Best value", study.best_value),
-                    (
-                        "Best parameters",
-                        json.dumps(
-                            study.best_params,
-                            ensure_ascii=False,
-                            sort_keys=True,
+            try:
+                best_trial = study.best_trial
+                best_value = study.best_value
+                best_params = study.best_params
+            except ValueError:
+                pass
+            else:
+                links.append(("Open best trial", self._trial_url(best_trial, study)))
+                rows.extend(
+                    [
+                        ("Best value", best_value),
+                        (
+                            "Best parameters",
+                            json.dumps(
+                                best_params,
+                                ensure_ascii=False,
+                                sort_keys=True,
+                            ),
                         ),
-                    ),
-                ]
-            )
+                    ]
+                )
         elif states["COMPLETE"]:
             rows.append(("Pareto trials", len(study.best_trials)))
 

--- a/py/visdom/integrations/optuna.py
+++ b/py/visdom/integrations/optuna.py
@@ -22,8 +22,10 @@ import warnings
 from collections import Counter
 from collections.abc import Mapping, Sequence
 from typing import Any
+from urllib.parse import quote
 
 from visdom.experiments.tags import normalize_tags
+from visdom.utils.server_utils import escape_eid
 
 
 class OptunaCallback:
@@ -149,6 +151,15 @@ class OptunaCallback:
             raise ValueError("study is required when dashboard_env was not supplied")
         return "{}_trial_{:06d}".format(self.study_env(study), trial.number)
 
+    def _trial_url(self, trial: Any, study: Any) -> str:
+        root = "{}:{}{}".format(
+            self.viz.server,
+            self.viz.port,
+            self.viz.base_url,
+        ).rstrip("/")
+        env = quote(escape_eid(self.trial_env(trial, study)), safe="")
+        return "{}/env/{}".format(root, env)
+
     def _metric_names(self, study: Any, value_count: int) -> tuple[str, ...]:
         if self.objective_names is not None:
             names = self.objective_names
@@ -186,6 +197,7 @@ class OptunaCallback:
     def _summary_html(self, study: Any) -> str:
         trials = study.get_trials(deepcopy=False)
         states = Counter(trial.state.name for trial in trials)
+        links = []
         rows = [
             ("Study", study.study_name),
             (
@@ -198,6 +210,7 @@ class OptunaCallback:
             ("Failed", states["FAIL"]),
         ]
         if len(study.directions) == 1 and states["COMPLETE"]:
+            links.append(("Open best trial", self._trial_url(study.best_trial, study)))
             rows.extend(
                 [
                     ("Best value", study.best_value),
@@ -214,13 +227,32 @@ class OptunaCallback:
         elif states["COMPLETE"]:
             rows.append(("Pareto trials", len(study.best_trials)))
 
+        terminal_trials = [
+            trial
+            for trial in trials
+            if trial.state.name in ("COMPLETE", "PRUNED", "FAIL")
+        ]
+        if terminal_trials:
+            latest_trial = max(terminal_trials, key=lambda trial: trial.number)
+            links.append(("Open latest trial", self._trial_url(latest_trial, study)))
+
         body = "".join(
             "<tr><th>{}</th><td>{}</td></tr>".format(
                 html.escape(str(label)), html.escape(str(value))
             )
             for label, value in rows
         )
-        return "<h3>Optuna Study</h3><table>{}</table>".format(body)
+        navigation = ""
+        if links:
+            anchors = " | ".join(
+                '<a href="{}" target="_blank" rel="noopener noreferrer">{}</a>'.format(
+                    html.escape(url, quote=True),
+                    html.escape(label),
+                )
+                for label, url in links
+            )
+            navigation = "<p><strong>Open in Visdom:</strong> {}</p>".format(anchors)
+        return "<h3>Optuna Study</h3><table>{}</table>{}".format(body, navigation)
 
     def _dashboard_figures(self, study: Any) -> list[tuple[str, Any]]:
         try:

--- a/py/visdom/integrations/optuna.py
+++ b/py/visdom/integrations/optuna.py
@@ -172,7 +172,7 @@ class OptunaCallback:
         if self.objective_names is not None:
             names = self.objective_names
         else:
-            study_names = study.metric_names
+            study_names = getattr(study, "metric_names", None)
             if study_names is not None:
                 names = tuple(study_names)
             elif value_count == 1:

--- a/py/visdom/integrations/optuna.py
+++ b/py/visdom/integrations/optuna.py
@@ -16,7 +16,10 @@ Visdom dependency just for this optional adapter.
 
 from __future__ import annotations
 
+import html
+import json
 import warnings
+from collections import Counter
 from collections.abc import Mapping, Sequence
 from typing import Any
 
@@ -24,7 +27,7 @@ from visdom.experiments.tags import normalize_tags
 
 
 class OptunaCallback:
-    """Log each completed Optuna trial to a dedicated Visdom environment.
+    """Log completed Optuna trials and optionally maintain a study dashboard.
 
     Instances are passed to ``Study.optimize(callbacks=[...])``. Optuna calls
     the instance with a ``Study`` and ``FrozenTrial`` after a trial finishes;
@@ -32,9 +35,13 @@ class OptunaCallback:
     Visdom's experiment API.
 
     ``dashboard_env`` is the namespace for the study and its trial
-    environments. When omitted it is derived from the Optuna study name. The
-    callback itself does not create a dashboard pane; it only establishes the
-    stable environment layout that a dashboard can aggregate later.
+    environments. When omitted it is derived from the Optuna study name.
+    ``create_dashboard=True`` creates a summary, an HParams pane and Optuna's
+    Plotly study visualizations in that environment. The first completed trial
+    creates the dashboard; later trials refresh it every ``refresh_every``
+    successful writes. Call :meth:`update_dashboard` after ``Study.optimize``
+    to ensure the final trials are included when the total is not an exact
+    multiple of that interval.
 
     Optuna is intentionally not imported here. This keeps the integration
     optional and also means importing :mod:`visdom.integrations` never requires
@@ -52,6 +59,8 @@ class OptunaCallback:
         raise_on_error: Re-raise Visdom logging failures when true. By default a
             warning is emitted so an unavailable dashboard does not stop the
             optimization.
+        create_dashboard: Create and periodically refresh the study dashboard.
+        refresh_every: Number of newly logged trials between dashboard refreshes.
 
     Example::
 
@@ -59,8 +68,10 @@ class OptunaCallback:
             viz,
             dashboard_env="optuna_resnet",
             objective_names=["validation_accuracy"],
+            create_dashboard=True,
         )
         study.optimize(objective, callbacks=[callback])
+        callback.update_dashboard(study)
     """
 
     def __init__(
@@ -70,17 +81,26 @@ class OptunaCallback:
         objective_names: Sequence[str] | None = None,
         tags: Mapping[str, str] | None = None,
         raise_on_error: bool = False,
+        create_dashboard: bool = False,
+        refresh_every: int = 10,
     ) -> None:
         if dashboard_env is not None and not isinstance(dashboard_env, str):
             raise TypeError("dashboard_env must be a string or None")
         if dashboard_env == "":
             raise ValueError("dashboard_env must not be empty")
+        if refresh_every < 1:
+            raise ValueError("refresh_every must be at least 1")
 
         self.viz = viz
         self.dashboard_env = dashboard_env
         self.objective_names = self._validate_objective_names(objective_names)
         self.tags = self._validate_tags(tags)
         self.raise_on_error = raise_on_error
+        self.create_dashboard = create_dashboard
+        self.refresh_every = refresh_every
+        self._dashboard_created = False
+        self._trials_since_refresh = 0
+        self._trial_envs: list[str] = []
 
     @staticmethod
     def _validate_objective_names(
@@ -163,6 +183,156 @@ class OptunaCallback:
         )
         return normalize_tags(tags)
 
+    def _summary_html(self, study: Any) -> str:
+        trials = study.get_trials(deepcopy=False)
+        states = Counter(trial.state.name for trial in trials)
+        rows = [
+            ("Study", study.study_name),
+            (
+                "Direction",
+                ", ".join(direction.name.lower() for direction in study.directions),
+            ),
+            ("Trials", len(trials)),
+            ("Complete", states["COMPLETE"]),
+            ("Pruned", states["PRUNED"]),
+            ("Failed", states["FAIL"]),
+        ]
+        if len(study.directions) == 1 and states["COMPLETE"]:
+            rows.extend(
+                [
+                    ("Best value", study.best_value),
+                    (
+                        "Best parameters",
+                        json.dumps(
+                            study.best_params,
+                            ensure_ascii=False,
+                            sort_keys=True,
+                        ),
+                    ),
+                ]
+            )
+        elif states["COMPLETE"]:
+            rows.append(("Pareto trials", len(study.best_trials)))
+
+        body = "".join(
+            "<tr><th>{}</th><td>{}</td></tr>".format(
+                html.escape(str(label)), html.escape(str(value))
+            )
+            for label, value in rows
+        )
+        return "<h3>Optuna Study</h3><table>{}</table>".format(body)
+
+    def _dashboard_figures(self, study: Any) -> list[tuple[str, Any]]:
+        try:
+            from optuna.visualization import (
+                plot_optimization_history,
+                plot_param_importances,
+                plot_timeline,
+            )
+
+            objective_names = self._metric_names(study, len(study.directions))
+            figures = []
+            multi_objective = len(objective_names) > 1
+            complete_trials = sum(
+                trial.state.name == "COMPLETE"
+                for trial in study.get_trials(deepcopy=False)
+            )
+            for index, objective_name in enumerate(objective_names):
+                target = (
+                    (lambda trial, i=index: trial.values[i])
+                    if multi_objective
+                    else None
+                )
+                kwargs: dict[str, Any] = {"target_name": objective_name}
+                if target is not None:
+                    kwargs["target"] = target
+                history = plot_optimization_history(study, **kwargs)
+                history.update_layout(
+                    title="Optimization History — {}".format(objective_name)
+                )
+                suffix = "-{}".format(index) if multi_objective else ""
+                figures.append(("optuna-history{}".format(suffix), history))
+
+                if complete_trials >= 2:
+                    try:
+                        importance = plot_param_importances(study, **kwargs)
+                    except ValueError:
+                        pass
+                    else:
+                        importance.update_layout(
+                            title="Parameter Importance — {}".format(objective_name)
+                        )
+                        figures.append(
+                            ("optuna-importance{}".format(suffix), importance)
+                        )
+
+            timeline = plot_timeline(study)
+            timeline.update_layout(title="Optuna Trial Timeline")
+            figures.append(("optuna-timeline", timeline))
+            return figures
+        except ImportError as error:
+            warnings.warn(
+                "Optuna dashboard plots are unavailable: {}".format(error),
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return []
+
+    def _build_dashboard_payload(self, study: Any) -> dict[str, Any]:
+        if not self._trial_envs:
+            raise ValueError("cannot create an Optuna dashboard before logging a trial")
+        return {
+            "env": self.study_env(study),
+            "env_ids": list(self._trial_envs),
+            "summary": self._summary_html(study),
+            "figures": self._dashboard_figures(study),
+        }
+
+    def update_dashboard(self, study: Any) -> bool:
+        """Create or refresh all dashboard panes for ``study``.
+
+        Returns whether the dashboard was written successfully. Only trials
+        logged by this callback instance are included in the HParams pane;
+        loading trials from a resumed study is handled by the later resume
+        integration.
+        """
+        payload = self._build_dashboard_payload(study)
+        try:
+            self.viz.text(
+                payload["summary"],
+                win="optuna-summary",
+                env=payload["env"],
+                opts={"title": "Optuna Study"},
+            )
+            self.viz.hparams(
+                env_ids=payload["env_ids"],
+                win="optuna-trials",
+                env=payload["env"],
+                opts={"title": "Optuna Trials"},
+            )
+            for win, figure in payload["figures"]:
+                self.viz.plotlyplot(figure, win=win, env=payload["env"])
+        except Exception as error:
+            if self.raise_on_error:
+                raise
+            warnings.warn(
+                "OptunaCallback failed to update the dashboard: {}".format(error),
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return False
+        self._dashboard_created = True
+        self._trials_since_refresh = 0
+        return True
+
+    def _maybe_update_dashboard(self, study: Any) -> None:
+        self._trials_since_refresh += 1
+        if (
+            not self._dashboard_created
+            or self._trials_since_refresh >= self.refresh_every
+        ):
+            self.update_dashboard(study)
+
     def _build_payload(self, study: Any, trial: Any) -> dict[str, Any]:
         env = self.trial_env(trial, study)
         state = trial.state.name
@@ -211,3 +381,8 @@ class OptunaCallback:
                 RuntimeWarning,
                 stacklevel=2,
             )
+            return
+
+        self._trial_envs.append(payload["env"])
+        if self.create_dashboard:
+            self._maybe_update_dashboard(study)

--- a/py/visdom/integrations/optuna.py
+++ b/py/visdom/integrations/optuna.py
@@ -65,7 +65,8 @@ class OptunaCallback:
             warning is emitted so an unavailable dashboard does not stop the
             optimization.
         create_dashboard: Create and periodically refresh the study dashboard.
-        refresh_every: Number of newly logged trials between dashboard refreshes.
+        refresh_every: Positive integer number of newly logged trials between
+            dashboard refreshes.
 
     Example::
 
@@ -93,6 +94,8 @@ class OptunaCallback:
             raise TypeError("dashboard_env must be a string or None")
         if dashboard_env == "":
             raise ValueError("dashboard_env must not be empty")
+        if isinstance(refresh_every, bool) or not isinstance(refresh_every, int):
+            raise TypeError("refresh_every must be an integer")
         if refresh_every < 1:
             raise ValueError("refresh_every must be at least 1")
 
@@ -137,8 +140,10 @@ class OptunaCallback:
     def study_env(self, study: Any) -> str:
         """Return the environment namespace for an Optuna study."""
         if self.dashboard_env is not None:
-            return self.dashboard_env
-        return "optuna_{}".format(study.study_name)
+            env = self.dashboard_env
+        else:
+            env = "optuna_{}".format(study.study_name)
+        return escape_eid(env)
 
     def trial_env(self, trial: Any, study: Any = None) -> str:
         """Return the deterministic Visdom environment for an Optuna trial.
@@ -345,8 +350,8 @@ class OptunaCallback:
         loading trials from a resumed study is handled by the later resume
         integration.
         """
-        payload = self._build_dashboard_payload(study)
         try:
+            payload = self._build_dashboard_payload(study)
             self.viz.text(
                 payload["summary"],
                 win="optuna-summary",

--- a/py/visdom/integrations/optuna.py
+++ b/py/visdom/integrations/optuna.py
@@ -28,13 +28,16 @@ from visdom.experiments.tags import normalize_tags
 from visdom.utils.server_utils import escape_eid
 
 
+_INTERMEDIATE_METRIC_NAME = "intermediate_value"
+
+
 class OptunaCallback:
     """Log completed Optuna trials and optionally maintain a study dashboard.
 
     Instances are passed to ``Study.optimize(callbacks=[...])``. Optuna calls
     the instance with a ``Study`` and ``FrozenTrial`` after a trial finishes;
-    the callback stores the trial's parameters, objective values and state via
-    Visdom's experiment API.
+    the callback stores the trial's parameters, objective values, reported
+    intermediate values and state via Visdom's experiment API.
 
     ``dashboard_env`` is the namespace for the study and its trial
     environments. When omitted it is derived from the Optuna study name.
@@ -194,6 +197,12 @@ class OptunaCallback:
         )
         return normalize_tags(tags)
 
+    @staticmethod
+    def _intermediate_values(trial: Any) -> list[tuple[int, float]]:
+        """Return reported intermediate values ordered by training step."""
+        values = getattr(trial, "intermediate_values", None) or {}
+        return sorted(values.items())
+
     def _summary_html(self, study: Any) -> str:
         trials = study.get_trials(deepcopy=False)
         states = Counter(trial.state.name for trial in trials)
@@ -257,6 +266,7 @@ class OptunaCallback:
     def _dashboard_figures(self, study: Any) -> list[tuple[str, Any]]:
         try:
             from optuna.visualization import (
+                plot_intermediate_values,
                 plot_optimization_history,
                 plot_param_importances,
                 plot_timeline,
@@ -265,10 +275,8 @@ class OptunaCallback:
             objective_names = self._metric_names(study, len(study.directions))
             figures = []
             multi_objective = len(objective_names) > 1
-            complete_trials = sum(
-                trial.state.name == "COMPLETE"
-                for trial in study.get_trials(deepcopy=False)
-            )
+            trials = study.get_trials(deepcopy=False)
+            complete_trials = sum(trial.state.name == "COMPLETE" for trial in trials)
             for index, objective_name in enumerate(objective_names):
                 target = (
                     (lambda trial, i=index: trial.values[i])
@@ -297,6 +305,15 @@ class OptunaCallback:
                         figures.append(
                             ("optuna-importance{}".format(suffix), importance)
                         )
+
+            if any(self._intermediate_values(trial) for trial in trials):
+                try:
+                    intermediate = plot_intermediate_values(study)
+                except ValueError:
+                    pass
+                else:
+                    intermediate.update_layout(title="Optuna Intermediate Values")
+                    figures.append(("optuna-intermediate-values", intermediate))
 
             timeline = plot_timeline(study)
             timeline.update_layout(title="Optuna Trial Timeline")
@@ -399,6 +416,12 @@ class OptunaCallback:
                 description=payload["description"],
                 env=payload["env"],
             )
+            for step, value in self._intermediate_values(trial):
+                self.viz.log_metrics(
+                    {_INTERMEDIATE_METRIC_NAME: value},
+                    step=step,
+                    env=payload["env"],
+                )
             if payload["metrics"]:
                 self.viz.log_metrics(payload["metrics"], env=payload["env"])
             self.viz.finish_experiment(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- `py/visdom/integrations/optuna.py`
  - Record `FrozenTrial.intermediate_values` in training-step order.
  - Store reported values using the `intermediate_value` metric.
  - Preserve intermediate values for pruned trials.
  - Add an `optuna-intermediate-values` dashboard pane.
  - Skip the pane when no intermediate data is available or Optuna cannot generate the figure.

- `README.md`
  - Document intermediate-value recording and visualization.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The Optuna integration covers trial logging, study dashboards and intermediate trial reporting.
The implementation is split into three smaller PRs:
- Optuna trial callback
- Study dashboard
- Intermediate trial reporting

This is the third PR and adds intermediate trial reporting.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, experiments you ran to see how -->
<!--- your change affects existing areas of the code and their behaviors, etc. -->
<!--- One method of testing is to run the `demo.py` script from the examples -->
<!--- both on your branch and a clean branch and ensure that none of the functionality -->
<!--- appears different. Be sure to install from source when testing. -->
Run the following code
```
from __future__ import annotations

import argparse
import math
import time
from collections import Counter

import numpy as np
import optuna
import visdom

from visdom.integrations import OptunaCallback


def parse_args() -> argparse.Namespace:
    parser = argparse.ArgumentParser(
        description="Test Visdom Optuna intermediate reporting and pruning."
    )
    parser.add_argument("--server", default="http://localhost")
    parser.add_argument("--port", type=int, default=8097)
    parser.add_argument("--base-url", default="/")
    parser.add_argument(
        "--env",
        help="Dashboard environment; defaults to a unique timestamped name.",
    )
    parser.add_argument("--study-name", default="intermediate-pruning-demo")
    parser.add_argument("--n-trials", type=int, default=8)
    parser.add_argument("--steps", type=int, default=12)
    parser.add_argument("--refresh-every", type=int, default=2)
    parser.add_argument("--seed", type=int, default=7)
    args = parser.parse_args()
    if args.n_trials < 2:
        parser.error("--n-trials must be at least 2")
    if args.steps < 3:
        parser.error("--steps must be at least 3")
    if args.refresh_every < 1:
        parser.error("--refresh-every must be at least 1")
    return args


def dashboard_url(viz: visdom.Visdom, env: str) -> str:
    root = "{}:{}{}".format(viz.server, viz.port, viz.base_url).rstrip("/")
    return "{}/env/{}".format(root, env)


def main() -> None:
    args = parse_args()
    dashboard_env = args.env or "optuna_intermediate_pruning_{}".format(
        int(time.time())
    )
    viz = visdom.Visdom(
        server=args.server,
        port=args.port,
        base_url=args.base_url,
        env=dashboard_env,
        use_incoming_socket=False,
        raise_exceptions=True,
    )
    if not viz.check_connection(timeout_seconds=3):
        raise SystemExit(
            "Cannot connect to Visdom at {}:{}. Start the server first with "
            "`python3 -m visdom.server`.".format(args.server, args.port)
        )

    callback = OptunaCallback(
        viz,
        dashboard_env=dashboard_env,
        objective_names=["loss"],
        create_dashboard=True,
        refresh_every=args.refresh_every,
        raise_on_error=True,
    )
    study = optuna.create_study(
        study_name=args.study_name,
        direction="minimize",
        sampler=optuna.samplers.TPESampler(seed=args.seed),
        pruner=optuna.pruners.ThresholdPruner(
            upper=0.8,
            n_warmup_steps=2,
        ),
    )

    # These first two trials make the test deterministic: "good" completes and
    # "bad" is pruned once the pruner's warm-up period has elapsed.
    study.enqueue_trial({"profile": "good", "learning_rate": 0.01})
    study.enqueue_trial({"profile": "bad", "learning_rate": 0.01})

    def objective(trial: optuna.Trial) -> float:
        profile = trial.suggest_categorical("profile", ["good", "medium", "bad"])
        learning_rate = trial.suggest_float("learning_rate", 1e-4, 1e-1, log=True)
        initial_loss = {"good": 0.55, "medium": 0.95, "bad": 1.5}[profile]
        decay = {"good": 0.84, "medium": 0.93, "bad": 0.98}[profile]
        learning_rate_penalty = 0.04 * abs(math.log10(learning_rate) + 2.0)
        trial_env = callback.trial_env(trial)
        loss = initial_loss

        for step in range(args.steps):
            loss = initial_loss * decay**step + learning_rate_penalty
            trial.report(loss, step=step)
            viz.line(
                X=np.asarray([step], dtype=np.float64),
                Y=np.asarray([loss], dtype=np.float64),
                win="live-training-loss",
                env=trial_env,
                update="append",
                opts={
                    "title": "Live Training Loss",
                    "xlabel": "step",
                    "ylabel": "loss",
                },
            )
            if trial.should_prune():
                raise optuna.TrialPruned(
                    "loss {:.4f} exceeded the pruning threshold at step {}".format(
                        loss, step
                    )
                )

        return loss

    study.optimize(objective, n_trials=args.n_trials, callbacks=[callback])
    if not callback.update_dashboard(study):
        raise RuntimeError("the final Optuna dashboard update failed")

    states = Counter(trial.state.name for trial in study.trials)
    if not states["COMPLETE"] or not states["PRUNED"]:
        raise AssertionError(
            "expected both COMPLETE and PRUNED trials, got {}".format(dict(states))
        )
    if any(not trial.intermediate_values for trial in study.trials):
        raise AssertionError("every trial should contain intermediate values")

    print("\nOptuna intermediate reporting and pruning test passed.")
    print("Trial states: {}".format(dict(states)))
    print("Dashboard environment: {}".format(dashboard_env))
    print("Dashboard URL: {}".format(dashboard_url(viz, dashboard_env)))


if __name__ == "__main__":
    main()
```

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/0e99a3a2-a8f2-48f1-a668-b40f05e44f32



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Summary by Sourcery

Add intermediate-value tracking and optional dashboard visualization to the Optuna integration.

New Features:
- Record Optuna intermediate trial values as ordered Visdom metrics, including values from pruned trials.
- Add optional Optuna study dashboards with summary, trial, optimization, timeline, parameter-importance, and intermediate-value visualizations.

Enhancements:
- Support configurable dashboard creation and periodic refreshes with safe handling when visualization dependencies or data are unavailable.
- Link dashboard summaries to the best and latest trial environments.

Documentation:
- Document Optuna intermediate-value recording, dashboard usage, and Plotly requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Optuna study dashboards with configurable refresh intervals.
  * Dashboards include study summaries, hyperparameters, optimization history, parameter importance, intermediate metrics, timelines, and links to individual trials.
  * Added safer trial navigation and support for studies with or without named metrics.
  * Dashboard updates can warn or raise errors based on configuration.
  * Studies without completed or feasible trials no longer fail when displaying best-trial information.

* **Documentation**
  * Expanded Optuna integration guidance, including Plotly setup, dashboard configuration, supported trial states, panes, metrics, links, and post-trial recording behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->