### PR TITLE
feat: add opt-in experiment tracking to VisdomKerasLogger

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,10 +569,24 @@ model.fit(x_train, y_train, epochs=20, callbacks=[logger])
 
 Each metric gets its own window titled `"<name> (step)"`, throttled to one send every `log_every` batches. The optimizer's current learning rate is read (not computed) and plotted alongside as `lr`.
 
+**Experiment tracking with `params`** — records the run in the ExperimentStore alongside the charts, so it becomes queryable through [`vis.search_experiments`](#vissearch_experiments) / [`vis.compare_experiments`](#viscompare_experiments). Off by default. Without `params` the logger only ever calls `viz.line()`:
+
+```python
+logger = VisdomKerasLogger(viz, env="keras_run", params={"lr": 0.01})
+model.fit(x_train, y_train, epochs=20, callbacks=[logger])
+
+viz.search_experiments("status = finished")
+```
+
+Hyper-parameters are recorded when training begins, each epoch's metrics as they are plotted, and the run is marked `finished` when `fit()` returns. Only epoch metrics are recorded — per-batch values from `log_every` stay visualization-only so a run's metric history keeps the granularity the search and compare views read it at.
+
+**Note:** a finished experiment rejects further writes, so an env records one tracked run. Give every run its own env, including a repeat run of the same script. Keras reports no exception to `on_train_end`, so a tracked run is always recorded as `finished`. Call `viz.finish_experiment(status="failed", env=...)` directly to record a run that did not.
+
 **Parameters:**
 - `viz`: a connected `visdom.Visdom()` instance
 - `env`: environment name (default: `viz.env` if set, otherwise auto-generated from timestamp)
 - `log_every`: also plot metrics at batch granularity, one send every N batches (default: `None`, disabled)
+- `params`: hyper-parameters to record, opting the run into experiment tracking (default: `None`, disabled)
 
 **Note:** each call to `viz.line()` is a synchronous network request made on the training thread. Pick a `log_every` large enough that it doesn't stall training waiting on the server — 50+ is a reasonable default on GPU.
 

--- a/example/train_keras_example.py
+++ b/example/train_keras_example.py
@@ -22,7 +22,8 @@ def main():
     y_train, y_val = y[:400], y[400:]
 
     viz = visdom.Visdom()
-    logger = VisdomKerasLogger(viz, env="keras_run", log_every=5)
+    params = {"optimizer": "adam", "epochs": 20, "hidden_units": 32}
+    logger = VisdomKerasLogger(viz, env="keras_run", log_every=5, params=params)
 
     model = keras.Sequential(
         [

--- a/py/visdom/loggers/keras.py
+++ b/py/visdom/loggers/keras.py
@@ -54,6 +54,23 @@ class VisdomKerasLogger(Callback):
     Not thread-safe: _step/_wins/_step_wins have no locking, so calling
     fit() on the same instance from multiple threads can race.
 
+    Passing params opts into experiment tracking: the run is recorded in
+    the ExperimentStore (viz.experiment() on train begin, viz.log_metrics()
+    once per epoch, viz.finish_experiment() on train end) so it becomes
+    queryable via viz.search_experiments() / viz.compare_experiments().
+    Without params, this logger only ever calls viz.line() — same as
+    before this existed. Only epoch metrics are recorded; per-batch
+    values stay visualization-only so a run's metric history keeps the
+    granularity the search and compare views read it at.
+
+    Tracking finishes the env's experiment when fit() returns, and a
+    finished experiment rejects further writes, so one env holds one
+    tracked run. Give each run in a sweep its own env; reusing an env
+    keeps plotting but leaves the later runs out of the experiment
+    record. Keras reports no exception to on_train_end, so a tracked run
+    is always recorded as "finished" — call viz.finish_experiment(
+    status="failed", env=...) directly to record a run that did not.
+
     Usage::
 
         from visdom.loggers import VisdomKerasLogger
@@ -65,9 +82,16 @@ class VisdomKerasLogger(Callback):
         # with per-batch logging + LR tracking, one send every 50 batches
         logger = VisdomKerasLogger(viz, log_every=50)
         model.fit(x_train, y_train, epochs=10, callbacks=[logger])
+
+        # with experiment tracking, one env per run
+        for lr in [0.1, 0.01]:
+            logger = VisdomKerasLogger(
+                viz, env="sweep_lr_{}".format(lr), params={"lr": lr}
+            )
+            model.fit(x_train, y_train, epochs=10, callbacks=[logger])
     """
 
-    def __init__(self, viz, env=None, log_every=None):
+    def __init__(self, viz, env=None, log_every=None, params=None):
         super().__init__()
         self.viz = viz
         _viz_env = getattr(viz, "env", None)
@@ -81,12 +105,21 @@ class VisdomKerasLogger(Callback):
             if log_every < 1:
                 raise ValueError("log_every must be >= 1, got {}".format(log_every))
         self.log_every = log_every
+        self._params = params
         self._wins = {}
         self._step_wins = {}
         self._step = 0
 
     def on_train_begin(self, logs=None):
         self._step = 0
+        if self._params is not None:
+            try:
+                self.viz.experiment(params=self._params, env=self.env)
+            except Exception as e:
+                warnings.warn(
+                    "VisdomKerasLogger failed to start experiment "
+                    "tracking: {}".format(e)
+                )
 
     def on_epoch_end(self, epoch, logs=None):
         if not logs:
@@ -137,6 +170,24 @@ class VisdomKerasLogger(Callback):
             warnings.warn(
                 "VisdomKerasLogger failed to log epoch {}: {}".format(epoch, e)
             )
+        if self._params is not None:
+            try:
+                self.viz.log_metrics(logs, step=epoch, env=self.env)
+            except Exception as e:
+                warnings.warn(
+                    "VisdomKerasLogger failed to log epoch {} metrics to "
+                    "experiment tracking: {}".format(epoch, e)
+                )
+
+    def on_train_end(self, logs=None):
+        if self._params is not None:
+            try:
+                self.viz.finish_experiment(env=self.env)
+            except Exception as e:
+                warnings.warn(
+                    "VisdomKerasLogger failed to finish experiment "
+                    "tracking: {}".format(e)
+                )
 
     def _plot_step(self, win_name, value, replace):
         if win_name not in self._step_wins:

--- a/py/visdom/loggers/keras.py
+++ b/py/visdom/loggers/keras.py
@@ -105,6 +105,8 @@ class VisdomKerasLogger(Callback):
             if log_every < 1:
                 raise ValueError("log_every must be >= 1, got {}".format(log_every))
         self.log_every = log_every
+        if params is not None and not isinstance(params, dict):
+            raise TypeError("params must be a dict of {name: value}")
         self._params = params
         self._wins = {}
         self._step_wins = {}

--- a/py/visdom/loggers/keras.py
+++ b/py/visdom/loggers/keras.py
@@ -112,16 +112,42 @@ class VisdomKerasLogger(Callback):
         self._step_wins = {}
         self._step = 0
 
+    @staticmethod
+    def _check_experiment_reply(reply, action):
+        """Warn if the server rejected an experiment-tracking call.
+
+        Connection failures raise and are caught by the callers below, but a
+        server-side rejection (readonly server, already-finished experiment,
+        unknown env) comes back as an ordinary reply with no exception. A
+        successful reply is always the stored experiment dict, keyed by
+        "env_id"; anything else means nothing was recorded. `reply is True`
+        is `_send`'s own sentinel for offline mode, where nothing was sent
+        to a server at all, so it is not a rejection.
+
+        Returns True if the call succeeded (or was offline), False if it
+        was rejected, so on_train_begin can stop retrying after a failed
+        handshake.
+        """
+        if reply is True:
+            return True
+        if not isinstance(reply, dict) or "env_id" not in reply:
+            warnings.warn("VisdomKerasLogger failed to {}: {}".format(action, reply))
+            return False
+        return True
+
     def on_train_begin(self, logs=None):
         self._step = 0
         if self._params is not None:
             try:
-                self.viz.experiment(params=self._params, env=self.env)
+                reply = self.viz.experiment(params=self._params, env=self.env)
+                if not self._check_experiment_reply(reply, "start experiment tracking"):
+                    self._params = None
             except Exception as e:
                 warnings.warn(
                     "VisdomKerasLogger failed to start experiment "
                     "tracking: {}".format(e)
                 )
+                self._params = None
 
     def on_epoch_end(self, epoch, logs=None):
         if not logs:
@@ -174,7 +200,10 @@ class VisdomKerasLogger(Callback):
             )
         if self._params is not None:
             try:
-                self.viz.log_metrics(logs, step=epoch, env=self.env)
+                reply = self.viz.log_metrics(logs, step=epoch, env=self.env)
+                self._check_experiment_reply(
+                    reply, "log epoch {} metrics to experiment tracking".format(epoch)
+                )
             except Exception as e:
                 warnings.warn(
                     "VisdomKerasLogger failed to log epoch {} metrics to "
@@ -184,7 +213,8 @@ class VisdomKerasLogger(Callback):
     def on_train_end(self, logs=None):
         if self._params is not None:
             try:
-                self.viz.finish_experiment(env=self.env)
+                reply = self.viz.finish_experiment(env=self.env)
+                self._check_experiment_reply(reply, "finish experiment tracking")
             except Exception as e:
                 warnings.warn(
                     "VisdomKerasLogger failed to finish experiment "


### PR DESCRIPTION
## Description
Adds an opt-in `params=` kwarg to `VisdomKerasLogger` that records the run in the `ExperimentStore` (`viz.experiment()` on train begin, `viz.log_metrics()` per epoch, `viz.finish_experiment()` on train end) alongside existing `viz.line()` plotting. Only epoch metrics are recorded; per-batch values from `log_every` stay visualization-only

## Motivation and Context
Keras runs tracked via `VisdomKerasLogger` were only visible as charts, with no way to query/compare hyperparameters and metrics across runs.

## How Has This Been Tested?
Ran `example/train_keras_example.py` end to end with `params={"optimizer": "adam", "epochs": 20, "hidden_units": 32}` against a live server and confirmed the experiment landed with status `finished`, all three params recorded, and all four metrics captured once per epoch.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

## Summary by Sourcery

Enable optional experiment tracking for Keras runs while retaining existing Visdom chart logging.

New Features:
- Add opt-in experiment tracking to VisdomKerasLogger through a new params argument, recording hyperparameters, epoch metrics, and run completion status.

Enhancements:
- Preserve existing chart-only behavior when experiment tracking is not enabled and warn without disrupting training when tracking operations fail.

Documentation:
- Document Keras experiment tracking, per-run environment requirements, and queryable experiment workflows.

Chores:
- Update the Keras example to demonstrate tracked hyperparameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional experiment tracking for Keras training runs through a `params` option.
  - Records training configuration and epoch-level metrics for tracked runs.
  - Per-batch logging remains available for visualization without being added to experiment records.
  - Tracking failures generate warnings and disable tracking for the affected run.

- **Documentation**
  - Documented Keras experiment tracking and expanded Optuna guidance.
  - Added multi-objective examples, Pareto-front dashboards, accurate timeline rendering, and single-objective limitations for intermediate-value reporting and pruning.
  - Updated the Keras example to demonstrate experiment tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->