### PR TITLE
Add multi-objective Pareto front visualization for Optuna studies

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,8 @@ See `example/train_keras_example.py` for a full working example.
 
 **Requirements:** `pip install visdom optuna`
 
+**Dashboard visualizations:** `pip install plotly`
+
 `visdom.integrations.OptunaCallback` implements Optuna's study callback
 protocol. After each trial finishes it records the trial's parameters, objective
 values and state as a Visdom experiment in a dedicated environment. Optuna is
@@ -600,6 +602,8 @@ callback = OptunaCallback(
     viz,
     dashboard_env="optuna_quadratic",
     objective_names=["loss"],
+    create_dashboard=True,
+    refresh_every=10,
 )
 
 
@@ -610,14 +614,21 @@ def objective(trial):
 
 study = optuna.create_study(study_name="quadratic", direction="minimize")
 study.optimize(objective, n_trials=100, callbacks=[callback])
+callback.update_dashboard(study)
 ```
 
-This first-stage integration records one experiment per trial, using names such
-as `optuna_quadratic_trial_000017`. Pass `raise_on_error=True` if a Visdom
-logging failure should stop optimization; by default it emits a warning and
-allows the study to continue. Single- and multi-objective studies are supported,
-and `COMPLETE`, `PRUNED` and `FAIL` states are preserved in the
-`optuna_state` tag.
+The integration records one experiment per trial, using names such as
+`optuna_quadratic_trial_000017`. With `create_dashboard=True`, the first trial
+creates summary, HParams, optimization history and timeline panes, plus
+parameter importance when Optuna can compute it. Later trials refresh the panes
+in `optuna_quadratic` every `refresh_every` successful writes. The explicit
+final `update_dashboard()` includes any trials left since the last scheduled
+refresh. Plotly is only needed for the Optuna visualization panes.
+
+Pass `raise_on_error=True` if a Visdom logging failure should stop optimization;
+by default it emits a warning and allows the study to continue. Single- and
+multi-objective studies are supported, and `COMPLETE`, `PRUNED` and `FAIL`
+states are preserved in the `optuna_state` tag.
 
 ## Details
 <img src="https://user-images.githubusercontent.com/19650074/198747904-7a8a580f-851a-45fb-8f45-94e54a910ee2.png"/>

--- a/README.md
+++ b/README.md
@@ -618,17 +618,29 @@ callback.update_dashboard(study)
 ```
 
 The integration records one experiment per trial, using names such as
-`optuna_quadratic_trial_000017`. With `create_dashboard=True`, the first trial
-creates summary, HParams, optimization history and timeline panes, plus
-parameter importance when Optuna can compute it. Later trials refresh the panes
-in `optuna_quadratic` every `refresh_every` successful writes. The explicit
-final `update_dashboard()` includes any trials left since the last scheduled
-refresh. Plotly is only needed for the Optuna visualization panes.
+`optuna_quadratic_trial_000017`. Intermediate values reported with
+`trial.report(value, step)` are stored as the `intermediate_value` metric in
+step order before the final objective value. With `create_dashboard=True`, the
+first trial creates summary, HParams, optimization history and timeline panes,
+plus intermediate-value and parameter-importance panes when Optuna can compute
+them. Later trials refresh the panes in `optuna_quadratic` every `refresh_every`
+successful writes. The explicit final `update_dashboard()` includes any trials
+left since the last scheduled refresh. Plotly is only needed for the Optuna
+visualization panes.
+
+The summary pane links directly to the best and latest terminal trial
+environments. The callback never opens a browser on its own.
 
 Pass `raise_on_error=True` if a Visdom logging failure should stop optimization;
 by default it emits a warning and allows the study to continue. Single- and
 multi-objective studies are supported, and `COMPLETE`, `PRUNED` and `FAIL`
-states are preserved in the `optuna_state` tag.
+states are preserved in the `optuna_state` tag. A pruned trial retains every
+intermediate value reported before pruning. Optuna remains responsible for the
+pruning decision: call `trial.report()` and `trial.should_prune()` inside the
+objective and raise `optuna.TrialPruned` when requested. Because Optuna invokes
+study callbacks after a trial reaches a terminal state, `OptunaCallback`
+records these values after the trial finishes rather than streaming them while
+the trial is running.
 
 ## Details
 <img src="https://user-images.githubusercontent.com/19650074/198747904-7a8a580f-851a-45fb-8f45-94e54a910ee2.png"/>

--- a/README.md
+++ b/README.md
@@ -617,13 +617,41 @@ study.optimize(objective, n_trials=100, callbacks=[callback])
 callback.update_dashboard(study)
 ```
 
+For multi-objective studies, list the objective names in the same order as the
+study directions and return values:
+
+```python
+callback = OptunaCallback(
+    viz,
+    dashboard_env="optuna_accuracy_latency",
+    objective_names=["accuracy", "latency_ms"],
+    create_dashboard=True,
+)
+
+
+def multi_objective(trial):
+    width = trial.suggest_int("width", 1, 10)
+    accuracy = 0.80 + 0.01 * width
+    latency_ms = 10.0 + 2.0 * width
+    return accuracy, latency_ms
+
+
+study = optuna.create_study(
+    study_name="accuracy-latency",
+    directions=["maximize", "minimize"],
+)
+study.optimize(multi_objective, n_trials=40, callbacks=[callback])
+callback.update_dashboard(study)
+```
+
 The integration records one experiment per trial, using names such as
 `optuna_quadratic_trial_000017`. Intermediate values reported with
 `trial.report(value, step)` are stored as the `intermediate_value` metric in
 step order before the final objective value. With `create_dashboard=True`, the
 first trial creates summary, HParams, optimization history and timeline panes,
 plus intermediate-value and parameter-importance panes when Optuna can compute
-them. Later trials refresh the panes in `optuna_quadratic` every `refresh_every`
+them. Completed studies with two or three objectives also get a Pareto-front
+pane. Later trials refresh the panes in `optuna_quadratic` every `refresh_every`
 successful writes. The explicit final `update_dashboard()` includes any trials
 left since the last scheduled refresh. Plotly is only needed for the Optuna
 visualization panes.
@@ -640,7 +668,9 @@ pruning decision: call `trial.report()` and `trial.should_prune()` inside the
 objective and raise `optuna.TrialPruned` when requested. Because Optuna invokes
 study callbacks after a trial reaches a terminal state, `OptunaCallback`
 records these values after the trial finishes rather than streaming them while
-the trial is running.
+the trial is running. Optuna does not support `trial.report()` or
+`trial.should_prune()` for multi-objective studies, so intermediate-value and
+pruning support applies only to single-objective studies.
 
 ## Details
 <img src="https://user-images.githubusercontent.com/19650074/198747904-7a8a580f-851a-45fb-8f45-94e54a910ee2.png"/>

--- a/README.md
+++ b/README.md
@@ -654,7 +654,9 @@ them. Completed studies with two or three objectives also get a Pareto-front
 pane. Later trials refresh the panes in `optuna_quadratic` every `refresh_every`
 successful writes. The explicit final `update_dashboard()` includes any trials
 left since the last scheduled refresh. Plotly is only needed for the Optuna
-visualization panes.
+visualization panes. Timeline bars preserve each trial's true duration, and a
+fixed-size marker at the true start time keeps even sub-pixel trials visible and
+hoverable without exaggerating their runtime.
 
 The summary pane links directly to the best and latest terminal trial
 environments. The callback never opens a browser on its own.

--- a/py/tests/unit/optuna_integration.py
+++ b/py/tests/unit/optuna_integration.py
@@ -52,7 +52,7 @@ def fake_visualization_module(intermediate_error=None):
         "importance": Mock(name="importance"),
         "intermediate": Mock(name="intermediate"),
         "pareto": Mock(name="pareto"),
-        "timeline": Mock(name="timeline"),
+        "timeline": Mock(name="timeline", data=()),
     }
     visualization.plot_optimization_history = Mock(return_value=figures["history"])
     visualization.plot_param_importances = Mock(return_value=figures["importance"])

--- a/py/tests/unit/optuna_integration.py
+++ b/py/tests/unit/optuna_integration.py
@@ -14,7 +14,12 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import Mock, call, patch
 
+import pytest
+
 from visdom.integrations import OptunaCallback
+
+
+pytestmark = pytest.mark.unit
 
 
 def make_trial(
@@ -45,7 +50,7 @@ def make_study(trials):
     )
 
 
-def fake_visualization_module(intermediate_error=None):
+def fake_visualization_module(intermediate_error=None, history_error=None):
     visualization = types.ModuleType("optuna.visualization")
     figures = {
         "history": Mock(name="history"),
@@ -54,7 +59,9 @@ def fake_visualization_module(intermediate_error=None):
         "pareto": Mock(name="pareto"),
         "timeline": Mock(name="timeline", data=()),
     }
-    visualization.plot_optimization_history = Mock(return_value=figures["history"])
+    visualization.plot_optimization_history = Mock(
+        return_value=figures["history"], side_effect=history_error
+    )
     visualization.plot_param_importances = Mock(return_value=figures["importance"])
     visualization.plot_intermediate_values = Mock(
         return_value=figures["intermediate"], side_effect=intermediate_error
@@ -66,6 +73,59 @@ def fake_visualization_module(intermediate_error=None):
     optuna.__path__ = []
     optuna.visualization = visualization
     return optuna, visualization, figures
+
+
+class TestOptunaEnvironmentIds(unittest.TestCase):
+    def test_study_name_slashes_are_sanitized_before_trial_ids_are_used(self):
+        trial = make_trial(number=3)
+        study = make_study([trial])
+        study.study_name = "team/study"
+        viz = Mock()
+        callback = OptunaCallback(viz)
+
+        callback(study, trial)
+
+        self.assertEqual(callback.study_env(study), "optuna_team_study")
+        self.assertEqual(
+            callback.trial_env(trial, study),
+            "optuna_team_study_trial_000003",
+        )
+        self.assertEqual(callback._trial_envs, ["optuna_team_study_trial_000003"])
+        self.assertEqual(
+            viz.experiment.call_args.kwargs["env"],
+            "optuna_team_study_trial_000003",
+        )
+
+
+class TestOptunaDashboardErrorHandling(unittest.TestCase):
+    def test_figure_generation_failure_uses_dashboard_error_policy(self):
+        trial = make_trial()
+        study = make_study([trial])
+        study.best_trial = trial
+        optuna, visualization, _ = fake_visualization_module(
+            history_error=RuntimeError("figure exploded")
+        )
+        modules = {
+            "optuna": optuna,
+            "optuna.visualization": visualization,
+        }
+
+        warning_viz = Mock()
+        warning_callback = OptunaCallback(warning_viz)
+        warning_callback._trial_envs = [warning_callback.trial_env(trial, study)]
+        with patch.dict(sys.modules, modules):
+            with self.assertWarnsRegex(
+                RuntimeWarning,
+                "failed to update the dashboard: figure exploded",
+            ):
+                self.assertFalse(warning_callback.update_dashboard(study))
+        warning_viz.text.assert_not_called()
+
+        raising_callback = OptunaCallback(Mock(), raise_on_error=True)
+        raising_callback._trial_envs = [raising_callback.trial_env(trial, study)]
+        with patch.dict(sys.modules, modules):
+            with self.assertRaisesRegex(RuntimeError, "figure exploded"):
+                raising_callback.update_dashboard(study)
 
 
 class TestOptunaIntermediateValues(unittest.TestCase):

--- a/py/tests/unit/optuna_integration.py
+++ b/py/tests/unit/optuna_integration.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+
+# Copyright 2017-present, The Visdom Authors
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Unit tests for the optional Optuna experiment integration."""
+
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, call, patch
+
+from visdom.integrations import OptunaCallback
+
+
+def make_trial(
+    number=0,
+    state="COMPLETE",
+    values=(0.25,),
+    params=None,
+    intermediate_values=None,
+):
+    return SimpleNamespace(
+        number=number,
+        state=SimpleNamespace(name=state),
+        values=values,
+        params=params or {"x": 2.0},
+        intermediate_values=intermediate_values or {},
+    )
+
+
+def make_study(trials):
+    return SimpleNamespace(
+        study_name="quadratic",
+        directions=[SimpleNamespace(name="MINIMIZE")],
+        metric_names=None,
+        best_value=0.25,
+        best_params={"x": 2.0},
+        best_trials=[],
+        get_trials=Mock(return_value=trials),
+    )
+
+
+def fake_visualization_module(intermediate_error=None):
+    visualization = types.ModuleType("optuna.visualization")
+    figures = {
+        "history": Mock(name="history"),
+        "importance": Mock(name="importance"),
+        "intermediate": Mock(name="intermediate"),
+        "pareto": Mock(name="pareto"),
+        "timeline": Mock(name="timeline"),
+    }
+    visualization.plot_optimization_history = Mock(return_value=figures["history"])
+    visualization.plot_param_importances = Mock(return_value=figures["importance"])
+    visualization.plot_intermediate_values = Mock(
+        return_value=figures["intermediate"], side_effect=intermediate_error
+    )
+    visualization.plot_pareto_front = Mock(return_value=figures["pareto"])
+    visualization.plot_timeline = Mock(return_value=figures["timeline"])
+
+    optuna = types.ModuleType("optuna")
+    optuna.__path__ = []
+    optuna.visualization = visualization
+    return optuna, visualization, figures
+
+
+class TestOptunaIntermediateValues(unittest.TestCase):
+    def test_logs_intermediate_values_in_step_order_before_final_metric(self):
+        viz = Mock()
+        trial = make_trial(
+            values=(0.2,),
+            intermediate_values={2: 0.3, 0: 0.9, 1: 0.5},
+        )
+        callback = OptunaCallback(viz, dashboard_env="optuna_quadratic")
+
+        callback(make_study([trial]), trial)
+
+        self.assertEqual(
+            viz.log_metrics.call_args_list,
+            [
+                call(
+                    {"intermediate_value": 0.9},
+                    step=0,
+                    env="optuna_quadratic_trial_000000",
+                ),
+                call(
+                    {"intermediate_value": 0.5},
+                    step=1,
+                    env="optuna_quadratic_trial_000000",
+                ),
+                call(
+                    {"intermediate_value": 0.3},
+                    step=2,
+                    env="optuna_quadratic_trial_000000",
+                ),
+                call(
+                    {"objective": 0.2},
+                    env="optuna_quadratic_trial_000000",
+                ),
+            ],
+        )
+        self.assertEqual(
+            [method[0] for method in viz.method_calls],
+            [
+                "experiment",
+                "log_metrics",
+                "log_metrics",
+                "log_metrics",
+                "log_metrics",
+                "finish_experiment",
+            ],
+        )
+
+    def test_trial_without_intermediate_values_only_logs_final_metric(self):
+        viz = Mock()
+        trial = make_trial(values=(0.2,))
+        callback = OptunaCallback(viz, dashboard_env="optuna_quadratic")
+
+        callback(make_study([trial]), trial)
+
+        viz.log_metrics.assert_called_once_with(
+            {"objective": 0.2}, env="optuna_quadratic_trial_000000"
+        )
+
+    def test_pruned_trial_preserves_intermediate_values_and_failed_status(self):
+        viz = Mock()
+        trial = make_trial(
+            state="PRUNED",
+            values=None,
+            intermediate_values={4: 0.6},
+        )
+        callback = OptunaCallback(viz, dashboard_env="optuna_quadratic")
+
+        callback(make_study([trial]), trial)
+
+        viz.log_metrics.assert_called_once_with(
+            {"intermediate_value": 0.6},
+            step=4,
+            env="optuna_quadratic_trial_000000",
+        )
+        self.assertEqual(
+            viz.experiment.call_args.kwargs["tags"]["optuna_state"], "PRUNED"
+        )
+        viz.finish_experiment.assert_called_once_with(
+            status="failed", env="optuna_quadratic_trial_000000"
+        )
+
+    def test_intermediate_logging_failure_uses_existing_error_policy(self):
+        trial = make_trial(intermediate_values={0: 0.9})
+        study = make_study([trial])
+
+        warning_viz = Mock()
+        warning_viz.log_metrics.side_effect = RuntimeError("offline")
+        warning_callback = OptunaCallback(warning_viz, dashboard_env="optuna_quadratic")
+        with self.assertWarnsRegex(RuntimeWarning, "failed to log trial 0: offline"):
+            warning_callback(study, trial)
+        warning_viz.finish_experiment.assert_not_called()
+        self.assertEqual(warning_callback._trial_envs, [])
+
+        raising_viz = Mock()
+        raising_viz.log_metrics.side_effect = RuntimeError("offline")
+        raising_callback = OptunaCallback(
+            raising_viz,
+            dashboard_env="optuna_quadratic",
+            raise_on_error=True,
+        )
+        with self.assertRaisesRegex(RuntimeError, "offline"):
+            raising_callback(study, trial)
+
+
+class TestOptunaIntermediateDashboard(unittest.TestCase):
+    def dashboard_figures(self, trial, intermediate_error=None):
+        optuna, visualization, figures = fake_visualization_module(
+            intermediate_error=intermediate_error
+        )
+        modules = {
+            "optuna": optuna,
+            "optuna.visualization": visualization,
+        }
+        callback = OptunaCallback(Mock(), dashboard_env="optuna_quadratic")
+        with patch.dict(sys.modules, modules):
+            result = callback._dashboard_figures(make_study([trial]))
+        return result, visualization, figures
+
+    def test_adds_intermediate_figure_when_values_exist(self):
+        trial = make_trial(intermediate_values={0: 0.9})
+
+        result, visualization, figures = self.dashboard_figures(trial)
+
+        self.assertEqual(
+            [win for win, _ in result],
+            ["optuna-history", "optuna-intermediate-values", "optuna-timeline"],
+        )
+        visualization.plot_intermediate_values.assert_called_once()
+        figures["intermediate"].update_layout.assert_called_once_with(
+            title="Optuna Intermediate Values"
+        )
+
+    def test_skips_intermediate_figure_when_values_are_absent(self):
+        result, visualization, _ = self.dashboard_figures(make_trial())
+
+        self.assertEqual(
+            [win for win, _ in result],
+            ["optuna-history", "optuna-timeline"],
+        )
+        visualization.plot_intermediate_values.assert_not_called()
+
+    def test_skips_intermediate_figure_when_optuna_cannot_build_it(self):
+        trial = make_trial(intermediate_values={0: 0.9})
+
+        result, visualization, _ = self.dashboard_figures(
+            trial, intermediate_error=ValueError("not enough data")
+        )
+
+        self.assertEqual(
+            [win for win, _ in result],
+            ["optuna-history", "optuna-timeline"],
+        )
+        visualization.plot_intermediate_values.assert_called_once()
+
+
+class TestOptunaMultiObjective(unittest.TestCase):
+    def test_logs_two_objectives_and_adds_pareto_front(self):
+        trial = make_trial(values=(0.92, 18.4))
+        study = SimpleNamespace(
+            study_name="accuracy-latency",
+            directions=[
+                SimpleNamespace(name="MAXIMIZE"),
+                SimpleNamespace(name="MINIMIZE"),
+            ],
+            metric_names=None,
+            best_trials=[trial],
+            get_trials=Mock(return_value=[trial]),
+        )
+        viz = Mock()
+        callback = OptunaCallback(
+            viz,
+            dashboard_env="optuna_accuracy_latency",
+            objective_names=["accuracy", "latency_ms"],
+        )
+
+        callback(study, trial)
+
+        viz.log_metrics.assert_called_once_with(
+            {"accuracy": 0.92, "latency_ms": 18.4},
+            env="optuna_accuracy_latency_trial_000000",
+        )
+        self.assertEqual(
+            viz.experiment.call_args.kwargs["tags"]["optuna_direction"],
+            "maximize,minimize",
+        )
+
+        optuna, visualization, figures = fake_visualization_module()
+        with patch.dict(
+            sys.modules,
+            {"optuna": optuna, "optuna.visualization": visualization},
+        ):
+            result = callback._dashboard_figures(study)
+
+        self.assertEqual(
+            [win for win, _ in result],
+            [
+                "optuna-history-0",
+                "optuna-history-1",
+                "optuna-pareto-front",
+                "optuna-timeline",
+            ],
+        )
+        visualization.plot_pareto_front.assert_called_once_with(
+            study,
+            target_names=["accuracy", "latency_ms"],
+        )
+        figures["pareto"].update_layout.assert_called_once_with(
+            title="Optuna Pareto Front"
+        )
+
+    def test_logs_three_objectives_and_adds_pareto_front(self):
+        trial = make_trial(values=(0.92, 18.4, 512.0))
+        study = SimpleNamespace(
+            study_name="accuracy-latency-memory",
+            directions=[
+                SimpleNamespace(name="MAXIMIZE"),
+                SimpleNamespace(name="MINIMIZE"),
+                SimpleNamespace(name="MINIMIZE"),
+            ],
+            metric_names=None,
+            best_trials=[trial],
+            get_trials=Mock(return_value=[trial]),
+        )
+        viz = Mock()
+        callback = OptunaCallback(
+            viz,
+            dashboard_env="optuna_accuracy_latency_memory",
+            objective_names=["accuracy", "latency_ms", "memory_mb"],
+        )
+
+        callback(study, trial)
+
+        viz.log_metrics.assert_called_once_with(
+            {"accuracy": 0.92, "latency_ms": 18.4, "memory_mb": 512.0},
+            env="optuna_accuracy_latency_memory_trial_000000",
+        )
+
+        optuna, visualization, figures = fake_visualization_module()
+        with patch.dict(
+            sys.modules,
+            {"optuna": optuna, "optuna.visualization": visualization},
+        ):
+            result = callback._dashboard_figures(study)
+
+        self.assertEqual(
+            [win for win, _ in result],
+            [
+                "optuna-history-0",
+                "optuna-history-1",
+                "optuna-history-2",
+                "optuna-pareto-front",
+                "optuna-timeline",
+            ],
+        )
+        visualization.plot_pareto_front.assert_called_once_with(
+            study,
+            target_names=["accuracy", "latency_ms", "memory_mb"],
+        )
+        figures["pareto"].update_layout.assert_called_once_with(
+            title="Optuna Pareto Front"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/py/visdom/integrations/optuna.py
+++ b/py/visdom/integrations/optuna.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import html
 import json
+import threading
 import warnings
 from collections import Counter
 from collections.abc import Mapping, Sequence
@@ -99,7 +100,7 @@ class OptunaCallback:
     ) -> None:
         if dashboard_env is not None and not isinstance(dashboard_env, str):
             raise TypeError("dashboard_env must be a string or None")
-        if dashboard_env == "":
+        if dashboard_env is not None and not dashboard_env.strip():
             raise ValueError("dashboard_env must not be empty")
         if isinstance(refresh_every, bool) or not isinstance(refresh_every, int):
             raise TypeError("refresh_every must be an integer")
@@ -116,6 +117,7 @@ class OptunaCallback:
         self._dashboard_created = False
         self._trials_since_refresh = 0
         self._trial_envs: list[str] = []
+        self._dashboard_lock = threading.RLock()
 
     @staticmethod
     def _validate_objective_names(
@@ -134,6 +136,12 @@ class OptunaCallback:
             raise ValueError("objective_names must contain non-empty strings")
         if len(set(names)) != len(names):
             raise ValueError("objective_names must be unique")
+        if _INTERMEDIATE_METRIC_NAME in names:
+            raise ValueError(
+                "objective_names must not contain reserved name {!r}".format(
+                    _INTERMEDIATE_METRIC_NAME
+                )
+            )
         return names
 
     @staticmethod
@@ -198,6 +206,12 @@ class OptunaCallback:
         if len(names) != value_count:
             raise ValueError(
                 "expected {} objective name(s), got {}".format(value_count, len(names))
+            )
+        if _INTERMEDIATE_METRIC_NAME in names:
+            raise ValueError(
+                "objective names must not contain reserved name {!r}".format(
+                    _INTERMEDIATE_METRIC_NAME
+                )
             )
         return names
 
@@ -366,8 +380,14 @@ class OptunaCallback:
                 if complete_trials >= 2:
                     try:
                         importance = plot_param_importances(study, **kwargs)
-                    except ValueError:
-                        pass
+                    except (ImportError, ValueError) as error:
+                        warnings.warn(
+                            "Skipping Optuna parameter importance plot: {}".format(
+                                error
+                            ),
+                            RuntimeWarning,
+                            stacklevel=2,
+                        )
                     else:
                         importance.update_layout(
                             title="Parameter Importance — {}".format(objective_name)
@@ -382,8 +402,12 @@ class OptunaCallback:
                         study,
                         target_names=list(objective_names),
                     )
-                except ValueError:
-                    pass
+                except ValueError as error:
+                    warnings.warn(
+                        "Skipping Optuna Pareto front plot: {}".format(error),
+                        RuntimeWarning,
+                        stacklevel=2,
+                    )
                 else:
                     pareto.update_layout(title="Optuna Pareto Front")
                     figures.append(("optuna-pareto-front", pareto))
@@ -391,14 +415,25 @@ class OptunaCallback:
             if any(self._intermediate_values(trial) for trial in trials):
                 try:
                     intermediate = plot_intermediate_values(study)
-                except ValueError:
-                    pass
+                except ValueError as error:
+                    warnings.warn(
+                        "Skipping Optuna intermediate values plot: {}".format(error),
+                        RuntimeWarning,
+                        stacklevel=2,
+                    )
                 else:
                     intermediate.update_layout(title="Optuna Intermediate Values")
                     figures.append(("optuna-intermediate-values", intermediate))
 
             timeline = plot_timeline(study)
-            self._add_timeline_markers(timeline)
+            try:
+                self._add_timeline_markers(timeline)
+            except (AttributeError, TypeError, ValueError) as error:
+                warnings.warn(
+                    "Skipping Optuna timeline markers: {}".format(error),
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
             timeline.update_layout(title="Optuna Trial Timeline")
             figures.append(("optuna-timeline", timeline))
             return figures
@@ -428,42 +463,44 @@ class OptunaCallback:
         loading trials from a resumed study is handled by the later resume
         integration.
         """
-        try:
-            payload = self._build_dashboard_payload(study)
-            self.viz.text(
-                payload["summary"],
-                win="optuna-summary",
-                env=payload["env"],
-                opts={"title": "Optuna Study"},
-            )
-            self.viz.hparams(
-                env_ids=payload["env_ids"],
-                win="optuna-trials",
-                env=payload["env"],
-                opts={"title": "Optuna Trials"},
-            )
-            for win, figure in payload["figures"]:
-                self.viz.plotlyplot(figure, win=win, env=payload["env"])
-        except Exception as error:
-            if self.raise_on_error:
-                raise
-            warnings.warn(
-                "OptunaCallback failed to update the dashboard: {}".format(error),
-                RuntimeWarning,
-                stacklevel=2,
-            )
-            return False
-        self._dashboard_created = True
-        self._trials_since_refresh = 0
-        return True
+        with self._dashboard_lock:
+            try:
+                payload = self._build_dashboard_payload(study)
+                self.viz.text(
+                    payload["summary"],
+                    win="optuna-summary",
+                    env=payload["env"],
+                    opts={"title": "Optuna Study"},
+                )
+                self.viz.hparams(
+                    env_ids=payload["env_ids"],
+                    win="optuna-trials",
+                    env=payload["env"],
+                    opts={"title": "Optuna Trials"},
+                )
+                for win, figure in payload["figures"]:
+                    self.viz.plotlyplot(figure, win=win, env=payload["env"])
+            except Exception as error:
+                if self.raise_on_error:
+                    raise
+                warnings.warn(
+                    "OptunaCallback failed to update the dashboard: {}".format(error),
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                return False
+            self._dashboard_created = True
+            self._trials_since_refresh = 0
+            return True
 
     def _maybe_update_dashboard(self, study: Any) -> None:
-        self._trials_since_refresh += 1
-        if (
-            not self._dashboard_created
-            or self._trials_since_refresh >= self.refresh_every
-        ):
-            self.update_dashboard(study)
+        with self._dashboard_lock:
+            self._trials_since_refresh += 1
+            if (
+                not self._dashboard_created
+                or self._trials_since_refresh >= self.refresh_every
+            ):
+                self.update_dashboard(study)
 
     def _build_payload(self, study: Any, trial: Any) -> dict[str, Any]:
         env = self.trial_env(trial, study)
@@ -521,6 +558,7 @@ class OptunaCallback:
             )
             return
 
-        self._trial_envs.append(payload["env"])
-        if self.create_dashboard:
-            self._maybe_update_dashboard(study)
+        with self._dashboard_lock:
+            self._trial_envs.append(payload["env"])
+            if self.create_dashboard:
+                self._maybe_update_dashboard(study)

--- a/py/visdom/integrations/optuna.py
+++ b/py/visdom/integrations/optuna.py
@@ -22,8 +22,10 @@ import warnings
 from collections import Counter
 from collections.abc import Mapping, Sequence
 from typing import Any
+from urllib.parse import quote
 
 from visdom.experiments.tags import normalize_tags
+from visdom.utils.server_utils import escape_eid
 
 
 class OptunaCallback:
@@ -149,6 +151,15 @@ class OptunaCallback:
             raise ValueError("study is required when dashboard_env was not supplied")
         return "{}_trial_{:06d}".format(self.study_env(study), trial.number)
 
+    def _trial_url(self, trial: Any, study: Any) -> str:
+        root = "{}:{}{}".format(
+            self.viz.server,
+            self.viz.port,
+            self.viz.base_url,
+        ).rstrip("/")
+        env = quote(escape_eid(self.trial_env(trial, study)), safe="")
+        return "{}/env/{}".format(root, env)
+
     def _metric_names(self, study: Any, value_count: int) -> tuple[str, ...]:
         if self.objective_names is not None:
             names = self.objective_names
@@ -186,6 +197,7 @@ class OptunaCallback:
     def _summary_html(self, study: Any) -> str:
         trials = study.get_trials(deepcopy=False)
         states = Counter(trial.state.name for trial in trials)
+        links = []
         rows = [
             ("Study", study.study_name),
             (
@@ -198,6 +210,7 @@ class OptunaCallback:
             ("Failed", states["FAIL"]),
         ]
         if len(study.directions) == 1 and states["COMPLETE"]:
+            links.append(("Open best trial", self._trial_url(study.best_trial, study)))
             rows.extend(
                 [
                     ("Best value", study.best_value),
@@ -214,13 +227,32 @@ class OptunaCallback:
         elif states["COMPLETE"]:
             rows.append(("Pareto trials", len(study.best_trials)))
 
+        terminal_trials = [
+            trial
+            for trial in trials
+            if trial.state.name in ("COMPLETE", "PRUNED", "FAIL")
+        ]
+        if terminal_trials:
+            latest_trial = max(terminal_trials, key=lambda trial: trial.number)
+            links.append(("Open latest trial", self._trial_url(latest_trial, study)))
+
         body = "".join(
             "<tr><th>{}</th><td>{}</td></tr>".format(
                 html.escape(str(label)), html.escape(str(value))
             )
             for label, value in rows
         )
-        return "<h3>Optuna Study</h3><table>{}</table>".format(body)
+        navigation = ""
+        if links:
+            anchors = " | ".join(
+                '<a href="{}" target="_blank" rel="noopener noreferrer">{}</a>'.format(
+                    html.escape(url, quote=True),
+                    html.escape(label),
+                )
+                for label, url in links
+            )
+            navigation = "<p><strong>Open in Visdom:</strong> {}</p>".format(anchors)
+        return "<h3>Optuna Study</h3><table>{}</table>{}".format(body, navigation)
 
     def _dashboard_figures(self, study: Any) -> list[tuple[str, Any]]:
         try:

--- a/py/visdom/integrations/optuna.py
+++ b/py/visdom/integrations/optuna.py
@@ -16,7 +16,10 @@ Visdom dependency just for this optional adapter.
 
 from __future__ import annotations
 
+import html
+import json
 import warnings
+from collections import Counter
 from collections.abc import Mapping, Sequence
 from typing import Any
 
@@ -24,7 +27,7 @@ from visdom.experiments.tags import normalize_tags
 
 
 class OptunaCallback:
-    """Log each completed Optuna trial to a dedicated Visdom environment.
+    """Log completed Optuna trials and optionally maintain a study dashboard.
 
     Instances are passed to ``Study.optimize(callbacks=[...])``. Optuna calls
     the instance with a ``Study`` and ``FrozenTrial`` after a trial finishes;
@@ -32,9 +35,13 @@ class OptunaCallback:
     Visdom's experiment API.
 
     ``dashboard_env`` is the namespace for the study and its trial
-    environments. When omitted it is derived from the Optuna study name. The
-    callback itself does not create a dashboard pane; it only establishes the
-    stable environment layout that a dashboard can aggregate later.
+    environments. When omitted it is derived from the Optuna study name.
+    ``create_dashboard=True`` creates a summary, an HParams pane and Optuna's
+    Plotly study visualizations in that environment. The first completed trial
+    creates the dashboard; later trials refresh it every ``refresh_every``
+    successful writes. Call :meth:`update_dashboard` after ``Study.optimize``
+    to ensure the final trials are included when the total is not an exact
+    multiple of that interval.
 
     Optuna is intentionally not imported here. This keeps the integration
     optional and also means importing :mod:`visdom.integrations` never requires
@@ -52,6 +59,8 @@ class OptunaCallback:
         raise_on_error: Re-raise Visdom logging failures when true. By default a
             warning is emitted so an unavailable dashboard does not stop the
             optimization.
+        create_dashboard: Create and periodically refresh the study dashboard.
+        refresh_every: Number of newly logged trials between dashboard refreshes.
 
     Example::
 
@@ -59,8 +68,10 @@ class OptunaCallback:
             viz,
             dashboard_env="optuna_resnet",
             objective_names=["validation_accuracy"],
+            create_dashboard=True,
         )
         study.optimize(objective, callbacks=[callback])
+        callback.update_dashboard(study)
     """
 
     def __init__(
@@ -70,17 +81,26 @@ class OptunaCallback:
         objective_names: Sequence[str] | None = None,
         tags: Mapping[str, str] | None = None,
         raise_on_error: bool = False,
+        create_dashboard: bool = False,
+        refresh_every: int = 10,
     ) -> None:
         if dashboard_env is not None and not isinstance(dashboard_env, str):
             raise TypeError("dashboard_env must be a string or None")
         if dashboard_env == "":
             raise ValueError("dashboard_env must not be empty")
+        if refresh_every < 1:
+            raise ValueError("refresh_every must be at least 1")
 
         self.viz = viz
         self.dashboard_env = dashboard_env
         self.objective_names = self._validate_objective_names(objective_names)
         self.tags = self._validate_tags(tags)
         self.raise_on_error = raise_on_error
+        self.create_dashboard = create_dashboard
+        self.refresh_every = refresh_every
+        self._dashboard_created = False
+        self._trials_since_refresh = 0
+        self._trial_envs: list[str] = []
 
     @staticmethod
     def _validate_objective_names(
@@ -163,6 +183,156 @@ class OptunaCallback:
         )
         return normalize_tags(tags)
 
+    def _summary_html(self, study: Any) -> str:
+        trials = study.get_trials(deepcopy=False)
+        states = Counter(trial.state.name for trial in trials)
+        rows = [
+            ("Study", study.study_name),
+            (
+                "Direction",
+                ", ".join(direction.name.lower() for direction in study.directions),
+            ),
+            ("Trials", len(trials)),
+            ("Complete", states["COMPLETE"]),
+            ("Pruned", states["PRUNED"]),
+            ("Failed", states["FAIL"]),
+        ]
+        if len(study.directions) == 1 and states["COMPLETE"]:
+            rows.extend(
+                [
+                    ("Best value", study.best_value),
+                    (
+                        "Best parameters",
+                        json.dumps(
+                            study.best_params,
+                            ensure_ascii=False,
+                            sort_keys=True,
+                        ),
+                    ),
+                ]
+            )
+        elif states["COMPLETE"]:
+            rows.append(("Pareto trials", len(study.best_trials)))
+
+        body = "".join(
+            "<tr><th>{}</th><td>{}</td></tr>".format(
+                html.escape(str(label)), html.escape(str(value))
+            )
+            for label, value in rows
+        )
+        return "<h3>Optuna Study</h3><table>{}</table>".format(body)
+
+    def _dashboard_figures(self, study: Any) -> list[tuple[str, Any]]:
+        try:
+            from optuna.visualization import (
+                plot_optimization_history,
+                plot_param_importances,
+                plot_timeline,
+            )
+
+            objective_names = self._metric_names(study, len(study.directions))
+            figures = []
+            multi_objective = len(objective_names) > 1
+            complete_trials = sum(
+                trial.state.name == "COMPLETE"
+                for trial in study.get_trials(deepcopy=False)
+            )
+            for index, objective_name in enumerate(objective_names):
+                target = (
+                    (lambda trial, i=index: trial.values[i])
+                    if multi_objective
+                    else None
+                )
+                kwargs: dict[str, Any] = {"target_name": objective_name}
+                if target is not None:
+                    kwargs["target"] = target
+                history = plot_optimization_history(study, **kwargs)
+                history.update_layout(
+                    title="Optimization History — {}".format(objective_name)
+                )
+                suffix = "-{}".format(index) if multi_objective else ""
+                figures.append(("optuna-history{}".format(suffix), history))
+
+                if complete_trials >= 2:
+                    try:
+                        importance = plot_param_importances(study, **kwargs)
+                    except ValueError:
+                        pass
+                    else:
+                        importance.update_layout(
+                            title="Parameter Importance — {}".format(objective_name)
+                        )
+                        figures.append(
+                            ("optuna-importance{}".format(suffix), importance)
+                        )
+
+            timeline = plot_timeline(study)
+            timeline.update_layout(title="Optuna Trial Timeline")
+            figures.append(("optuna-timeline", timeline))
+            return figures
+        except ImportError as error:
+            warnings.warn(
+                "Optuna dashboard plots are unavailable: {}".format(error),
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return []
+
+    def _build_dashboard_payload(self, study: Any) -> dict[str, Any]:
+        if not self._trial_envs:
+            raise ValueError("cannot create an Optuna dashboard before logging a trial")
+        return {
+            "env": self.study_env(study),
+            "env_ids": list(self._trial_envs),
+            "summary": self._summary_html(study),
+            "figures": self._dashboard_figures(study),
+        }
+
+    def update_dashboard(self, study: Any) -> bool:
+        """Create or refresh all dashboard panes for ``study``.
+
+        Returns whether the dashboard was written successfully. Only trials
+        logged by this callback instance are included in the HParams pane;
+        loading trials from a resumed study is handled by the later resume
+        integration.
+        """
+        payload = self._build_dashboard_payload(study)
+        try:
+            self.viz.text(
+                payload["summary"],
+                win="optuna-summary",
+                env=payload["env"],
+                opts={"title": "Optuna Study"},
+            )
+            self.viz.hparams(
+                env_ids=payload["env_ids"],
+                win="optuna-trials",
+                env=payload["env"],
+                opts={"title": "Optuna Trials"},
+            )
+            for win, figure in payload["figures"]:
+                self.viz.plotlyplot(figure, win=win, env=payload["env"])
+        except Exception as error:
+            if self.raise_on_error:
+                raise
+            warnings.warn(
+                "OptunaCallback failed to update the dashboard: {}".format(error),
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return False
+        self._dashboard_created = True
+        self._trials_since_refresh = 0
+        return True
+
+    def _maybe_update_dashboard(self, study: Any) -> None:
+        self._trials_since_refresh += 1
+        if (
+            not self._dashboard_created
+            or self._trials_since_refresh >= self.refresh_every
+        ):
+            self.update_dashboard(study)
+
     def _build_payload(self, study: Any, trial: Any) -> dict[str, Any]:
         env = self.trial_env(trial, study)
         state = trial.state.name
@@ -211,3 +381,8 @@ class OptunaCallback:
                 RuntimeWarning,
                 stacklevel=2,
             )
+            return
+
+        self._trial_envs.append(payload["env"])
+        if self.create_dashboard:
+            self._maybe_update_dashboard(study)

--- a/py/visdom/integrations/optuna.py
+++ b/py/visdom/integrations/optuna.py
@@ -269,6 +269,7 @@ class OptunaCallback:
                 plot_intermediate_values,
                 plot_optimization_history,
                 plot_param_importances,
+                plot_pareto_front,
                 plot_timeline,
             )
 
@@ -305,6 +306,18 @@ class OptunaCallback:
                         figures.append(
                             ("optuna-importance{}".format(suffix), importance)
                         )
+
+            if complete_trials and len(objective_names) in (2, 3):
+                try:
+                    pareto = plot_pareto_front(
+                        study,
+                        target_names=list(objective_names),
+                    )
+                except ValueError:
+                    pass
+                else:
+                    pareto.update_layout(title="Optuna Pareto Front")
+                    figures.append(("optuna-pareto-front", pareto))
 
             if any(self._intermediate_values(trial) for trial in trials):
                 try:

--- a/py/visdom/integrations/optuna.py
+++ b/py/visdom/integrations/optuna.py
@@ -203,6 +203,49 @@ class OptunaCallback:
         values = getattr(trial, "intermediate_values", None) or {}
         return sorted(values.items())
 
+    @staticmethod
+    def _add_timeline_markers(timeline: Any) -> None:
+        """Keep very short trials visible without changing their duration bars.
+
+        Optuna renders each trial as a horizontal bar whose width is its runtime.
+        When callback or scheduler overhead dominates a study's wall-clock span,
+        sub-millisecond trials can become substantially narrower than one browser
+        pixel. A fixed-size marker at each trial's true start time preserves the
+        timeline semantics while keeping those trials discoverable and hoverable.
+        """
+        for trace in tuple(timeline.data):
+            if trace.type != "bar" or trace.orientation != "h":
+                continue
+
+            starts = list(trace.base) if trace.base is not None else []
+            durations = list(trace.x) if trace.x is not None else []
+            trial_numbers = list(trace.y) if trace.y is not None else []
+            if not starts or not (len(starts) == len(durations) == len(trial_numbers)):
+                continue
+
+            text = list(trace.text) if trace.text is not None else None
+            color = trace.marker.color if trace.marker is not None else None
+            timeline.add_scatter(
+                x=starts,
+                y=trial_numbers,
+                mode="markers",
+                name=trace.name,
+                legendgroup=trace.name,
+                showlegend=False,
+                marker={
+                    "color": color,
+                    "size": 9,
+                    "symbol": "circle",
+                    "line": {"color": "white", "width": 1},
+                },
+                customdata=durations,
+                text=text,
+                hovertemplate=(
+                    "Start: %{x}<br>Duration: %{customdata:.3f} ms"
+                    "<br>%{text}<extra>" + html.escape(str(trace.name)) + "</extra>"
+                ),
+            )
+
     def _summary_html(self, study: Any) -> str:
         trials = study.get_trials(deepcopy=False)
         states = Counter(trial.state.name for trial in trials)
@@ -329,6 +372,7 @@ class OptunaCallback:
                     figures.append(("optuna-intermediate-values", intermediate))
 
             timeline = plot_timeline(study)
+            self._add_timeline_markers(timeline)
             timeline.update_layout(title="Optuna Trial Timeline")
             figures.append(("optuna-timeline", timeline))
             return figures

--- a/py/visdom/integrations/optuna.py
+++ b/py/visdom/integrations/optuna.py
@@ -137,8 +137,10 @@ class OptunaCallback:
     def study_env(self, study: Any) -> str:
         """Return the environment namespace for an Optuna study."""
         if self.dashboard_env is not None:
-            return self.dashboard_env
-        return "optuna_{}".format(study.study_name)
+            env = self.dashboard_env
+        else:
+            env = "optuna_{}".format(study.study_name)
+        return escape_eid(env)
 
     def trial_env(self, trial: Any, study: Any = None) -> str:
         """Return the deterministic Visdom environment for an Optuna trial.
@@ -402,8 +404,8 @@ class OptunaCallback:
         loading trials from a resumed study is handled by the later resume
         integration.
         """
-        payload = self._build_dashboard_payload(study)
         try:
+            payload = self._build_dashboard_payload(study)
             self.viz.text(
                 payload["summary"],
                 win="optuna-summary",

--- a/py/visdom/integrations/optuna.py
+++ b/py/visdom/integrations/optuna.py
@@ -65,7 +65,8 @@ class OptunaCallback:
             warning is emitted so an unavailable dashboard does not stop the
             optimization.
         create_dashboard: Create and periodically refresh the study dashboard.
-        refresh_every: Number of newly logged trials between dashboard refreshes.
+        refresh_every: Positive integer number of newly logged trials between
+            dashboard refreshes.
 
     Example::
 
@@ -93,6 +94,8 @@ class OptunaCallback:
             raise TypeError("dashboard_env must be a string or None")
         if dashboard_env == "":
             raise ValueError("dashboard_env must not be empty")
+        if isinstance(refresh_every, bool) or not isinstance(refresh_every, int):
+            raise TypeError("refresh_every must be an integer")
         if refresh_every < 1:
             raise ValueError("refresh_every must be at least 1")
 

--- a/py/visdom/integrations/optuna.py
+++ b/py/visdom/integrations/optuna.py
@@ -28,13 +28,16 @@ from visdom.experiments.tags import normalize_tags
 from visdom.utils.server_utils import escape_eid
 
 
+_INTERMEDIATE_METRIC_NAME = "intermediate_value"
+
+
 class OptunaCallback:
     """Log completed Optuna trials and optionally maintain a study dashboard.
 
     Instances are passed to ``Study.optimize(callbacks=[...])``. Optuna calls
     the instance with a ``Study`` and ``FrozenTrial`` after a trial finishes;
-    the callback stores the trial's parameters, objective values and state via
-    Visdom's experiment API.
+    the callback stores the trial's parameters, objective values, reported
+    intermediate values and state via Visdom's experiment API.
 
     ``dashboard_env`` is the namespace for the study and its trial
     environments. When omitted it is derived from the Optuna study name.
@@ -194,6 +197,12 @@ class OptunaCallback:
         )
         return normalize_tags(tags)
 
+    @staticmethod
+    def _intermediate_values(trial: Any) -> list[tuple[int, float]]:
+        """Return reported intermediate values ordered by training step."""
+        values = getattr(trial, "intermediate_values", None) or {}
+        return sorted(values.items())
+
     def _summary_html(self, study: Any) -> str:
         trials = study.get_trials(deepcopy=False)
         states = Counter(trial.state.name for trial in trials)
@@ -257,6 +266,7 @@ class OptunaCallback:
     def _dashboard_figures(self, study: Any) -> list[tuple[str, Any]]:
         try:
             from optuna.visualization import (
+                plot_intermediate_values,
                 plot_optimization_history,
                 plot_param_importances,
                 plot_timeline,
@@ -265,10 +275,8 @@ class OptunaCallback:
             objective_names = self._metric_names(study, len(study.directions))
             figures = []
             multi_objective = len(objective_names) > 1
-            complete_trials = sum(
-                trial.state.name == "COMPLETE"
-                for trial in study.get_trials(deepcopy=False)
-            )
+            trials = study.get_trials(deepcopy=False)
+            complete_trials = sum(trial.state.name == "COMPLETE" for trial in trials)
             for index, objective_name in enumerate(objective_names):
                 target = (
                     (lambda trial, i=index: trial.values[i])
@@ -297,6 +305,15 @@ class OptunaCallback:
                         figures.append(
                             ("optuna-importance{}".format(suffix), importance)
                         )
+
+            if any(self._intermediate_values(trial) for trial in trials):
+                try:
+                    intermediate = plot_intermediate_values(study)
+                except ValueError:
+                    pass
+                else:
+                    intermediate.update_layout(title="Optuna Intermediate Values")
+                    figures.append(("optuna-intermediate-values", intermediate))
 
             timeline = plot_timeline(study)
             timeline.update_layout(title="Optuna Trial Timeline")
@@ -399,6 +416,12 @@ class OptunaCallback:
                 description=payload["description"],
                 env=payload["env"],
             )
+            for step, value in self._intermediate_values(trial):
+                self.viz.log_metrics(
+                    {_INTERMEDIATE_METRIC_NAME: value},
+                    step=step,
+                    env=payload["env"],
+                )
             if payload["metrics"]:
                 self.viz.log_metrics(payload["metrics"], env=payload["env"])
             self.viz.finish_experiment(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`py/visdom/integrations/optuna.py`
  - Add an `optuna-pareto-front` dashboard pane for completed Optuna studies with **two or three** objectives.
  - Use the configured objective names as Pareto-front axis labels.

`py/tests/unit/optuna_integration.py`
  - Add separate tests for two-objective and three-objective metric logging and Pareto-front generation.

`README.md`
  - Add a multi-objective Optuna usage example.
  - Document Pareto-front dashboard behavior.
  - Clarify that Optuna intermediate reporting and pruning apply only to single-objective studies.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR adds changes to support pareto-front visualization for studies with two or three objectives.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, experiments you ran to see how -->
<!--- your change affects existing areas of the code and their behaviors, etc. -->
<!--- One method of testing is to run the `demo.py` script from the examples -->
<!--- both on your branch and a clean branch and ensure that none of the functionality -->
<!--- appears different. Be sure to install from source when testing. -->
Run the following code
```

import argparse
import math
import time
from collections import Counter

import optuna
import visdom

from visdom.integrations import OptunaCallback


OBJECTIVE_NAMES = ("accuracy", "latency_ms", "memory_mb")
OBJECTIVE_DIRECTIONS = ("maximize", "minimize", "minimize")


def parse_args() -> argparse.Namespace:
    parser = argparse.ArgumentParser(
        description=(
            "Optimize accuracy, latency, and memory and verify the Visdom "
            "three-objective Pareto-front pane."
        )
    )
    parser.add_argument("--server", default="http://localhost")
    parser.add_argument("--port", type=int, default=8097)
    parser.add_argument("--base-url", default="/")
    parser.add_argument(
        "--env",
        help="Dashboard environment; defaults to a unique timestamped name.",
    )
    parser.add_argument("--n-trials", type=int, default=30)
    parser.add_argument("--refresh-every", type=int, default=5)
    parser.add_argument("--seed", type=int, default=42)
    args = parser.parse_args()
    if args.n_trials < 3:
        parser.error("--n-trials must be at least 3")
    if args.refresh_every < 1:
        parser.error("--refresh-every must be at least 1")
    return args


def dashboard_url(viz: visdom.Visdom, env: str) -> str:
    root = "{}:{}{}".format(viz.server, viz.port, viz.base_url).rstrip("/")
    return "{}/env/{}".format(root, env)


def objective(trial: optuna.Trial) -> tuple[float, float, float]:
    """Return accuracy, latency, and memory with intentional trade-offs."""
    layers = trial.suggest_int("layers", 1, 6)
    width = trial.suggest_int("width", 32, 256, step=32)
    dropout = trial.suggest_float("dropout", 0.0, 0.5)
    learning_rate = trial.suggest_float("learning_rate", 1e-5, 1e-1, log=True)
    batch_size = trial.suggest_categorical("batch_size", [16, 32, 64, 128])

    capacity = layers * width
    accuracy = (
        0.70
        + 0.22 * (1.0 - math.exp(-capacity / 500.0))
        - 0.08 * abs(dropout - 0.20)
        - 0.02 * abs(math.log10(learning_rate) + 3.0)
    )
    latency_ms = 2.0 + capacity / 55.0 + batch_size / 128.0
    memory_mb = 96.0 + capacity * 0.60 + batch_size * 1.5
    return accuracy, latency_ms, memory_mb


def assert_study_results(study: optuna.Study, expected_trials: int) -> None:
    complete_trials = [
        trial for trial in study.trials if trial.state.name == "COMPLETE"
    ]
    if len(complete_trials) != expected_trials:
        raise AssertionError(
            "expected {} complete trials, got {}".format(
                expected_trials,
                len(complete_trials),
            )
        )
    if any(len(trial.values or ()) != 3 for trial in complete_trials):
        raise AssertionError(
            "every completed trial must contain three objective values"
        )
    if not study.best_trials:
        raise AssertionError("expected at least one trial on the Pareto front")


def main() -> None:
    args = parse_args()
    dashboard_env = args.env or "optuna_three_objectives_{}".format(int(time.time()))
    viz = visdom.Visdom(
        server=args.server,
        port=args.port,
        base_url=args.base_url,
        env=dashboard_env,
        use_incoming_socket=False,
        raise_exceptions=True,
    )
    if not viz.check_connection(timeout_seconds=3):
        raise SystemExit(
            "Cannot connect to Visdom at {}:{}. Start the server first with "
            "`python3 -m visdom.server`.".format(args.server, args.port)
        )

    callback = OptunaCallback(
        viz,
        dashboard_env=dashboard_env,
        objective_names=OBJECTIVE_NAMES,
        create_dashboard=True,
        refresh_every=args.refresh_every,
        raise_on_error=True,
    )
    study = optuna.create_study(
        study_name="accuracy-latency-memory",
        directions=OBJECTIVE_DIRECTIONS,
        sampler=optuna.samplers.NSGAIISampler(seed=args.seed),
    )
    study.optimize(objective, n_trials=args.n_trials, callbacks=[callback])

    if not callback.update_dashboard(study):
        raise RuntimeError("the final Optuna dashboard update failed")
    assert_study_results(study, args.n_trials)

    pareto_exists = viz.win_exists("optuna-pareto-front", env=dashboard_env)
    if str(pareto_exists).lower() != "true":
        raise AssertionError("the three-objective Pareto-front pane was not created")

    states = Counter(trial.state.name for trial in study.trials)
    print("\nThree-objective Optuna integration test passed.")
    print("Objectives: {}".format(", ".join(OBJECTIVE_NAMES)))
    print("Directions: {}".format(", ".join(OBJECTIVE_DIRECTIONS)))
    print("Trial states: {}".format(dict(states)))
    print("Pareto trials: {}".format(len(study.best_trials)))
    for trial in study.best_trials[:5]:
        print("  trial {}: {}".format(trial.number, tuple(trial.values)))
    print("Dashboard environment: {}".format(dashboard_env))
    print("Dashboard URL: {}".format(dashboard_url(viz, dashboard_env)))


if __name__ == "__main__":
    main()
```

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/f0434447-7f8f-4e54-bb99-e46492890881



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Summary by Sourcery

Extend the Optuna integration with optional study dashboards and multi-objective Pareto-front visualization while preserving single-objective intermediate reporting and pruning support.

New Features:
- Add optional Optuna study dashboards with summary, trial, history, timeline, intermediate-value, parameter-importance, and two- or three-objective Pareto-front visualizations.
- Support objective-specific metric logging and Pareto-front axis labels for multi-objective studies.
- Refresh dashboards periodically during optimization and allow explicit final updates.

Bug Fixes:
- Preserve and display Optuna intermediate values for single-objective trials, including pruned trials.

Enhancements:
- Improve Optuna dashboard summaries with study statistics and links to relevant trial environments.
- Keep short Optuna trials visible in timeline visualizations without altering their recorded durations.
- Sanitize study and trial environment identifiers for safe Visdom URLs.

Build:
- Document Plotly as an optional dependency for Optuna dashboard visualizations.

Documentation:
- Add single- and multi-objective Optuna dashboard examples and document visualization, refresh, intermediate reporting, and pruning behavior.

Tests:
- Add unit coverage for intermediate-value logging, dashboard generation and error handling, and two- and three-objective Pareto-front visualization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional Optuna study dashboards with summary, hyperparameter, optimization history, timeline, intermediate-value, parameter-importance, and Pareto-front visualizations.
  - Added configurable automatic refresh intervals, manual updates, intermediate-value tracking, and per-trial dashboard links.
  - Added support for multi-objective studies and objective directions.

- **Bug Fixes**
  - Improved dashboard validation and error handling with warnings for unsupported or unavailable visualizations.

- **Documentation**
  - Expanded Optuna setup guidance, examples, visualization requirements, refresh behavior, and single- versus multi-objective limitations.

- **Tests**
  - Added coverage for dashboards, trial statuses, intermediate values, error handling, and multi-objective visualizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->