### PR TITLE
fix: bump pane version on every update so patches are not discarded

### DIFF
--- a/py/tests/unit/pane_versions.py
+++ b/py/tests/unit/pane_versions.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+
+# Copyright 2017-present, The Visdom Authors
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Every accepted ``/update`` advances the pane's broadcast sequence number.
+
+``version`` is the handshake behind incremental updates: the server broadcasts
+``window_update`` carrying the pane's new version, and the frontend applies the
+patch only when it reads ``pane.version + 1`` (``updateWindow`` in
+``js/main.js``). A version that fails to move is not a cosmetic problem -- the
+client discards the patch and re-requests the entire environment instead.
+
+The bump used to live in ``update_window()``, which ``UpdateHandler.update()``
+reaches for plot panes but returns before for text, image_history, plot_history
+and table panes, and which the embeddings route never calls at all. Those four
+types stayed at version 1 for the life of the pane while the server kept
+broadcasting updates against them, so every ``vis.text()`` append cost a full
+environment reload. These tests pin the counter to ``update_packet()`` -- the
+one place an accepted update becomes a broadcast -- and assert it for every
+pane type rather than for the single type that happened to work.
+"""
+
+import json
+
+import pytest
+
+from visdom.server.defaults import (
+    DEFAULT_MAX_IMAGE_HISTORY,
+    DEFAULT_MAX_OLD_CONTENT,
+    DEFAULT_MAX_PLOT_HISTORY,
+    DEFAULT_MAX_TEXT_LINES,
+)
+from visdom.server.handlers.web_handlers import UpdateHandler
+from visdom.utils.shared_utils import get_rand_id
+
+from testutils.fakes import FakeHandler
+
+pytestmark = pytest.mark.unit
+
+
+def _pane(ptype, **extra):
+    pane = {
+        "command": "window",
+        "version": 1,
+        "id": "win_{}".format(ptype),
+        "title": ptype,
+        "contentID": get_rand_id(),
+        "type": ptype,
+    }
+    pane.update(extra)
+    return pane
+
+
+def _plot_pane():
+    return _pane(
+        "plot",
+        content={
+            "data": [{"type": "scatter", "x": [1], "y": [1], "name": "a"}],
+            "layout": {},
+        },
+    )
+
+
+def _text_pane():
+    return _pane("text", content="line0")
+
+
+def _image_history_pane():
+    return _pane("image_history", content=[{"src": "img0"}], selected=0)
+
+
+def _plot_history_pane():
+    return _pane("plot_history", content=[{"data": [], "layout": {}}], selected=0)
+
+
+def _table_pane():
+    return _pane("table", content=[["a", "b"]], editable=True)
+
+
+def _embeddings_pane():
+    return _pane(
+        "embeddings",
+        content={"data": [[1, 2]], "selected": None, "has_previous": False},
+        old_content=[],
+    )
+
+
+#: ``(id, pane factory, update args)`` for every type ``/update`` accepts.
+#: ``table`` is here because the handler broadcasts for it even though the
+#: update itself is refused -- a broadcast the client cannot reconcile is the
+#: bug under test, whether or not the content changed.
+PANE_CASES = [
+    ("plot", _plot_pane, {"data": [{"type": "scatter", "x": [2], "y": [2]}]}),
+    ("text", _text_pane, {"data": [{"content": "line1"}]}),
+    (
+        "image_history",
+        _image_history_pane,
+        {"data": [{"type": "image_history", "content": {"src": "img1"}}]},
+    ),
+    (
+        "plot_history",
+        _plot_history_pane,
+        {"data": [{"type": "plot_history", "content": {"data": [], "layout": {}}}]},
+    ),
+    ("table", _table_pane, {"data": [{"content": [["c"]]}]}),
+]
+
+
+def _update_packet(pane, args):
+    return UpdateHandler.update_packet(
+        pane,
+        args,
+        DEFAULT_MAX_TEXT_LINES,
+        DEFAULT_MAX_OLD_CONTENT,
+        DEFAULT_MAX_IMAGE_HISTORY,
+        DEFAULT_MAX_PLOT_HISTORY,
+    )
+
+
+@pytest.mark.parametrize(
+    "name, build, args", PANE_CASES, ids=[c[0] for c in PANE_CASES]
+)
+def test_update_bumps_the_version(name, build, args):
+    pane = build()
+    updated, _ = _update_packet(pane, args)
+    assert updated["version"] == 2
+
+
+@pytest.mark.parametrize(
+    "name, build, args", PANE_CASES, ids=[c[0] for c in PANE_CASES]
+)
+def test_repeated_updates_advance_by_one_each(name, build, args):
+    pane = build()
+    for expected in (2, 3, 4):
+        pane, _ = _update_packet(pane, args)
+        assert pane["version"] == expected
+
+
+@pytest.mark.parametrize(
+    "name, build, args", PANE_CASES, ids=[c[0] for c in PANE_CASES]
+)
+def test_the_patch_carries_the_new_version(name, build, args):
+    """The client applies the diff, so the diff has to move its copy too.
+
+    Without a ``/version`` op the browser's pane keeps the old number and the
+    *next* update fails the ``version + 1`` check instead of this one.
+    """
+    pane = build()
+    _, patch = _update_packet(pane, args)
+    versions = [op for op in patch if op["path"] == "/version"]
+    assert versions == [{"op": "replace", "path": "/version", "value": 2}]
+
+
+def test_a_pane_without_a_version_is_not_a_crash():
+    """Environments persisted before panes carried a version still update."""
+    pane = _text_pane()
+    del pane["version"]
+    updated, _ = _update_packet(pane, {"data": [{"content": "line1"}]})
+    assert updated["version"] == 2
+
+
+# -- embeddings -------------------------------------------------------------
+# Embeddings bypass ``update_packet`` for a hand-built patch, so they need the
+# same assertions made against their own route.
+
+
+ENTITY_SELECTED = {"data": {"update_type": "EntitySelected", "selected": 0}}
+REGION_SELECTED = {"data": {"update_type": "RegionSelected", "points": [[3, 4]]}}
+
+
+@pytest.mark.parametrize("args", [ENTITY_SELECTED, REGION_SELECTED])
+def test_embeddings_update_bumps_the_version(args):
+    pane = _embeddings_pane()
+    UpdateHandler.update_embeddings_packet(pane, args, DEFAULT_MAX_OLD_CONTENT)
+    assert pane["version"] == 2
+
+
+@pytest.mark.parametrize("args", [ENTITY_SELECTED, REGION_SELECTED])
+def test_embeddings_patch_carries_the_new_version(args):
+    pane = _embeddings_pane()
+    patch = UpdateHandler.update_embeddings_packet(pane, args, DEFAULT_MAX_OLD_CONTENT)
+    assert {"op": "replace", "path": "/version", "value": 2} in patch
+
+
+def test_an_unknown_embeddings_update_type_changes_nothing():
+    """No patch, so no version to announce -- and nothing to broadcast."""
+    pane = _embeddings_pane()
+    patch = UpdateHandler.update_embeddings_packet(
+        pane, {"data": {"update_type": "Nonsense"}}, DEFAULT_MAX_OLD_CONTENT
+    )
+    assert patch == []
+    assert pane["version"] == 1
+
+
+# -- what the subscriber actually receives ----------------------------------
+
+
+def _broadcast(build, args, count=3):
+    """Drive ``wrap_func`` ``count`` times; return the pane and what a sub saw.
+
+    ``wrap_func`` sends the whole pane instead of a patch whenever the pane
+    serialises smaller than its diff, so a given type may produce ``window`` or
+    ``window_update`` messages. Both carry a version and both are returned.
+    """
+    pane = build()
+    handler = FakeHandler(state={"main": {"jsons": {pane["id"]: pane}, "reload": {}}})
+    sub = handler.add_sub(eid="main")
+    for _ in range(count):
+        UpdateHandler.wrap_func(handler, dict(args, win=pane["id"], eid="main"))
+    return handler.state["main"]["jsons"][pane["id"]], sub.sent
+
+
+@pytest.mark.parametrize(
+    "name, build, args", PANE_CASES, ids=[c[0] for c in PANE_CASES]
+)
+def test_every_broadcast_carries_the_next_version(name, build, args):
+    """The sequence the frontend checks against, asserted end to end.
+
+    Whichever shape the broadcast takes, the versions it announces have to be
+    the consecutive run starting one past where the pane began -- that is
+    precisely the ``cmd.version == pane.version + 1`` ladder the client walks.
+    """
+    pane, sent = _broadcast(build, args)
+    assert pane["version"] == 4
+    assert [msg["version"] for msg in sent] == [2, 3, 4]
+
+
+def test_an_unknown_embeddings_update_broadcasts_nothing():
+    pane = _embeddings_pane()
+    handler = FakeHandler(state={"main": {"jsons": {pane["id"]: pane}, "reload": {}}})
+    sub = handler.add_sub(eid="main")
+    UpdateHandler.wrap_func(
+        handler,
+        {"win": pane["id"], "eid": "main", "data": {"update_type": "Nonsense"}},
+    )
+    assert sub.messages == []
+    assert handler.dirtied == []
+
+
+def test_embeddings_broadcast_versions_are_consecutive():
+    pane = _embeddings_pane()
+    handler = FakeHandler(state={"main": {"jsons": {pane["id"]: pane}, "reload": {}}})
+    sub = handler.add_sub(eid="main")
+    for i in range(3):
+        UpdateHandler.wrap_func(
+            handler,
+            {
+                "win": pane["id"],
+                "eid": "main",
+                "data": {"update_type": "EntitySelected", "selected": i},
+            },
+        )
+    assert [json.loads(m)["version"] for m in sub.messages] == [2, 3, 4]

--- a/py/tests/unit/window_builder.py
+++ b/py/tests/unit/window_builder.py
@@ -286,16 +286,18 @@ def test_caption_is_skipped_when_content_is_not_a_dict():
     assert text_pane["content"] == "hello"
 
 
-def test_version_is_bumped_once_per_update(titled_pane):
-    update_window(titled_pane, {"opts": {"title": "a"}})
-    assert titled_pane["version"] == 2
-    update_window(titled_pane, {"opts": {"title": "b"}})
-    assert titled_pane["version"] == 3
+@pytest.mark.parametrize("args", [{"opts": {"title": "a"}}, {}])
+def test_version_is_left_to_the_caller(titled_pane, args):
+    """``update_window`` merges fields; it does not sequence the broadcast.
 
-
-def test_version_is_bumped_even_for_an_empty_update(titled_pane):
-    update_window(titled_pane, {})
-    assert titled_pane["version"] == 2
+    Only some updates reach this helper -- ``UpdateHandler.update()`` returns
+    before it for text, image_history, plot_history and table panes -- so
+    bumping here left those types stuck at version 1 and made the frontend
+    reload the whole environment on every update. The counter now moves in
+    ``UpdateHandler.update_packet()``; see ``unit/pane_versions.py``.
+    """
+    update_window(titled_pane, args)
+    assert titled_pane["version"] == 1
 
 
 def test_returns_the_same_pane_object(titled_pane):

--- a/py/visdom/server/handlers/web_handlers.py
+++ b/py/visdom/server/handlers/web_handlers.py
@@ -125,6 +125,30 @@ class ExistsHandler(BaseHandler):
 
 class UpdateHandler(BaseHandler):
     @staticmethod
+    def bump_version(p):
+        """Advance the pane's broadcast sequence number and return the new value.
+
+        The frontend applies an incremental patch only when the message carries
+        exactly ``pane.version + 1`` (``updateWindow`` in ``js/main.js``); any
+        other value makes it discard the patch and re-request the whole
+        environment. Every path that broadcasts a ``window_update`` therefore has
+        to move this counter.
+
+        It lives here rather than in ``update_window()`` because
+        ``UpdateHandler.update()`` returns before that helper for text,
+        image_history, plot_history and table panes, and the embeddings route
+        never calls it at all. Those types stayed pinned at version 1 while the
+        server kept broadcasting updates, so the client's check could never pass
+        and every update cost a full environment reload.
+
+        Reads through ``get`` rather than ``+= 1`` so that an environment
+        persisted before panes carried a version still updates instead of raising
+        ``KeyError`` out of a request.
+        """
+        p["version"] = p.get("version", 1) + 1
+        return p["version"]
+
+    @staticmethod
     def update_packet(
         p, args, max_text_lines, max_old_content, max_image_history, max_plot_history
     ):
@@ -145,6 +169,9 @@ class UpdateHandler(BaseHandler):
             max_image_history,
             max_plot_history,
         )
+        # Bumped before the patch is computed so the diff carries the new
+        # version to the client, keeping its copy in step for the next update.
+        UpdateHandler.bump_version(p)
         p["contentID"] = get_rand_id()
 
         patch = jsonpatch.make_patch(old_p, p)
@@ -158,11 +185,13 @@ class UpdateHandler(BaseHandler):
             selected = args["data"]["selected"]
             p["content"]["selected"] = selected
             p["contentID"] = content_id
+            version = UpdateHandler.bump_version(p)
             # `selected` may not exist yet on the first selection, so use "add"
             # (which also overwrites when the key is already present).
             return [
                 {"op": "add", "path": "/content/selected", "value": selected},
                 {"op": "replace", "path": "/contentID", "value": content_id},
+                {"op": "replace", "path": "/version", "value": version},
             ]
         if update_type == "RegionSelected":
             old_data = p["content"]["data"]
@@ -175,12 +204,16 @@ class UpdateHandler(BaseHandler):
             p["content"]["has_previous"] = True
             p["content"]["selected"] = None
             p["contentID"] = content_id
+            version = UpdateHandler.bump_version(p)
             return [
                 {"op": "replace", "path": "/content/data", "value": new_data},
                 {"op": "add", "path": "/content/has_previous", "value": True},
                 {"op": "add", "path": "/content/selected", "value": None},
                 {"op": "replace", "path": "/contentID", "value": content_id},
+                {"op": "replace", "path": "/version", "value": version},
             ]
+        # An unrecognised update_type changed nothing, so there is no version to
+        # announce and no patch to send.
         return []
 
     @staticmethod
@@ -470,8 +503,15 @@ class UpdateHandler(BaseHandler):
             diff_packet = UpdateHandler.update_embeddings_packet(
                 p, args, handler.max_old_content
             )
-            UpdateHandler.broadcast_window_update(handler, args, eid, p, diff_packet)
-            handler.mark_dirty(eid)
+            # An empty patch means the update_type was not recognised and the
+            # pane is unchanged. Broadcasting it anyway would send a version the
+            # client cannot reconcile, costing it a full environment reload for a
+            # no-op.
+            if diff_packet:
+                UpdateHandler.broadcast_window_update(
+                    handler, args, eid, p, diff_packet
+                )
+                handler.mark_dirty(eid)
             handler.write(p["id"])
             return
 

--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -412,7 +412,14 @@ def extract_eid(args):
 
 
 def update_window(p, args):
-    """Adds new args to a window if they exist"""
+    """Merge an update's ``layout``/``opts``/``legend`` into an existing window.
+
+    Does not touch ``p["version"]``. That counter sequences the incremental
+    ``window_update`` broadcast, and only some updates reach this helper --
+    ``UpdateHandler.update()`` returns before it for text, image_history,
+    plot_history and table panes -- so it is advanced once per accepted update
+    by ``UpdateHandler.update_packet()`` instead.
+    """
     content = p["content"]
     layout_update = args.get("layout", {})
     for layout_name, layout_val in layout_update.items():
@@ -447,7 +454,6 @@ def update_window(p, args):
             for i, d in enumerate(pdata):
                 if i < len(legend):
                     d["name"] = legend[i]
-    p["version"] += 1
     return p
 
 


### PR DESCRIPTION
## Description

`p["version"] += 1` lived in `update_window()`. `UpdateHandler.update()` returns before that helper for `text`, `image_history`, `plot_history` and `table` panes, and the embeddings route never calls it at all — so those types stayed pinned at version `1` for the life of the pane while the server kept broadcasting `window_update` messages against them.

The frontend applies an incremental patch only when the message carries `pane.version + 1` (`updateWindow`, `js/main.js:387`):

```js
if (
  (cmd.win in storeData.panes &&
    cmd.version == storeData.panes[cmd.win].version + 1) || ...
) {
  addPaneBatched(cmd);           // apply the patch
} else if (!_envReloadInFlight.current) {
  _envReloadInFlight.current = true;
  sendEnvQuery(selection.envIDs); // re-download the whole environment
}
```

With both sides stuck at `1` the comparison reads `1 == 2`, which can never be true, so **every** update fell through to `sendEnvQuery()`. The incremental protocol was effectively disabled for the pane types the library is most used
for; only `scatter` and the other trace-based plots ever worked.

### What changed

- The counter moves to a new `UpdateHandler.bump_version()`, called from `update_packet()` — the single point where an accepted update becomes a broadcast — so it advances regardless of which branch `update()` took.
- `update_window()` no longer touches `version`; its docstring now says so and points at the new owner.
- The embeddings route builds its JSON patch by hand, so it bumps too **and** emits the matching `/version` op. Without that op the browser's copy would keepthe old number and fail the check on the *next* update instead of this one.
- An unrecognised embeddings `update_type` now broadcasts nothing at all, rather than an empty patch carrying a version the client cannot reconcile (which cost a full reload for a no-op).
- `bump_version()` reads through `.get()` rather than `+= 1`, so an environment persisted before panes carried a version updates instead of raising `KeyError`out of a request.

### Files touched

| File | Change |
| --- | --- |
| `py/visdom/utils/server_utils.py` | Remove the bump from `update_window()`; document the moved responsibility |
| `py/visdom/server/handlers/web_handlers.py` | Add `UpdateHandler.bump_version()`; call it from `update_packet()` and both embeddings branches; skip the broadcast on an empty embeddings diff |
| `py/tests/unit/pane_versions.py` | **New** — 28 cases covering all six pane types |
| `py/tests/unit/window_builder.py` | The two `update_window` version tests now pin the opposite contract |

## Motivation and Context

A training loop that calls `vis.text()` once per step made the browser re-download the entire environment once per step. The same applied to every `image_history` frame, every `plot_history` frame, and every embeddings
selection. On a large environment this is the difference between shipping a few-hundred-byte JSON patch and re-serialising every pane in the environment, for every single update.

The bug was invisible because the one pane type that *did* work — plots — is the type most tests exercise, so a single working path masked four broken ones.

## How Has This Been Tested?

**Environment:** Python 3.13, `pip install -e .`, `pytest` from `test-requirements.txt`. Branched from `dev` at `792e6e7`.

### Before / after, measured against a live server

Four `/update` calls per pane, reading `state[eid]["jsons"][win]["version"]` afterwards:

| Pane type | Before | After |
| --- | --- | --- |
| `text` | `1` | `5` |
| `scatter` | `5` | `5` |
| `image_history` | `1` | `5` |

Broadcasts captured from a subscribed socket, three text updates:

```
before:  command=window_update  version=1
         command=window_update  version=1
         command=window_update  version=1

after:   command=window_update  version=2
         command=window_update  version=3
         command=window_update  version=4
```

The `after` sequence is exactly the `pane.version + 1` ladder the client walks, so the patches are now applied instead of triggering a reload.

### Test suite

```
pytest -m unit          # passes (CI gate)
pytest -m "not server"  # passes
black --check py        # clean
```

New `py/tests/unit/pane_versions.py` (`pytestmark = pytest.mark.unit`) asserts, for **all six** pane types — `plot`, `text`, `image_history`, `plot_history`, `table`, `embeddings`:

- a single update advances `version` by one;
- repeated updates advance by exactly one each;
- the emitted patch carries a `/version` replace op with the new value;
- the versions a subscribed socket actually receives are the consecutive run starting one past where the pane began;
- an unknown embeddings `update_type` changes nothing and broadcasts nothing;
- a pane with no `version` key at all (an environment persisted before the field existed) updates rather than raising.

Parametrising over every pane type is deliberate: the gap that let one working type mask four broken ones cannot reopen.

The two `update_window` version assertions in `window_builder.py` were inverted rather than deleted, so the helper's new contract — *it does not sequence the broadcast* — is pinned rather than merely unstated.

## Screenshots (if appropriate)

N/A — no visual change. The user-visible effect is that panes update incrementally instead of the dashboard re-fetching the environment on each update.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist

- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/) — *left at `0.2.4`; happy to bump the patch version if maintainers prefer it on bug fixes*
- [x] My code follows the code style of this project. — `black==23.1.0` clean
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. — docstrings on `update_window()` and `bump_version()` record where the counter lives and why; no README or `__init__.pyi` change needed, as no public API or wire format changed

## Summary by Sourcery

Restore incremental pane updates by consistently advancing and broadcasting pane versions for every accepted update.

Bug Fixes:
- Ensure every accepted pane update advances its version so incremental frontend patches are applied instead of triggering full environment reloads.
- Keep embeddings updates synchronized with client versions and suppress broadcasts for unrecognized update types.
- Allow updates to panes from persisted environments that lack a version field.

Enhancements:
- Centralize pane version sequencing at the point updates are converted into broadcasts rather than in the window-merging helper.

Documentation:
- Document ownership and behavior of pane version sequencing in the update helpers.

Tests:
- Add unit coverage for version progression, emitted patch versions, subscriber broadcasts, embeddings behavior, and legacy panes across all supported pane types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update sequencing so pane versions advance consistently across standard, embedding, and selection updates.
  * Ensured subscribers receive consecutive version numbers for successive pane updates.
  * Prevented unrecognized embedding updates from producing empty patches or marking environments as changed.
  * Added support for updating panes that do not yet have a stored version.
  * Improved validation for layout creation and append-window requests.
  * Improved environment loading, forking, deletion, and experiment tag handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->