### PR TITLE
feat: add VisdomLightningLogger to plot pytorch lightning metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,47 @@ Tracking is opt-in: without `params`, `VisdomLogger` only ever calls `viz.line()
 
 Each unique name passed to `tracker.log()` gets its own window. The first call creates it; subsequent calls append. See `example/train_example.py` for a full working example.
 
+### PyTorch Lightning
+
+**Requirements:** `pip install visdom lightning` (or `pip install visdom pytorch-lightning`)
+
+`visdom.loggers.VisdomLightningLogger` implements Lightning's `Logger` protocol. Lightning aggregates every `self.log()` / `self.log_dict()` call in a `LightningModule` and hands the result to the logger, so nothing in the model or training loop changes — the user passes one `logger=` argument to `Trainer`.
+
+```python
+import lightning.pytorch as pl
+import visdom
+from visdom.loggers import VisdomLightningLogger
+
+viz = visdom.Visdom()
+logger = VisdomLightningLogger(viz, env="lightning_run")
+
+trainer = pl.Trainer(max_epochs=20, logger=logger, log_every_n_steps=5)
+trainer.fit(model, train_loader, val_loader)
+```
+
+Each metric key gets its own window — one key, one line chart, with no train/val name parsing. The `epoch` key Lightning mixes into the metrics dict is not plotted. How often the logger is called is controlled by Lightning (`Trainer(log_every_n_steps=...)` for step metrics, once per epoch for epoch metrics).
+
+Hyperparameters passed to `self.save_hyperparameters()` are rendered once as a properties pane via `viz.properties()`.
+
+**Gradient norms** come from Lightning, not the logger. Add to your `LightningModule` and they arrive through the logger like any other metric:
+
+```python
+from lightning.pytorch.utilities import grad_norm
+
+def on_before_optimizer_step(self, optimizer):
+    self.log_dict(grad_norm(self, norm_type=2))
+```
+
+**Parameters:**
+- `viz`: a connected `visdom.Visdom()` instance
+- `env`: environment name (default: `viz.env` if set, otherwise auto-generated from timestamp)
+
+**Note:** each call to `viz.line()` is a synchronous network request made on the thread Lightning calls from, so a very small `log_every_n_steps` with many metrics can stall training while it waits on the server.
+
+**Note:** `log_metrics` and `log_hyperparams` run on rank zero only. Use one logger instance per `Trainer` run. Not thread-safe — internal state has no locking.
+
+See `example/train_lightning_example.py` for a full working example.
+
 ### scikit-learn
 
 **Requirements:** `pip install visdom scikit-learn`

--- a/README.md
+++ b/README.md
@@ -480,6 +480,10 @@ def on_before_optimizer_step(self, optimizer):
 
 **Note:** `log_metrics` and `log_hyperparams` run on rank zero only. Use one logger instance per `Trainer` run. Not thread-safe — internal state has no locking.
 
+**Note:** when the run ends (success or failure) the logger saves the env on the server, so it can be reloaded later.
+
+**Note:** values that don't convert to a float (non-numeric strings, multi-element tensors, `None`) are skipped with a warning rather than raising.
+
 See `example/train_lightning_example.py` for a full working example.
 
 ### scikit-learn

--- a/example/train_lightning_example.py
+++ b/example/train_lightning_example.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# Copyright 2017-present, The Visdom Authors
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import lightning.pytorch as pl
+import torch
+from lightning.pytorch.utilities import grad_norm
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+import visdom
+from visdom.loggers import VisdomLightningLogger
+
+
+class Net(pl.LightningModule):
+    def __init__(self, lr=1e-2, hidden=32):
+        super().__init__()
+        self.save_hyperparameters()
+        self.net = nn.Sequential(nn.Linear(20, hidden), nn.ReLU(), nn.Linear(hidden, 1))
+        self.loss_fn = nn.BCEWithLogitsLoss()
+
+    def forward(self, x):
+        return self.net(x).squeeze(-1)
+
+    def _step(self, batch, prefix):
+        x, y = batch
+        logits = self(x)
+        loss = self.loss_fn(logits, y)
+        acc = ((logits > 0) == (y > 0.5)).float().mean()
+        self.log_dict({"{}_loss".format(prefix): loss, "{}_acc".format(prefix): acc})
+        return loss
+
+    def training_step(self, batch, _):
+        return self._step(batch, "train")
+
+    def validation_step(self, batch, _):
+        self._step(batch, "val")
+
+    def on_before_optimizer_step(self, optimizer):
+        # Lightning computes the norms; the logger only plots them.
+        self.log_dict(grad_norm(self, norm_type=2))
+
+    def configure_optimizers(self):
+        return torch.optim.Adam(self.parameters(), lr=self.hparams.lr)
+
+
+def main():
+    torch.manual_seed(42)
+    X = torch.randn(500, 20)
+    y = (X[:, :10].sum(dim=1) > 0).float()
+    train_loader = DataLoader(TensorDataset(X[:400], y[:400]), batch_size=32)
+    val_loader = DataLoader(TensorDataset(X[400:], y[400:]), batch_size=32)
+
+    viz = visdom.Visdom()
+    logger = VisdomLightningLogger(viz, env="lightning_run")
+
+    trainer = pl.Trainer(
+        max_epochs=20,
+        logger=logger,
+        log_every_n_steps=5,
+        enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+    )
+    trainer.fit(Net(), train_loader, val_loader)
+
+
+if __name__ == "__main__":
+    main()

--- a/py/visdom/loggers/__init__.py
+++ b/py/visdom/loggers/__init__.py
@@ -23,3 +23,10 @@ try:
     __all__.append("VisdomKerasLogger")
 except ImportError:
     pass
+
+try:
+    from visdom.loggers.lightning import VisdomLightningLogger
+
+    __all__.append("VisdomLightningLogger")
+except ImportError:
+    pass

--- a/py/visdom/loggers/lightning.py
+++ b/py/visdom/loggers/lightning.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# Copyright 2017-present, The Visdom Authors
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import datetime
+import warnings
+
+try:
+    from lightning.pytorch.loggers import Logger
+    from lightning.pytorch.utilities import rank_zero_only
+except ImportError:
+    try:
+        from pytorch_lightning.loggers import Logger
+        from pytorch_lightning.utilities import rank_zero_only
+    except ImportError:
+        raise ImportError(
+            "lightning is required for VisdomLightningLogger. Install with: "
+            "pip install lightning (or pip install pytorch-lightning)"
+        )
+
+
+class VisdomLightningLogger(Logger):
+    """Plots PyTorch Lightning metrics to Visdom as training runs.
+
+    Implements Lightning's Logger protocol. Lightning aggregates every
+    ``self.log()`` / ``self.log_dict()`` call in a LightningModule and
+    hands the result to ``log_metrics(metrics, step)``, so there is no
+    separate history dict to read and no change to the training loop --
+    the user passes one ``logger=`` argument to ``Trainer``.
+
+    Each metric key gets its own window -- one key, one line chart, with
+    no train/val name parsing. The bookkeeping ``epoch`` key Lightning
+    mixes into the dict is not plotted.
+
+    How often ``log_metrics`` fires is controlled entirely by Lightning
+    (``Trainer(log_every_n_steps=...)`` for step metrics, once per epoch
+    for epoch metrics) -- this logger adds no throttling of its own. Each
+    call to ``viz.line()`` is a synchronous network request made on the
+    thread Lightning calls from, so a very small ``log_every_n_steps``
+    with many metrics can stall training while it waits on the server.
+
+    Gradient norms come from Lightning, not this logger. Add to your
+    LightningModule::
+
+        from lightning.pytorch.utilities import grad_norm
+
+        def on_before_optimizer_step(self, optimizer):
+            self.log_dict(grad_norm(self, norm_type=2))
+
+    Lightning computes the norms with its own utility and they arrive
+    through ``log_metrics`` like any other metric.
+
+    Multi-GPU: ``log_metrics`` and ``log_hyperparams`` run on rank zero
+    only. Use one logger instance per ``Trainer`` run. Not thread-safe:
+    ``_wins``/``_step`` have no locking.
+
+    Usage::
+
+        import lightning.pytorch as pl
+        import visdom
+        from visdom.loggers import VisdomLightningLogger
+
+        viz = visdom.Visdom()
+        logger = VisdomLightningLogger(viz, env="lightning_run")
+
+        trainer = pl.Trainer(max_epochs=20, logger=logger,
+                             log_every_n_steps=5)
+        trainer.fit(model, train_loader, val_loader)
+    """
+
+    def __init__(self, viz, env=None):
+        super().__init__()
+        self.viz = viz
+        _viz_env = getattr(viz, "env", None)
+        self.env = (
+            env
+            or (_viz_env if _viz_env and _viz_env != "main" else None)
+            or "lightning_{}".format(datetime.datetime.now().strftime("%Y%m%d_%H%M%S"))
+        )
+        self._wins = {}
+        self._hparam_win = None
+        self._step = 0
+
+    @property
+    def name(self):
+        return "visdom"
+
+    @property
+    def version(self):
+        return self.env
+
+    def _plot(self, key, x, value):
+        if key not in self._wins:
+            self._wins[key] = self.viz.line(
+                X=[x],
+                Y=[value],
+                env=self.env,
+                opts={"title": key, "xlabel": "step", "ylabel": key},
+            )
+        else:
+            self.viz.line(
+                X=[x],
+                Y=[value],
+                win=self._wins[key],
+                env=self.env,
+                update="append",
+            )
+
+    @rank_zero_only
+    def log_metrics(self, metrics, step=None):
+        if not metrics:
+            return
+        if step is None:
+            x = self._step
+            self._step += 1
+        else:
+            x = int(step)
+        try:
+            for key, value in metrics.items():
+                if key == "epoch":
+                    continue
+                self._plot(key, x, float(value))
+        except Exception as e:
+            warnings.warn(
+                "VisdomLightningLogger failed to log step {}: {}".format(step, e)
+            )
+
+    @rank_zero_only
+    def log_hyperparams(self, params, *args, **kwargs):
+        if params is None:
+            return
+        if not isinstance(params, dict):
+            params = vars(params)
+        if not params:
+            return
+        content = [
+            {"type": "text", "name": str(k), "value": str(v)} for k, v in params.items()
+        ]
+        try:
+            if self._hparam_win is None:
+                self._hparam_win = self.viz.properties(
+                    content, env=self.env, opts={"title": "hyperparameters"}
+                )
+            else:
+                self.viz.properties(
+                    content,
+                    win=self._hparam_win,
+                    env=self.env,
+                    opts={"title": "hyperparameters"},
+                )
+        except Exception as e:
+            warnings.warn(
+                "VisdomLightningLogger failed to log hyperparameters: {}".format(e)
+            )

--- a/py/visdom/loggers/lightning.py
+++ b/py/visdom/loggers/lightning.py
@@ -114,21 +114,24 @@ class VisdomLightningLogger(Logger):
             return None
 
     def _plot(self, key, x, value):
-        if key not in self._wins:
-            self._wins[key] = self.viz.line(
-                X=[x],
-                Y=[value],
-                env=self.env,
-                opts={"title": key, "xlabel": "step", "ylabel": key},
-            )
-        else:
+        win = self._wins.get(key)
+        if win:
             self.viz.line(
                 X=[x],
                 Y=[value],
-                win=self._wins[key],
+                win=win,
                 env=self.env,
                 update="append",
             )
+            return
+        win = self.viz.line(
+            X=[x],
+            Y=[value],
+            env=self.env,
+            opts={"title": key, "xlabel": "step", "ylabel": key},
+        )
+        if win:
+            self._wins[key] = win
 
     @rank_zero_only
     def log_metrics(self, metrics, step=None):
@@ -171,17 +174,19 @@ class VisdomLightningLogger(Logger):
             {"type": "text", "name": str(k), "value": str(v)} for k, v in params.items()
         ]
         try:
-            if self._hparam_win is None:
-                self._hparam_win = self.viz.properties(
-                    content, env=self.env, opts={"title": "hyperparameters"}
-                )
-            else:
+            if self._hparam_win:
                 self.viz.properties(
                     content,
                     win=self._hparam_win,
                     env=self.env,
                     opts={"title": "hyperparameters"},
                 )
+            else:
+                win = self.viz.properties(
+                    content, env=self.env, opts={"title": "hyperparameters"}
+                )
+                if win:
+                    self._hparam_win = win
         except Exception as e:
             warnings.warn(
                 "VisdomLightningLogger failed to log hyperparameters: {}".format(e)

--- a/py/visdom/loggers/lightning.py
+++ b/py/visdom/loggers/lightning.py
@@ -102,6 +102,15 @@ class VisdomLightningLogger(Logger):
     def experiment(self):
         return self.viz
 
+    @staticmethod
+    def _to_float(value):
+        """Coerce a logged value to a plottable float, or None if it is
+        not numeric (a string, None, a multi-element array, ...)."""
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
     def _plot(self, key, x, value):
         if key not in self._wins:
             self._wins[key] = self.viz.line(
@@ -127,12 +136,22 @@ class VisdomLightningLogger(Logger):
             x = self._step
             self._step += 1
         else:
-            x = int(step)
+            try:
+                x = int(step)
+            except (TypeError, ValueError):
+                x = self._step
+                self._step += 1
         for key, value in metrics.items():
             if key == "epoch":
                 continue
+            y = self._to_float(value)
+            if y is None:
+                warnings.warn(
+                    "VisdomLightningLogger skipping non-numeric metric {}".format(key)
+                )
+                continue
             try:
-                self._plot(key, x, float(value))
+                self._plot(key, x, y)
             except Exception as e:
                 warnings.warn(
                     "VisdomLightningLogger failed to log {}: {}".format(key, e)

--- a/py/visdom/loggers/lightning.py
+++ b/py/visdom/loggers/lightning.py
@@ -10,10 +10,12 @@ import warnings
 
 try:
     from lightning.pytorch.loggers import Logger
+    from lightning.pytorch.loggers.logger import rank_zero_experiment
     from lightning.pytorch.utilities import rank_zero_only
 except ImportError:
     try:
         from pytorch_lightning.loggers import Logger
+        from pytorch_lightning.loggers.logger import rank_zero_experiment
         from pytorch_lightning.utilities import rank_zero_only
     except ImportError:
         raise ImportError(
@@ -53,9 +55,12 @@ class VisdomLightningLogger(Logger):
     Lightning computes the norms with its own utility and they arrive
     through ``log_metrics`` like any other metric.
 
-    Multi-GPU: ``log_metrics`` and ``log_hyperparams`` run on rank zero
-    only. Use one logger instance per ``Trainer`` run. Not thread-safe:
-    ``_wins``/``_step`` have no locking.
+    When training ends (success or failure) ``finalize`` saves the env on
+    the server so the run can be reloaded later.
+
+    Multi-GPU: ``log_metrics``, ``log_hyperparams`` and ``finalize`` run
+    on rank zero only. Use one logger instance per ``Trainer`` run. Not
+    thread-safe: ``_wins``/``_step`` have no locking.
 
     Usage::
 
@@ -93,6 +98,7 @@ class VisdomLightningLogger(Logger):
         return self.env
 
     @property
+    @rank_zero_experiment
     def experiment(self):
         return self.viz
 
@@ -137,7 +143,7 @@ class VisdomLightningLogger(Logger):
         if params is None:
             return
         if not isinstance(params, dict):
-            params = vars(params)
+            params = dict(params) if hasattr(params, "items") else vars(params)
         if not params:
             return
         content = [
@@ -159,3 +165,10 @@ class VisdomLightningLogger(Logger):
             warnings.warn(
                 "VisdomLightningLogger failed to log hyperparameters: {}".format(e)
             )
+
+    @rank_zero_only
+    def finalize(self, status):
+        try:
+            self.viz.save([self.env])
+        except Exception as e:
+            warnings.warn("VisdomLightningLogger failed to save env: {}".format(e))

--- a/py/visdom/loggers/lightning.py
+++ b/py/visdom/loggers/lightning.py
@@ -92,6 +92,10 @@ class VisdomLightningLogger(Logger):
     def version(self):
         return self.env
 
+    @property
+    def experiment(self):
+        return self.viz
+
     def _plot(self, key, x, value):
         if key not in self._wins:
             self._wins[key] = self.viz.line(
@@ -118,15 +122,15 @@ class VisdomLightningLogger(Logger):
             self._step += 1
         else:
             x = int(step)
-        try:
-            for key, value in metrics.items():
-                if key == "epoch":
-                    continue
+        for key, value in metrics.items():
+            if key == "epoch":
+                continue
+            try:
                 self._plot(key, x, float(value))
-        except Exception as e:
-            warnings.warn(
-                "VisdomLightningLogger failed to log step {}: {}".format(step, e)
-            )
+            except Exception as e:
+                warnings.warn(
+                    "VisdomLightningLogger failed to log {}: {}".format(key, e)
+                )
 
     @rank_zero_only
     def log_hyperparams(self, params, *args, **kwargs):

--- a/py/visdom/loggers/lightning.py
+++ b/py/visdom/loggers/lightning.py
@@ -35,7 +35,9 @@ class VisdomLightningLogger(Logger):
 
     Each metric key gets its own window -- one key, one line chart, with
     no train/val name parsing. The bookkeeping ``epoch`` key Lightning
-    mixes into the dict is not plotted.
+    mixes into the dict is not plotted. Values that do not convert to a
+    float (non-numeric strings, multi-element tensors, ``None``) are
+    skipped with a warning rather than raising.
 
     How often ``log_metrics`` fires is controlled entirely by Lightning
     (``Trainer(log_every_n_steps=...)`` for step metrics, once per epoch


### PR DESCRIPTION
## Description
Adds `visdom.loggers.VisdomLightningLogger`, a Lightning Logger subclass. Pass it to `Trainer(logger=...)` and every `self.log()` call plots to Visdom, plus hyperparameters as a properties pane.

## Motivation and Context
Visdom has no PyTorch Lightning logger — users have to call `viz.line()` manually inside their `LightningModule` or wire up a custom Logger.

## How Has This Been Tested?
Ran `example/train_lightning_example.py` on local server; all metric, grad-norm and hyperparameter panes render correctly

## Screenshots (if appropriate):
<img width="1710" height="1073" alt="image" src="https://github.com/user-attachments/assets/b9ee0b16-6dd4-4e40-b565-27aba41b086c" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

## Summary by Sourcery

Add Visdom integration for PyTorch Lightning training runs.

New Features:
- Add a PyTorch Lightning logger that plots logged metrics in Visdom and displays saved hyperparameters in a properties pane.

Enhancements:
- Support both modern Lightning and legacy PyTorch Lightning imports, rank-zero logging, non-numeric metric handling, and automatic environment saving.

Documentation:
- Document PyTorch Lightning logger usage, configuration, behavior, and limitations.

Tests:
- Add a complete PyTorch Lightning training example covering metrics, gradient norms, and hyperparameters.