### PR TITLE
Fix Optuna dashboard trial selection across callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,8 @@ See `example/train_keras_example.py` for a full working example.
 
 **Requirements:** `pip install visdom optuna`
 
+**Dashboard visualizations:** `pip install plotly`
+
 `visdom.integrations.OptunaCallback` implements Optuna's study callback
 protocol. After each trial finishes it records the trial's parameters, objective
 values and state as a Visdom experiment in a dedicated environment. Optuna is
@@ -600,6 +602,8 @@ callback = OptunaCallback(
     viz,
     dashboard_env="optuna_quadratic",
     objective_names=["loss"],
+    create_dashboard=True,
+    refresh_every=10,
 )
 
 
@@ -610,14 +614,21 @@ def objective(trial):
 
 study = optuna.create_study(study_name="quadratic", direction="minimize")
 study.optimize(objective, n_trials=100, callbacks=[callback])
+callback.update_dashboard(study)
 ```
 
-This first-stage integration records one experiment per trial, using names such
-as `optuna_quadratic_trial_000017`. Pass `raise_on_error=True` if a Visdom
-logging failure should stop optimization; by default it emits a warning and
-allows the study to continue. Single- and multi-objective studies are supported,
-and `COMPLETE`, `PRUNED` and `FAIL` states are preserved in the
-`optuna_state` tag.
+The integration records one experiment per trial, using names such as
+`optuna_quadratic_trial_000017`. With `create_dashboard=True`, the first trial
+creates summary, HParams, optimization history and timeline panes, plus
+parameter importance when Optuna can compute it. Later trials refresh the panes
+in `optuna_quadratic` every `refresh_every` successful writes. The explicit
+final `update_dashboard()` includes any trials left since the last scheduled
+refresh. Plotly is only needed for the Optuna visualization panes.
+
+Pass `raise_on_error=True` if a Visdom logging failure should stop optimization;
+by default it emits a warning and allows the study to continue. Single- and
+multi-objective studies are supported, and `COMPLETE`, `PRUNED` and `FAIL`
+states are preserved in the `optuna_state` tag.
 
 ## Details
 <img src="https://user-images.githubusercontent.com/19650074/198747904-7a8a580f-851a-45fb-8f45-94e54a910ee2.png"/>

--- a/README.md
+++ b/README.md
@@ -647,16 +647,20 @@ callback.update_dashboard(study)
 The integration records one experiment per trial, using names such as
 `optuna_quadratic_trial_000017`. Intermediate values reported with
 `trial.report(value, step)` are stored as the `intermediate_value` metric in
-step order before the final objective value. With `create_dashboard=True`, the
-first trial creates summary, HParams, optimization history and timeline panes,
-plus intermediate-value and parameter-importance panes when Optuna can compute
-them. Completed studies with two or three objectives also get a Pareto-front
-pane. Later trials refresh the panes in `optuna_quadratic` every `refresh_every`
-successful writes. The explicit final `update_dashboard()` includes any trials
-left since the last scheduled refresh. Plotly is only needed for the Optuna
-visualization panes. Timeline bars preserve each trial's true duration, and a
-fixed-size marker at the true start time keeps even sub-pixel trials visible and
-hoverable without exaggerating their runtime.
+step order before the final objective value. Each experiment also carries a
+stable `optuna_dashboard_env` tag. With `create_dashboard=True`, the first trial
+creates summary, HParams, optimization history and timeline panes, plus
+intermediate-value and parameter-importance panes when Optuna can compute them.
+The HParams pane selects experiments by that dashboard tag rather than by a
+callback-local list, so `update_dashboard()` on a new callback recovers trials
+logged before a process restart and workers sharing a dashboard see the same
+trial selection. Completed studies with two or three objectives also get a
+Pareto-front pane. Later trials refresh the panes in `optuna_quadratic` every
+`refresh_every` successful writes. The explicit final `update_dashboard()`
+includes any trials left since the last scheduled refresh. Plotly is only needed
+for the Optuna visualization panes. Timeline bars preserve each trial's true
+duration, and a fixed-size marker at the true start time keeps even sub-pixel
+trials visible and hoverable without exaggerating their runtime.
 
 The summary pane links directly to the best and latest terminal trial
 environments. The callback never opens a browser on its own.

--- a/README.md
+++ b/README.md
@@ -653,14 +653,22 @@ creates summary, HParams, optimization history and timeline panes, plus
 intermediate-value and parameter-importance panes when Optuna can compute them.
 The HParams pane selects experiments by that dashboard tag rather than by a
 callback-local list, so `update_dashboard()` on a new callback recovers trials
-logged before a process restart and workers sharing a dashboard see the same
-trial selection. Completed studies with two or three objectives also get a
-Pareto-front pane. Later trials refresh the panes in `optuna_quadratic` every
-`refresh_every` successful writes. The explicit final `update_dashboard()`
-includes any trials left since the last scheduled refresh. Plotly is only needed
-for the Optuna visualization panes. Timeline bars preserve each trial's true
-duration, and a fixed-size marker at the true start time keeps even sub-pixel
-trials visible and hoverable without exaggerating their runtime.
+logged before a process restart. Dashboard refreshes from one callback are
+serialized, so `study.optimize(..., n_jobs=N)` cannot publish them out of order.
+When multiple processes or nodes share a study and dashboard namespace, enable
+`create_dashboard=True` in exactly one process; callbacks in the other workers
+still log their trials with the default `create_dashboard=False`. The designated
+writer's tag query includes trials from every worker. After all workers finish,
+have the coordinating process call `update_dashboard()` once for the final
+refresh.
+
+Completed studies with two or three objectives also get a Pareto-front pane.
+Later trials refresh the panes in `optuna_quadratic` every `refresh_every`
+successful writes by the dashboard writer. The explicit final
+`update_dashboard()` includes any trials left since the last scheduled refresh.
+Plotly is only needed for the Optuna visualization panes. Timeline bars preserve
+each trial's true duration, and a fixed-size marker at the true start time keeps
+even sub-pixel trials visible and hoverable without exaggerating their runtime.
 
 The summary pane links directly to the best and latest terminal trial
 environments. The callback never opens a browser on its own.

--- a/README.md
+++ b/README.md
@@ -618,17 +618,29 @@ callback.update_dashboard(study)
 ```
 
 The integration records one experiment per trial, using names such as
-`optuna_quadratic_trial_000017`. With `create_dashboard=True`, the first trial
-creates summary, HParams, optimization history and timeline panes, plus
-parameter importance when Optuna can compute it. Later trials refresh the panes
-in `optuna_quadratic` every `refresh_every` successful writes. The explicit
-final `update_dashboard()` includes any trials left since the last scheduled
-refresh. Plotly is only needed for the Optuna visualization panes.
+`optuna_quadratic_trial_000017`. Intermediate values reported with
+`trial.report(value, step)` are stored as the `intermediate_value` metric in
+step order before the final objective value. With `create_dashboard=True`, the
+first trial creates summary, HParams, optimization history and timeline panes,
+plus intermediate-value and parameter-importance panes when Optuna can compute
+them. Later trials refresh the panes in `optuna_quadratic` every `refresh_every`
+successful writes. The explicit final `update_dashboard()` includes any trials
+left since the last scheduled refresh. Plotly is only needed for the Optuna
+visualization panes.
+
+The summary pane links directly to the best and latest terminal trial
+environments. The callback never opens a browser on its own.
 
 Pass `raise_on_error=True` if a Visdom logging failure should stop optimization;
 by default it emits a warning and allows the study to continue. Single- and
 multi-objective studies are supported, and `COMPLETE`, `PRUNED` and `FAIL`
-states are preserved in the `optuna_state` tag.
+states are preserved in the `optuna_state` tag. A pruned trial retains every
+intermediate value reported before pruning. Optuna remains responsible for the
+pruning decision: call `trial.report()` and `trial.should_prune()` inside the
+objective and raise `optuna.TrialPruned` when requested. Because Optuna invokes
+study callbacks after a trial reaches a terminal state, `OptunaCallback`
+records these values after the trial finishes rather than streaming them while
+the trial is running.
 
 ## Details
 <img src="https://user-images.githubusercontent.com/19650074/198747904-7a8a580f-851a-45fb-8f45-94e54a910ee2.png"/>

--- a/README.md
+++ b/README.md
@@ -617,13 +617,41 @@ study.optimize(objective, n_trials=100, callbacks=[callback])
 callback.update_dashboard(study)
 ```
 
+For multi-objective studies, list the objective names in the same order as the
+study directions and return values:
+
+```python
+callback = OptunaCallback(
+    viz,
+    dashboard_env="optuna_accuracy_latency",
+    objective_names=["accuracy", "latency_ms"],
+    create_dashboard=True,
+)
+
+
+def multi_objective(trial):
+    width = trial.suggest_int("width", 1, 10)
+    accuracy = 0.80 + 0.01 * width
+    latency_ms = 10.0 + 2.0 * width
+    return accuracy, latency_ms
+
+
+study = optuna.create_study(
+    study_name="accuracy-latency",
+    directions=["maximize", "minimize"],
+)
+study.optimize(multi_objective, n_trials=40, callbacks=[callback])
+callback.update_dashboard(study)
+```
+
 The integration records one experiment per trial, using names such as
 `optuna_quadratic_trial_000017`. Intermediate values reported with
 `trial.report(value, step)` are stored as the `intermediate_value` metric in
 step order before the final objective value. With `create_dashboard=True`, the
 first trial creates summary, HParams, optimization history and timeline panes,
 plus intermediate-value and parameter-importance panes when Optuna can compute
-them. Later trials refresh the panes in `optuna_quadratic` every `refresh_every`
+them. Completed studies with two or three objectives also get a Pareto-front
+pane. Later trials refresh the panes in `optuna_quadratic` every `refresh_every`
 successful writes. The explicit final `update_dashboard()` includes any trials
 left since the last scheduled refresh. Plotly is only needed for the Optuna
 visualization panes.
@@ -640,7 +668,9 @@ pruning decision: call `trial.report()` and `trial.should_prune()` inside the
 objective and raise `optuna.TrialPruned` when requested. Because Optuna invokes
 study callbacks after a trial reaches a terminal state, `OptunaCallback`
 records these values after the trial finishes rather than streaming them while
-the trial is running.
+the trial is running. Optuna does not support `trial.report()` or
+`trial.should_prune()` for multi-objective studies, so intermediate-value and
+pruning support applies only to single-objective studies.
 
 ## Details
 <img src="https://user-images.githubusercontent.com/19650074/198747904-7a8a580f-851a-45fb-8f45-94e54a910ee2.png"/>

--- a/README.md
+++ b/README.md
@@ -654,7 +654,9 @@ them. Completed studies with two or three objectives also get a Pareto-front
 pane. Later trials refresh the panes in `optuna_quadratic` every `refresh_every`
 successful writes. The explicit final `update_dashboard()` includes any trials
 left since the last scheduled refresh. Plotly is only needed for the Optuna
-visualization panes.
+visualization panes. Timeline bars preserve each trial's true duration, and a
+fixed-size marker at the true start time keeps even sub-pixel trials visible and
+hoverable without exaggerating their runtime.
 
 The summary pane links directly to the best and latest terminal trial
 environments. The callback never opens a browser on its own.

--- a/py/tests/test_hparams_live.py
+++ b/py/tests/test_hparams_live.py
@@ -10,8 +10,8 @@
 
 Logging a run marks its environment on a queue
 (:class:`~visdom.experiments.live.LiveUpdateQueue`); a drain asks
-:func:`~visdom.experiments.live.resolve_targets` which panes that could affect
-and refreshes each through the ``experiments/hparams/update`` handler.
+:func:`~visdom.experiments.live.resolve_targets` which explicit-id panes it
+affects and refreshes each through the ``experiments/hparams/update`` handler.
 
 The two decisions are tested on their own — which panes a change reaches, and
 when a burst of marks turns into a rebuild — and then end to end through a real
@@ -47,10 +47,10 @@ def hparams_window(mode, query=None, env_ids=None):
 class TestResolveTargets(unittest.TestCase):
     """resolve_targets names the panes a set of changed envs could affect."""
 
-    def test_query_pane_is_affected_by_any_change(self):
-        """A query can start matching a run it did not match before."""
+    def test_query_pane_is_not_refreshed_automatically(self):
+        """Refreshing a query would turn every log write into a store scan."""
         state = {"main": {"jsons": {"hp1": hparams_window("query", query="lr < 1")}}}
-        self.assertEqual(resolve_targets(state, {"unrelated"}), [("main", "hp1")])
+        self.assertEqual(resolve_targets(state, {"unrelated"}), [])
 
     def test_env_ids_pane_only_follows_the_runs_it_names(self):
         """An explicit selection cannot grow, so unnamed runs leave it alone."""
@@ -81,8 +81,8 @@ class TestResolveTargets(unittest.TestCase):
         }
         self.assertEqual(resolve_targets(state, {"run-a"}), [])
 
-    def test_both_pane_is_affected_by_any_change(self):
-        """``both`` still holds a query, so it is re-run like any other query."""
+    def test_both_pane_is_not_refreshed_automatically(self):
+        """Even a bounded query is left to an explicit refresh."""
         state = {
             "main": {
                 "jsons": {
@@ -90,7 +90,7 @@ class TestResolveTargets(unittest.TestCase):
                 }
             }
         }
-        self.assertEqual(resolve_targets(state, {"run-b"}), [("main", "hp1")])
+        self.assertEqual(resolve_targets(state, {"run-b"}), [])
 
     def test_other_window_types_are_left_alone(self):
         """Only hparams panes are rebuilt from a selection."""
@@ -99,7 +99,7 @@ class TestResolveTargets(unittest.TestCase):
                 "jsons": {
                     "plot": {"type": "plot", "content": {}},
                     "text": {"type": "text", "content": ""},
-                    "hp1": hparams_window("query", query="lr < 1"),
+                    "hp1": hparams_window("env_ids", env_ids=["run-a"]),
                 }
             }
         }
@@ -118,8 +118,8 @@ class TestResolveTargets(unittest.TestCase):
     def test_panes_across_envs_are_all_named(self):
         """A run can be shown by panes living in several environments."""
         state = {
-            "main": {"jsons": {"hp1": hparams_window("query", query="lr < 1")}},
-            "other": {"jsons": {"hp2": hparams_window("query", query="acc > 0")}},
+            "main": {"jsons": {"hp1": hparams_window("env_ids", env_ids=["run-a"])}},
+            "other": {"jsons": {"hp2": hparams_window("env_ids", env_ids=["run-a"])}},
         }
         self.assertEqual(
             sorted(resolve_targets(state, {"run-a"})),
@@ -350,34 +350,32 @@ class TestLiveHparamsPanes(tornado.testing.AsyncHTTPTestCase):
         with open(os.path.join(self._tmp_dir, eid + ".json")) as fn:
             return json.load(fn)
 
-    def test_a_newly_logged_run_joins_a_matching_pane(self):
-        """The pane picks up a run that did not exist when it was built."""
+    def test_a_query_pane_waits_for_an_explicit_refresh(self):
+        """A log write must not trigger the query's whole-store scan."""
         self.create({"query": "lr < 0.01", "win": "hp1"})
         self.assertEqual(self._env_ids("hp1"), ["run-a"])
 
         self.log({"eid": "run-b", "params": {"lr": 0.001}})
         self.settle()
 
-        self.assertEqual(self._env_ids("hp1"), ["run-a", "run-b"])
+        self.assertEqual(self._env_ids("hp1"), ["run-a"])
 
     def test_the_refresh_reaches_disk(self):
         """A live rebuild saves the env, as a requested update does."""
-        self.create({"query": "lr < 0.01", "win": "hp1"})
-        self.log({"eid": "run-b", "params": {"lr": 0.001}})
+        self.create({"env_ids": ["run-a"], "win": "hp1"})
+        self.log({"eid": "run-a", "action": "metrics", "metrics": {"acc": 0.99}})
         self.settle()
 
         records = self._disk_env()["jsons"]["hp1"]["content"]["records"]
-        self.assertEqual(
-            sorted(record["env_id"] for record in records), ["run-a", "run-b"]
-        )
+        self.assertEqual(records[0]["metrics"]["acc"], 0.99)
 
     def test_the_pane_keeps_its_id_and_gets_a_new_contentID(self):
         """The client re-renders on contentID, and the pane keeps its place."""
-        self.create({"query": "lr < 0.01", "win": "hp1"})
+        self.create({"env_ids": ["run-a"], "win": "hp1"})
         before = self._window("hp1")
         content_id, position = before["contentID"], before["i"]
 
-        self.log({"eid": "run-b", "params": {"lr": 0.001}})
+        self.log({"eid": "run-a", "action": "metrics", "metrics": {"acc": 0.99}})
         self.settle()
 
         after = self._window("hp1")
@@ -387,7 +385,7 @@ class TestLiveHparamsPanes(tornado.testing.AsyncHTTPTestCase):
 
     def test_logged_metrics_reach_the_pane(self):
         """The metric values shown are the latest ones logged, not the first."""
-        self.create({"query": "lr < 0.01", "win": "hp1"})
+        self.create({"env_ids": ["run-a"], "win": "hp1"})
         self.log({"eid": "run-a", "action": "metrics", "metrics": {"acc": 0.99}})
         self.settle()
 
@@ -397,7 +395,7 @@ class TestLiveHparamsPanes(tornado.testing.AsyncHTTPTestCase):
 
     def test_finishing_a_run_refreshes_the_pane(self):
         """``finish`` changes the status a pane displays, so it counts as a change."""
-        self.create({"query": "lr < 0.01", "win": "hp1"})
+        self.create({"env_ids": ["run-a"], "win": "hp1"})
         self.log({"eid": "run-a", "action": "finish", "status": "finished"})
         self.settle()
 
@@ -427,7 +425,7 @@ class TestLiveHparamsPanes(tornado.testing.AsyncHTTPTestCase):
         callback instead of arming the loop leaves the queue to say it itself:
         five marks arrange exactly one drain.
         """
-        self.create({"query": "lr < 0.01", "win": "hp1"})
+        self.create({"env_ids": ["run-a"], "win": "hp1"})
         queue = self._app.live_updates
         drains = []
         queue._schedule = lambda delay, callback: drains.append(callback)
@@ -452,28 +450,29 @@ class TestLiveHparamsPanes(tornado.testing.AsyncHTTPTestCase):
 
     def test_a_pane_closed_before_the_drain_is_skipped(self):
         """Closing a pane mid-flight is a race, not a failure."""
-        self.create({"query": "lr < 0.01", "win": "hp1"})
-        self.create({"query": "lr < 0.01", "win": "hp2"})
+        self.create({"env_ids": ["run-a"], "win": "hp1"})
+        self.create({"env_ids": ["run-a"], "win": "hp2"})
 
-        self.log({"eid": "run-b", "params": {"lr": 0.001}})
+        self.log({"eid": "run-a", "action": "metrics", "metrics": {"acc": 0.99}})
         del self._app.state["main"]["jsons"]["hp1"]
         self.settle()
 
-        self.assertEqual(self._env_ids("hp2"), ["run-a", "run-b"])
+        self.assertEqual(self._env_ids("hp2"), ["run-a"])
         self.assertNotIn("hp1", self._app.state["main"]["jsons"])
 
     def test_panes_in_other_envs_are_refreshed_too(self):
         """A pane is refreshed wherever it lives, not only in the logged env."""
-        self.create({"query": "lr < 0.01", "win": "hp1", "eid": "dashboard"})
+        self.create({"env_ids": ["run-a"], "win": "hp1", "eid": "dashboard"})
 
-        self.log({"eid": "run-b", "params": {"lr": 0.001}})
+        self.log({"eid": "run-a", "action": "metrics", "metrics": {"acc": 0.99}})
         self.settle()
 
-        self.assertEqual(self._env_ids("hp1", eid="dashboard"), ["run-a", "run-b"])
+        records = self._window("hp1", eid="dashboard")["content"]["records"]
+        self.assertEqual(records[0]["metrics"]["acc"], 0.99)
 
     def test_readonly_servers_never_mark(self):
         """Logging is refused in readonly mode, so no rebuild can follow it."""
-        self.create({"query": "lr < 0.01", "win": "hp1"})
+        self.create({"env_ids": ["run-a"], "win": "hp1"})
         content_id = self._window("hp1")["contentID"]
 
         self._app.server_state.readonly = True

--- a/py/tests/unit/optuna_integration.py
+++ b/py/tests/unit/optuna_integration.py
@@ -52,7 +52,7 @@ def fake_visualization_module(intermediate_error=None):
         "importance": Mock(name="importance"),
         "intermediate": Mock(name="intermediate"),
         "pareto": Mock(name="pareto"),
-        "timeline": Mock(name="timeline"),
+        "timeline": Mock(name="timeline", data=()),
     }
     visualization.plot_optimization_history = Mock(return_value=figures["history"])
     visualization.plot_param_importances = Mock(return_value=figures["importance"])

--- a/py/tests/unit/optuna_integration.py
+++ b/py/tests/unit/optuna_integration.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+
+# Copyright 2017-present, The Visdom Authors
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Unit tests for the optional Optuna experiment integration."""
+
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, call, patch
+
+from visdom.integrations import OptunaCallback
+
+
+def make_trial(
+    number=0,
+    state="COMPLETE",
+    values=(0.25,),
+    params=None,
+    intermediate_values=None,
+):
+    return SimpleNamespace(
+        number=number,
+        state=SimpleNamespace(name=state),
+        values=values,
+        params=params or {"x": 2.0},
+        intermediate_values=intermediate_values or {},
+    )
+
+
+def make_study(trials):
+    return SimpleNamespace(
+        study_name="quadratic",
+        directions=[SimpleNamespace(name="MINIMIZE")],
+        metric_names=None,
+        best_value=0.25,
+        best_params={"x": 2.0},
+        best_trials=[],
+        get_trials=Mock(return_value=trials),
+    )
+
+
+def fake_visualization_module(intermediate_error=None):
+    visualization = types.ModuleType("optuna.visualization")
+    figures = {
+        "history": Mock(name="history"),
+        "importance": Mock(name="importance"),
+        "intermediate": Mock(name="intermediate"),
+        "pareto": Mock(name="pareto"),
+        "timeline": Mock(name="timeline"),
+    }
+    visualization.plot_optimization_history = Mock(return_value=figures["history"])
+    visualization.plot_param_importances = Mock(return_value=figures["importance"])
+    visualization.plot_intermediate_values = Mock(
+        return_value=figures["intermediate"], side_effect=intermediate_error
+    )
+    visualization.plot_pareto_front = Mock(return_value=figures["pareto"])
+    visualization.plot_timeline = Mock(return_value=figures["timeline"])
+
+    optuna = types.ModuleType("optuna")
+    optuna.__path__ = []
+    optuna.visualization = visualization
+    return optuna, visualization, figures
+
+
+class TestOptunaIntermediateValues(unittest.TestCase):
+    def test_logs_intermediate_values_in_step_order_before_final_metric(self):
+        viz = Mock()
+        trial = make_trial(
+            values=(0.2,),
+            intermediate_values={2: 0.3, 0: 0.9, 1: 0.5},
+        )
+        callback = OptunaCallback(viz, dashboard_env="optuna_quadratic")
+
+        callback(make_study([trial]), trial)
+
+        self.assertEqual(
+            viz.log_metrics.call_args_list,
+            [
+                call(
+                    {"intermediate_value": 0.9},
+                    step=0,
+                    env="optuna_quadratic_trial_000000",
+                ),
+                call(
+                    {"intermediate_value": 0.5},
+                    step=1,
+                    env="optuna_quadratic_trial_000000",
+                ),
+                call(
+                    {"intermediate_value": 0.3},
+                    step=2,
+                    env="optuna_quadratic_trial_000000",
+                ),
+                call(
+                    {"objective": 0.2},
+                    env="optuna_quadratic_trial_000000",
+                ),
+            ],
+        )
+        self.assertEqual(
+            [method[0] for method in viz.method_calls],
+            [
+                "experiment",
+                "log_metrics",
+                "log_metrics",
+                "log_metrics",
+                "log_metrics",
+                "finish_experiment",
+            ],
+        )
+
+    def test_trial_without_intermediate_values_only_logs_final_metric(self):
+        viz = Mock()
+        trial = make_trial(values=(0.2,))
+        callback = OptunaCallback(viz, dashboard_env="optuna_quadratic")
+
+        callback(make_study([trial]), trial)
+
+        viz.log_metrics.assert_called_once_with(
+            {"objective": 0.2}, env="optuna_quadratic_trial_000000"
+        )
+
+    def test_pruned_trial_preserves_intermediate_values_and_failed_status(self):
+        viz = Mock()
+        trial = make_trial(
+            state="PRUNED",
+            values=None,
+            intermediate_values={4: 0.6},
+        )
+        callback = OptunaCallback(viz, dashboard_env="optuna_quadratic")
+
+        callback(make_study([trial]), trial)
+
+        viz.log_metrics.assert_called_once_with(
+            {"intermediate_value": 0.6},
+            step=4,
+            env="optuna_quadratic_trial_000000",
+        )
+        self.assertEqual(
+            viz.experiment.call_args.kwargs["tags"]["optuna_state"], "PRUNED"
+        )
+        viz.finish_experiment.assert_called_once_with(
+            status="failed", env="optuna_quadratic_trial_000000"
+        )
+
+    def test_intermediate_logging_failure_uses_existing_error_policy(self):
+        trial = make_trial(intermediate_values={0: 0.9})
+        study = make_study([trial])
+
+        warning_viz = Mock()
+        warning_viz.log_metrics.side_effect = RuntimeError("offline")
+        warning_callback = OptunaCallback(warning_viz, dashboard_env="optuna_quadratic")
+        with self.assertWarnsRegex(RuntimeWarning, "failed to log trial 0: offline"):
+            warning_callback(study, trial)
+        warning_viz.finish_experiment.assert_not_called()
+        self.assertEqual(warning_callback._trial_envs, [])
+
+        raising_viz = Mock()
+        raising_viz.log_metrics.side_effect = RuntimeError("offline")
+        raising_callback = OptunaCallback(
+            raising_viz,
+            dashboard_env="optuna_quadratic",
+            raise_on_error=True,
+        )
+        with self.assertRaisesRegex(RuntimeError, "offline"):
+            raising_callback(study, trial)
+
+
+class TestOptunaIntermediateDashboard(unittest.TestCase):
+    def dashboard_figures(self, trial, intermediate_error=None):
+        optuna, visualization, figures = fake_visualization_module(
+            intermediate_error=intermediate_error
+        )
+        modules = {
+            "optuna": optuna,
+            "optuna.visualization": visualization,
+        }
+        callback = OptunaCallback(Mock(), dashboard_env="optuna_quadratic")
+        with patch.dict(sys.modules, modules):
+            result = callback._dashboard_figures(make_study([trial]))
+        return result, visualization, figures
+
+    def test_adds_intermediate_figure_when_values_exist(self):
+        trial = make_trial(intermediate_values={0: 0.9})
+
+        result, visualization, figures = self.dashboard_figures(trial)
+
+        self.assertEqual(
+            [win for win, _ in result],
+            ["optuna-history", "optuna-intermediate-values", "optuna-timeline"],
+        )
+        visualization.plot_intermediate_values.assert_called_once()
+        figures["intermediate"].update_layout.assert_called_once_with(
+            title="Optuna Intermediate Values"
+        )
+
+    def test_skips_intermediate_figure_when_values_are_absent(self):
+        result, visualization, _ = self.dashboard_figures(make_trial())
+
+        self.assertEqual(
+            [win for win, _ in result],
+            ["optuna-history", "optuna-timeline"],
+        )
+        visualization.plot_intermediate_values.assert_not_called()
+
+    def test_skips_intermediate_figure_when_optuna_cannot_build_it(self):
+        trial = make_trial(intermediate_values={0: 0.9})
+
+        result, visualization, _ = self.dashboard_figures(
+            trial, intermediate_error=ValueError("not enough data")
+        )
+
+        self.assertEqual(
+            [win for win, _ in result],
+            ["optuna-history", "optuna-timeline"],
+        )
+        visualization.plot_intermediate_values.assert_called_once()
+
+
+class TestOptunaMultiObjective(unittest.TestCase):
+    def test_logs_two_objectives_and_adds_pareto_front(self):
+        trial = make_trial(values=(0.92, 18.4))
+        study = SimpleNamespace(
+            study_name="accuracy-latency",
+            directions=[
+                SimpleNamespace(name="MAXIMIZE"),
+                SimpleNamespace(name="MINIMIZE"),
+            ],
+            metric_names=None,
+            best_trials=[trial],
+            get_trials=Mock(return_value=[trial]),
+        )
+        viz = Mock()
+        callback = OptunaCallback(
+            viz,
+            dashboard_env="optuna_accuracy_latency",
+            objective_names=["accuracy", "latency_ms"],
+        )
+
+        callback(study, trial)
+
+        viz.log_metrics.assert_called_once_with(
+            {"accuracy": 0.92, "latency_ms": 18.4},
+            env="optuna_accuracy_latency_trial_000000",
+        )
+        self.assertEqual(
+            viz.experiment.call_args.kwargs["tags"]["optuna_direction"],
+            "maximize,minimize",
+        )
+
+        optuna, visualization, figures = fake_visualization_module()
+        with patch.dict(
+            sys.modules,
+            {"optuna": optuna, "optuna.visualization": visualization},
+        ):
+            result = callback._dashboard_figures(study)
+
+        self.assertEqual(
+            [win for win, _ in result],
+            [
+                "optuna-history-0",
+                "optuna-history-1",
+                "optuna-pareto-front",
+                "optuna-timeline",
+            ],
+        )
+        visualization.plot_pareto_front.assert_called_once_with(
+            study,
+            target_names=["accuracy", "latency_ms"],
+        )
+        figures["pareto"].update_layout.assert_called_once_with(
+            title="Optuna Pareto Front"
+        )
+
+    def test_logs_three_objectives_and_adds_pareto_front(self):
+        trial = make_trial(values=(0.92, 18.4, 512.0))
+        study = SimpleNamespace(
+            study_name="accuracy-latency-memory",
+            directions=[
+                SimpleNamespace(name="MAXIMIZE"),
+                SimpleNamespace(name="MINIMIZE"),
+                SimpleNamespace(name="MINIMIZE"),
+            ],
+            metric_names=None,
+            best_trials=[trial],
+            get_trials=Mock(return_value=[trial]),
+        )
+        viz = Mock()
+        callback = OptunaCallback(
+            viz,
+            dashboard_env="optuna_accuracy_latency_memory",
+            objective_names=["accuracy", "latency_ms", "memory_mb"],
+        )
+
+        callback(study, trial)
+
+        viz.log_metrics.assert_called_once_with(
+            {"accuracy": 0.92, "latency_ms": 18.4, "memory_mb": 512.0},
+            env="optuna_accuracy_latency_memory_trial_000000",
+        )
+
+        optuna, visualization, figures = fake_visualization_module()
+        with patch.dict(
+            sys.modules,
+            {"optuna": optuna, "optuna.visualization": visualization},
+        ):
+            result = callback._dashboard_figures(study)
+
+        self.assertEqual(
+            [win for win, _ in result],
+            [
+                "optuna-history-0",
+                "optuna-history-1",
+                "optuna-history-2",
+                "optuna-pareto-front",
+                "optuna-timeline",
+            ],
+        )
+        visualization.plot_pareto_front.assert_called_once_with(
+            study,
+            target_names=["accuracy", "latency_ms", "memory_mb"],
+        )
+        figures["pareto"].update_layout.assert_called_once_with(
+            title="Optuna Pareto Front"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/py/tests/unit/optuna_integration.py
+++ b/py/tests/unit/optuna_integration.py
@@ -14,7 +14,12 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import Mock, call, patch
 
+import pytest
+
 from visdom.integrations import OptunaCallback
+
+
+pytestmark = pytest.mark.unit
 
 
 def make_trial(

--- a/py/visdom/experiments/live.py
+++ b/py/visdom/experiments/live.py
@@ -18,7 +18,7 @@ dependency so they can be exercised on their own:
   runs are coalesced, so a training loop logging a metric every step costs one
   rebuild per burst rather than one per step.
 * :func:`resolve_targets` — *what* to rebuild. Given the server's env state and
-  the environments that just changed, it names the panes affected.
+  the environments that just changed, it names the explicit-id panes affected.
 
 The queue is handed a resolver and a rebuild callback rather than reaching for
 either itself, which is what lets the server point it at the existing
@@ -54,10 +54,10 @@ def resolve_targets(state, changed):
     ids just written. Returns ``(eid, win_id)`` pairs — what a rebuild needs to
     identify a pane — in a stable order, grouped by environment.
 
-    A pane that names its runs explicitly (``mode="env_ids"``) is affected only
-    when one of those runs changed. A pane holding a query is affected by any
-    change at all: a run that did not match before may match now, and deciding
-    otherwise would mean re-running the query, which is the rebuild itself.
+    Only a pane that names its runs explicitly (``mode="env_ids"``) is refreshed
+    automatically, and only when one of those runs changed. Query selections
+    require a whole-store scan, so ``query`` and ``both`` panes are refreshed
+    only when requested explicitly.
 
     Environments that are not resident in memory are skipped rather than paged
     in. With an env per file, touching them all on every logged metric would
@@ -82,9 +82,9 @@ def resolve_targets(state, changed):
             spec = win.get("hparams")
             if not isinstance(spec, dict):
                 continue
-            if spec.get("mode") == "env_ids" and not changed.intersection(
-                _named_env_ids(spec)
-            ):
+            if spec.get("mode") != "env_ids":
+                continue
+            if not changed.intersection(_named_env_ids(spec)):
                 continue
             targets.append((eid, win_id))
     return targets

--- a/py/visdom/integrations/optuna.py
+++ b/py/visdom/integrations/optuna.py
@@ -22,8 +22,10 @@ import warnings
 from collections import Counter
 from collections.abc import Mapping, Sequence
 from typing import Any
+from urllib.parse import quote
 
 from visdom.experiments.tags import normalize_tags
+from visdom.utils.server_utils import escape_eid
 
 
 class OptunaCallback:
@@ -149,6 +151,15 @@ class OptunaCallback:
             raise ValueError("study is required when dashboard_env was not supplied")
         return "{}_trial_{:06d}".format(self.study_env(study), trial.number)
 
+    def _trial_url(self, trial: Any, study: Any) -> str:
+        root = "{}:{}{}".format(
+            self.viz.server,
+            self.viz.port,
+            self.viz.base_url,
+        ).rstrip("/")
+        env = quote(escape_eid(self.trial_env(trial, study)), safe="")
+        return "{}/env/{}".format(root, env)
+
     def _metric_names(self, study: Any, value_count: int) -> tuple[str, ...]:
         if self.objective_names is not None:
             names = self.objective_names
@@ -186,6 +197,7 @@ class OptunaCallback:
     def _summary_html(self, study: Any) -> str:
         trials = study.get_trials(deepcopy=False)
         states = Counter(trial.state.name for trial in trials)
+        links = []
         rows = [
             ("Study", study.study_name),
             (
@@ -198,6 +210,7 @@ class OptunaCallback:
             ("Failed", states["FAIL"]),
         ]
         if len(study.directions) == 1 and states["COMPLETE"]:
+            links.append(("Open best trial", self._trial_url(study.best_trial, study)))
             rows.extend(
                 [
                     ("Best value", study.best_value),
@@ -214,13 +227,32 @@ class OptunaCallback:
         elif states["COMPLETE"]:
             rows.append(("Pareto trials", len(study.best_trials)))
 
+        terminal_trials = [
+            trial
+            for trial in trials
+            if trial.state.name in ("COMPLETE", "PRUNED", "FAIL")
+        ]
+        if terminal_trials:
+            latest_trial = max(terminal_trials, key=lambda trial: trial.number)
+            links.append(("Open latest trial", self._trial_url(latest_trial, study)))
+
         body = "".join(
             "<tr><th>{}</th><td>{}</td></tr>".format(
                 html.escape(str(label)), html.escape(str(value))
             )
             for label, value in rows
         )
-        return "<h3>Optuna Study</h3><table>{}</table>".format(body)
+        navigation = ""
+        if links:
+            anchors = " | ".join(
+                '<a href="{}" target="_blank" rel="noopener noreferrer">{}</a>'.format(
+                    html.escape(url, quote=True),
+                    html.escape(label),
+                )
+                for label, url in links
+            )
+            navigation = "<p><strong>Open in Visdom:</strong> {}</p>".format(anchors)
+        return "<h3>Optuna Study</h3><table>{}</table>{}".format(body, navigation)
 
     def _dashboard_figures(self, study: Any) -> list[tuple[str, Any]]:
         try:

--- a/py/visdom/integrations/optuna.py
+++ b/py/visdom/integrations/optuna.py
@@ -16,7 +16,10 @@ Visdom dependency just for this optional adapter.
 
 from __future__ import annotations
 
+import html
+import json
 import warnings
+from collections import Counter
 from collections.abc import Mapping, Sequence
 from typing import Any
 
@@ -24,7 +27,7 @@ from visdom.experiments.tags import normalize_tags
 
 
 class OptunaCallback:
-    """Log each completed Optuna trial to a dedicated Visdom environment.
+    """Log completed Optuna trials and optionally maintain a study dashboard.
 
     Instances are passed to ``Study.optimize(callbacks=[...])``. Optuna calls
     the instance with a ``Study`` and ``FrozenTrial`` after a trial finishes;
@@ -32,9 +35,13 @@ class OptunaCallback:
     Visdom's experiment API.
 
     ``dashboard_env`` is the namespace for the study and its trial
-    environments. When omitted it is derived from the Optuna study name. The
-    callback itself does not create a dashboard pane; it only establishes the
-    stable environment layout that a dashboard can aggregate later.
+    environments. When omitted it is derived from the Optuna study name.
+    ``create_dashboard=True`` creates a summary, an HParams pane and Optuna's
+    Plotly study visualizations in that environment. The first completed trial
+    creates the dashboard; later trials refresh it every ``refresh_every``
+    successful writes. Call :meth:`update_dashboard` after ``Study.optimize``
+    to ensure the final trials are included when the total is not an exact
+    multiple of that interval.
 
     Optuna is intentionally not imported here. This keeps the integration
     optional and also means importing :mod:`visdom.integrations` never requires
@@ -52,6 +59,8 @@ class OptunaCallback:
         raise_on_error: Re-raise Visdom logging failures when true. By default a
             warning is emitted so an unavailable dashboard does not stop the
             optimization.
+        create_dashboard: Create and periodically refresh the study dashboard.
+        refresh_every: Number of newly logged trials between dashboard refreshes.
 
     Example::
 
@@ -59,8 +68,10 @@ class OptunaCallback:
             viz,
             dashboard_env="optuna_resnet",
             objective_names=["validation_accuracy"],
+            create_dashboard=True,
         )
         study.optimize(objective, callbacks=[callback])
+        callback.update_dashboard(study)
     """
 
     def __init__(
@@ -70,17 +81,26 @@ class OptunaCallback:
         objective_names: Sequence[str] | None = None,
         tags: Mapping[str, str] | None = None,
         raise_on_error: bool = False,
+        create_dashboard: bool = False,
+        refresh_every: int = 10,
     ) -> None:
         if dashboard_env is not None and not isinstance(dashboard_env, str):
             raise TypeError("dashboard_env must be a string or None")
         if dashboard_env == "":
             raise ValueError("dashboard_env must not be empty")
+        if refresh_every < 1:
+            raise ValueError("refresh_every must be at least 1")
 
         self.viz = viz
         self.dashboard_env = dashboard_env
         self.objective_names = self._validate_objective_names(objective_names)
         self.tags = self._validate_tags(tags)
         self.raise_on_error = raise_on_error
+        self.create_dashboard = create_dashboard
+        self.refresh_every = refresh_every
+        self._dashboard_created = False
+        self._trials_since_refresh = 0
+        self._trial_envs: list[str] = []
 
     @staticmethod
     def _validate_objective_names(
@@ -163,6 +183,156 @@ class OptunaCallback:
         )
         return normalize_tags(tags)
 
+    def _summary_html(self, study: Any) -> str:
+        trials = study.get_trials(deepcopy=False)
+        states = Counter(trial.state.name for trial in trials)
+        rows = [
+            ("Study", study.study_name),
+            (
+                "Direction",
+                ", ".join(direction.name.lower() for direction in study.directions),
+            ),
+            ("Trials", len(trials)),
+            ("Complete", states["COMPLETE"]),
+            ("Pruned", states["PRUNED"]),
+            ("Failed", states["FAIL"]),
+        ]
+        if len(study.directions) == 1 and states["COMPLETE"]:
+            rows.extend(
+                [
+                    ("Best value", study.best_value),
+                    (
+                        "Best parameters",
+                        json.dumps(
+                            study.best_params,
+                            ensure_ascii=False,
+                            sort_keys=True,
+                        ),
+                    ),
+                ]
+            )
+        elif states["COMPLETE"]:
+            rows.append(("Pareto trials", len(study.best_trials)))
+
+        body = "".join(
+            "<tr><th>{}</th><td>{}</td></tr>".format(
+                html.escape(str(label)), html.escape(str(value))
+            )
+            for label, value in rows
+        )
+        return "<h3>Optuna Study</h3><table>{}</table>".format(body)
+
+    def _dashboard_figures(self, study: Any) -> list[tuple[str, Any]]:
+        try:
+            from optuna.visualization import (
+                plot_optimization_history,
+                plot_param_importances,
+                plot_timeline,
+            )
+
+            objective_names = self._metric_names(study, len(study.directions))
+            figures = []
+            multi_objective = len(objective_names) > 1
+            complete_trials = sum(
+                trial.state.name == "COMPLETE"
+                for trial in study.get_trials(deepcopy=False)
+            )
+            for index, objective_name in enumerate(objective_names):
+                target = (
+                    (lambda trial, i=index: trial.values[i])
+                    if multi_objective
+                    else None
+                )
+                kwargs: dict[str, Any] = {"target_name": objective_name}
+                if target is not None:
+                    kwargs["target"] = target
+                history = plot_optimization_history(study, **kwargs)
+                history.update_layout(
+                    title="Optimization History — {}".format(objective_name)
+                )
+                suffix = "-{}".format(index) if multi_objective else ""
+                figures.append(("optuna-history{}".format(suffix), history))
+
+                if complete_trials >= 2:
+                    try:
+                        importance = plot_param_importances(study, **kwargs)
+                    except ValueError:
+                        pass
+                    else:
+                        importance.update_layout(
+                            title="Parameter Importance — {}".format(objective_name)
+                        )
+                        figures.append(
+                            ("optuna-importance{}".format(suffix), importance)
+                        )
+
+            timeline = plot_timeline(study)
+            timeline.update_layout(title="Optuna Trial Timeline")
+            figures.append(("optuna-timeline", timeline))
+            return figures
+        except ImportError as error:
+            warnings.warn(
+                "Optuna dashboard plots are unavailable: {}".format(error),
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return []
+
+    def _build_dashboard_payload(self, study: Any) -> dict[str, Any]:
+        if not self._trial_envs:
+            raise ValueError("cannot create an Optuna dashboard before logging a trial")
+        return {
+            "env": self.study_env(study),
+            "env_ids": list(self._trial_envs),
+            "summary": self._summary_html(study),
+            "figures": self._dashboard_figures(study),
+        }
+
+    def update_dashboard(self, study: Any) -> bool:
+        """Create or refresh all dashboard panes for ``study``.
+
+        Returns whether the dashboard was written successfully. Only trials
+        logged by this callback instance are included in the HParams pane;
+        loading trials from a resumed study is handled by the later resume
+        integration.
+        """
+        payload = self._build_dashboard_payload(study)
+        try:
+            self.viz.text(
+                payload["summary"],
+                win="optuna-summary",
+                env=payload["env"],
+                opts={"title": "Optuna Study"},
+            )
+            self.viz.hparams(
+                env_ids=payload["env_ids"],
+                win="optuna-trials",
+                env=payload["env"],
+                opts={"title": "Optuna Trials"},
+            )
+            for win, figure in payload["figures"]:
+                self.viz.plotlyplot(figure, win=win, env=payload["env"])
+        except Exception as error:
+            if self.raise_on_error:
+                raise
+            warnings.warn(
+                "OptunaCallback failed to update the dashboard: {}".format(error),
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return False
+        self._dashboard_created = True
+        self._trials_since_refresh = 0
+        return True
+
+    def _maybe_update_dashboard(self, study: Any) -> None:
+        self._trials_since_refresh += 1
+        if (
+            not self._dashboard_created
+            or self._trials_since_refresh >= self.refresh_every
+        ):
+            self.update_dashboard(study)
+
     def _build_payload(self, study: Any, trial: Any) -> dict[str, Any]:
         env = self.trial_env(trial, study)
         state = trial.state.name
@@ -211,3 +381,8 @@ class OptunaCallback:
                 RuntimeWarning,
                 stacklevel=2,
             )
+            return
+
+        self._trial_envs.append(payload["env"])
+        if self.create_dashboard:
+            self._maybe_update_dashboard(study)

--- a/py/visdom/integrations/optuna.py
+++ b/py/visdom/integrations/optuna.py
@@ -269,6 +269,7 @@ class OptunaCallback:
                 plot_intermediate_values,
                 plot_optimization_history,
                 plot_param_importances,
+                plot_pareto_front,
                 plot_timeline,
             )
 
@@ -305,6 +306,18 @@ class OptunaCallback:
                         figures.append(
                             ("optuna-importance{}".format(suffix), importance)
                         )
+
+            if complete_trials and len(objective_names) in (2, 3):
+                try:
+                    pareto = plot_pareto_front(
+                        study,
+                        target_names=list(objective_names),
+                    )
+                except ValueError:
+                    pass
+                else:
+                    pareto.update_layout(title="Optuna Pareto Front")
+                    figures.append(("optuna-pareto-front", pareto))
 
             if any(self._intermediate_values(trial) for trial in trials):
                 try:

--- a/py/visdom/integrations/optuna.py
+++ b/py/visdom/integrations/optuna.py
@@ -203,6 +203,49 @@ class OptunaCallback:
         values = getattr(trial, "intermediate_values", None) or {}
         return sorted(values.items())
 
+    @staticmethod
+    def _add_timeline_markers(timeline: Any) -> None:
+        """Keep very short trials visible without changing their duration bars.
+
+        Optuna renders each trial as a horizontal bar whose width is its runtime.
+        When callback or scheduler overhead dominates a study's wall-clock span,
+        sub-millisecond trials can become substantially narrower than one browser
+        pixel. A fixed-size marker at each trial's true start time preserves the
+        timeline semantics while keeping those trials discoverable and hoverable.
+        """
+        for trace in tuple(timeline.data):
+            if trace.type != "bar" or trace.orientation != "h":
+                continue
+
+            starts = list(trace.base) if trace.base is not None else []
+            durations = list(trace.x) if trace.x is not None else []
+            trial_numbers = list(trace.y) if trace.y is not None else []
+            if not starts or not (len(starts) == len(durations) == len(trial_numbers)):
+                continue
+
+            text = list(trace.text) if trace.text is not None else None
+            color = trace.marker.color if trace.marker is not None else None
+            timeline.add_scatter(
+                x=starts,
+                y=trial_numbers,
+                mode="markers",
+                name=trace.name,
+                legendgroup=trace.name,
+                showlegend=False,
+                marker={
+                    "color": color,
+                    "size": 9,
+                    "symbol": "circle",
+                    "line": {"color": "white", "width": 1},
+                },
+                customdata=durations,
+                text=text,
+                hovertemplate=(
+                    "Start: %{x}<br>Duration: %{customdata:.3f} ms"
+                    "<br>%{text}<extra>" + html.escape(str(trace.name)) + "</extra>"
+                ),
+            )
+
     def _summary_html(self, study: Any) -> str:
         trials = study.get_trials(deepcopy=False)
         states = Counter(trial.state.name for trial in trials)
@@ -329,6 +372,7 @@ class OptunaCallback:
                     figures.append(("optuna-intermediate-values", intermediate))
 
             timeline = plot_timeline(study)
+            self._add_timeline_markers(timeline)
             timeline.update_layout(title="Optuna Trial Timeline")
             figures.append(("optuna-timeline", timeline))
             return figures

--- a/py/visdom/integrations/optuna.py
+++ b/py/visdom/integrations/optuna.py
@@ -29,6 +29,7 @@ from visdom.utils.server_utils import escape_eid
 
 
 _INTERMEDIATE_METRIC_NAME = "intermediate_value"
+_DASHBOARD_TAG_NAME = "optuna_dashboard_env"
 
 
 class OptunaCallback:
@@ -46,7 +47,10 @@ class OptunaCallback:
     creates the dashboard; later trials refresh it every ``refresh_every``
     successful writes. Call :meth:`update_dashboard` after ``Study.optimize``
     to ensure the final trials are included when the total is not an exact
-    multiple of that interval.
+    multiple of that interval. The HParams pane selects trials through stable
+    experiment tags rather than callback-local state, so a new callback can
+    rebuild a persisted study dashboard and multiple workers share the same
+    trial selection.
 
     Optuna is intentionally not imported here. This keeps the integration
     optional and also means importing :mod:`visdom.integrations` never requires
@@ -193,9 +197,35 @@ class OptunaCallback:
                 "optuna_direction": ",".join(
                     direction.name.lower() for direction in study.directions
                 ),
+                _DASHBOARD_TAG_NAME: self.study_env(study),
             }
         )
         return normalize_tags(tags)
+
+    @staticmethod
+    def _query_literal(value: Any) -> str:
+        """Quote a string for Visdom's experiment query language."""
+        value = str(value)
+        escaped = (
+            value.replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+            .replace("\t", "\\t")
+        )
+        return '"{}"'.format(escaped)
+
+    def _dashboard_query(self, study: Any) -> str:
+        """Select every trial logged for this study and dashboard namespace."""
+        return " AND ".join(
+            (
+                'tag.integration = "optuna"',
+                "tag.optuna_study = {}".format(self._query_literal(study.study_name)),
+                "tag.{} = {}".format(
+                    _DASHBOARD_TAG_NAME,
+                    self._query_literal(self.study_env(study)),
+                ),
+            )
+        )
 
     @staticmethod
     def _intermediate_values(trial: Any) -> list[tuple[int, float]]:
@@ -385,11 +415,9 @@ class OptunaCallback:
             return []
 
     def _build_dashboard_payload(self, study: Any) -> dict[str, Any]:
-        if not self._trial_envs:
-            raise ValueError("cannot create an Optuna dashboard before logging a trial")
         return {
             "env": self.study_env(study),
-            "env_ids": list(self._trial_envs),
+            "query": self._dashboard_query(study),
             "summary": self._summary_html(study),
             "figures": self._dashboard_figures(study),
         }
@@ -397,10 +425,10 @@ class OptunaCallback:
     def update_dashboard(self, study: Any) -> bool:
         """Create or refresh all dashboard panes for ``study``.
 
-        Returns whether the dashboard was written successfully. Only trials
-        logged by this callback instance are included in the HParams pane;
-        loading trials from a resumed study is handled by the later resume
-        integration.
+        Returns whether the dashboard was written successfully. The HParams
+        pane queries the server for every trial carrying this study's stable
+        dashboard tag. It therefore includes trials logged by earlier callback
+        instances and by other workers that share the dashboard namespace.
         """
         payload = self._build_dashboard_payload(study)
         try:
@@ -411,7 +439,7 @@ class OptunaCallback:
                 opts={"title": "Optuna Study"},
             )
             self.viz.hparams(
-                env_ids=payload["env_ids"],
+                query=payload["query"],
                 win="optuna-trials",
                 env=payload["env"],
                 opts={"title": "Optuna Trials"},

--- a/py/visdom/integrations/optuna.py
+++ b/py/visdom/integrations/optuna.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import html
 import json
+import threading
 import warnings
 from collections import Counter
 from collections.abc import Mapping, Sequence
@@ -50,7 +51,9 @@ class OptunaCallback:
     multiple of that interval. The HParams pane selects trials through stable
     experiment tags rather than callback-local state, so a new callback can
     rebuild a persisted study dashboard and multiple workers share the same
-    trial selection.
+    trial selection. Dashboard refreshes are serialized within one callback
+    instance. When separate processes share a dashboard namespace, only one
+    callback should enable ``create_dashboard`` and act as its writer.
 
     Optuna is intentionally not imported here. This keeps the integration
     optional and also means importing :mod:`visdom.integrations` never requires
@@ -110,6 +113,7 @@ class OptunaCallback:
         self._dashboard_created = False
         self._trials_since_refresh = 0
         self._trial_envs: list[str] = []
+        self._dashboard_lock = threading.RLock()
 
     @staticmethod
     def _validate_objective_names(
@@ -428,44 +432,49 @@ class OptunaCallback:
         Returns whether the dashboard was written successfully. The HParams
         pane queries the server for every trial carrying this study's stable
         dashboard tag. It therefore includes trials logged by earlier callback
-        instances and by other workers that share the dashboard namespace.
+        instances and by other workers that share the dashboard namespace. A
+        callback-local lock prevents concurrent refreshes from overwriting a
+        newer payload. Separate processes must designate a single dashboard
+        writer because they do not share this lock.
         """
-        payload = self._build_dashboard_payload(study)
-        try:
-            self.viz.text(
-                payload["summary"],
-                win="optuna-summary",
-                env=payload["env"],
-                opts={"title": "Optuna Study"},
-            )
-            self.viz.hparams(
-                query=payload["query"],
-                win="optuna-trials",
-                env=payload["env"],
-                opts={"title": "Optuna Trials"},
-            )
-            for win, figure in payload["figures"]:
-                self.viz.plotlyplot(figure, win=win, env=payload["env"])
-        except Exception as error:
-            if self.raise_on_error:
-                raise
-            warnings.warn(
-                "OptunaCallback failed to update the dashboard: {}".format(error),
-                RuntimeWarning,
-                stacklevel=2,
-            )
-            return False
-        self._dashboard_created = True
-        self._trials_since_refresh = 0
-        return True
+        with self._dashboard_lock:
+            payload = self._build_dashboard_payload(study)
+            try:
+                self.viz.text(
+                    payload["summary"],
+                    win="optuna-summary",
+                    env=payload["env"],
+                    opts={"title": "Optuna Study"},
+                )
+                self.viz.hparams(
+                    query=payload["query"],
+                    win="optuna-trials",
+                    env=payload["env"],
+                    opts={"title": "Optuna Trials"},
+                )
+                for win, figure in payload["figures"]:
+                    self.viz.plotlyplot(figure, win=win, env=payload["env"])
+            except Exception as error:
+                if self.raise_on_error:
+                    raise
+                warnings.warn(
+                    "OptunaCallback failed to update the dashboard: {}".format(error),
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                return False
+            self._dashboard_created = True
+            self._trials_since_refresh = 0
+            return True
 
     def _maybe_update_dashboard(self, study: Any) -> None:
-        self._trials_since_refresh += 1
-        if (
-            not self._dashboard_created
-            or self._trials_since_refresh >= self.refresh_every
-        ):
-            self.update_dashboard(study)
+        with self._dashboard_lock:
+            self._trials_since_refresh += 1
+            if (
+                not self._dashboard_created
+                or self._trials_since_refresh >= self.refresh_every
+            ):
+                self.update_dashboard(study)
 
     def _build_payload(self, study: Any, trial: Any) -> dict[str, Any]:
         env = self.trial_env(trial, study)

--- a/py/visdom/integrations/optuna.py
+++ b/py/visdom/integrations/optuna.py
@@ -28,13 +28,16 @@ from visdom.experiments.tags import normalize_tags
 from visdom.utils.server_utils import escape_eid
 
 
+_INTERMEDIATE_METRIC_NAME = "intermediate_value"
+
+
 class OptunaCallback:
     """Log completed Optuna trials and optionally maintain a study dashboard.
 
     Instances are passed to ``Study.optimize(callbacks=[...])``. Optuna calls
     the instance with a ``Study`` and ``FrozenTrial`` after a trial finishes;
-    the callback stores the trial's parameters, objective values and state via
-    Visdom's experiment API.
+    the callback stores the trial's parameters, objective values, reported
+    intermediate values and state via Visdom's experiment API.
 
     ``dashboard_env`` is the namespace for the study and its trial
     environments. When omitted it is derived from the Optuna study name.
@@ -194,6 +197,12 @@ class OptunaCallback:
         )
         return normalize_tags(tags)
 
+    @staticmethod
+    def _intermediate_values(trial: Any) -> list[tuple[int, float]]:
+        """Return reported intermediate values ordered by training step."""
+        values = getattr(trial, "intermediate_values", None) or {}
+        return sorted(values.items())
+
     def _summary_html(self, study: Any) -> str:
         trials = study.get_trials(deepcopy=False)
         states = Counter(trial.state.name for trial in trials)
@@ -257,6 +266,7 @@ class OptunaCallback:
     def _dashboard_figures(self, study: Any) -> list[tuple[str, Any]]:
         try:
             from optuna.visualization import (
+                plot_intermediate_values,
                 plot_optimization_history,
                 plot_param_importances,
                 plot_timeline,
@@ -265,10 +275,8 @@ class OptunaCallback:
             objective_names = self._metric_names(study, len(study.directions))
             figures = []
             multi_objective = len(objective_names) > 1
-            complete_trials = sum(
-                trial.state.name == "COMPLETE"
-                for trial in study.get_trials(deepcopy=False)
-            )
+            trials = study.get_trials(deepcopy=False)
+            complete_trials = sum(trial.state.name == "COMPLETE" for trial in trials)
             for index, objective_name in enumerate(objective_names):
                 target = (
                     (lambda trial, i=index: trial.values[i])
@@ -297,6 +305,15 @@ class OptunaCallback:
                         figures.append(
                             ("optuna-importance{}".format(suffix), importance)
                         )
+
+            if any(self._intermediate_values(trial) for trial in trials):
+                try:
+                    intermediate = plot_intermediate_values(study)
+                except ValueError:
+                    pass
+                else:
+                    intermediate.update_layout(title="Optuna Intermediate Values")
+                    figures.append(("optuna-intermediate-values", intermediate))
 
             timeline = plot_timeline(study)
             timeline.update_layout(title="Optuna Trial Timeline")
@@ -399,6 +416,12 @@ class OptunaCallback:
                 description=payload["description"],
                 env=payload["env"],
             )
+            for step, value in self._intermediate_values(trial):
+                self.viz.log_metrics(
+                    {_INTERMEDIATE_METRIC_NAME: value},
+                    step=step,
+                    env=payload["env"],
+                )
             if payload["metrics"]:
                 self.viz.log_metrics(payload["metrics"], env=payload["env"])
             self.viz.finish_experiment(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`py/visdom/integrations/optuna.py`

- add the stable `optuna_dashboard_env` tag to Optuna trial experiments
- add safe query-value escaping for study and dashboard names
- build the HParams selection from experiment tags instead of `_trial_envs`
- allow `update_dashboard()` to run from a fresh callback instance
- keep `_trial_envs` for compatibility, without using it as the Dashboard source of truth

`README.md`

- document the `optuna_dashboard_env` tag

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously, the Dashboard relied on the callback instance’s in-memory _trial_envs, which meant old trials could not be recovered after a restart, each worker could only see the trials it had recorded locally, and workers could overwrite each other’s data when refreshing the Dashboard.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, experiments you ran to see how -->
<!--- your change affects existing areas of the code and their behaviors, etc. -->
<!--- One method of testing is to run the `demo.py` script from the examples -->
<!--- both on your branch and a clean branch and ensure that none of the functionality -->
<!--- appears different. Be sure to install from source when testing. -->
Execute the following code
```
from __future__ import annotations

import argparse
import json
import time
from collections import Counter
from concurrent.futures import ThreadPoolExecutor
from typing import Any
from urllib.parse import quote

import optuna
import visdom

from visdom.integrations import OptunaCallback


HPARAMS_WIN = "optuna-trials"
WORKERS = ("worker-a", "worker-b")


class RecordingVisdom:
    """Forward Visdom calls while retaining the latest HParams arguments."""

    def __init__(self, client: visdom.Visdom) -> None:
        self._client = client
        self.last_hparams_call: dict[str, Any] | None = None

    def __getattr__(self, name: str) -> Any:
        return getattr(self._client, name)

    def hparams(self, *args: Any, **kwargs: Any) -> Any:
        self.last_hparams_call = {"args": args, **kwargs}
        return self._client.hparams(*args, **kwargs)


def parse_args() -> argparse.Namespace:
    parser = argparse.ArgumentParser(
        description=(
            "Verify that independent Optuna callbacks share one Dashboard "
            "and that a fresh callback can rebuild it."
        )
    )
    parser.add_argument("--server", default="http://localhost")
    parser.add_argument("--port", type=int, default=8097)
    parser.add_argument("--base-url", default="/")
    parser.add_argument(
        "--env",
        help="Dashboard environment; defaults to a unique timestamped name.",
    )
    parser.add_argument("--trials-per-worker", type=int, default=3)
    parser.add_argument("--refresh-every", type=int, default=1)
    parser.add_argument("--seed", type=int, default=42)
    args = parser.parse_args()
    if args.trials_per_worker < 1:
        parser.error("--trials-per-worker must be at least 1")
    if args.refresh_every < 1:
        parser.error("--refresh-every must be at least 1")
    return args


def make_client(args: argparse.Namespace, env: str) -> visdom.Visdom:
    return visdom.Visdom(
        server=args.server,
        port=args.port,
        base_url=args.base_url,
        env=env,
        use_incoming_socket=False,
        raise_exceptions=True,
    )


def dashboard_url(viz: visdom.Visdom, env: str) -> str:
    root = "{}:{}{}".format(viz.server, viz.port, viz.base_url).rstrip("/")
    return "{}/env/{}".format(root, quote(env, safe=""))


def objective(trial: optuna.Trial) -> float:
    x = trial.suggest_float("x", -10.0, 10.0)
    y = trial.suggest_float("y", -5.0, 5.0)
    return (x - 2.0) ** 2 + (y + 1.0) ** 2


def run_worker(
    study: optuna.Study,
    callback: OptunaCallback,
    n_trials: int,
) -> None:
    study.optimize(objective, n_trials=n_trials, callbacks=[callback])


def load_hparams(viz: visdom.Visdom, env: str) -> dict[str, Any]:
    raw = viz.get_window_data(win=HPARAMS_WIN, env=env)
    pane = json.loads(raw) if isinstance(raw, str) else raw
    if not isinstance(pane, dict):
        raise AssertionError("Optuna HParams pane was not created")
    if pane.get("type") != "hparams":
        raise AssertionError("optuna-trials is not an HParams pane")
    return pane


def verify_hparams(
    pane: dict[str, Any],
    study: optuna.Study,
    callback: OptunaCallback,
    dashboard_client: RecordingVisdom,
    dashboard_env: str,
) -> tuple[list[str], Counter[str]]:
    content = pane.get("content")
    if not isinstance(content, dict):
        raise AssertionError("HParams pane has no content")
    records = content.get("records")
    if not isinstance(records, list):
        raise AssertionError("HParams pane has no records")

    expected_env_ids = {
        callback.trial_env(trial, study) for trial in study.get_trials(deepcopy=False)
    }
    actual_env_ids = {record.get("env_id") for record in records}
    if actual_env_ids != expected_env_ids:
        missing = sorted(expected_env_ids - actual_env_ids)
        unexpected = sorted(actual_env_ids - expected_env_ids)
        raise AssertionError(
            "HParams trial selection is incomplete; missing={}, unexpected={}".format(
                missing,
                unexpected,
            )
        )

    worker_counts: Counter[str] = Counter()
    for record in records:
        tags = record.get("tags", {})
        if tags.get("optuna_dashboard_env") != dashboard_env:
            raise AssertionError(
                "trial {} has the wrong optuna_dashboard_env tag".format(
                    record.get("env_id")
                )
            )
        worker_counts[tags.get("worker", "missing")] += 1

    expected_worker_counts = Counter(
        {worker: len(expected_env_ids) // len(WORKERS) for worker in WORKERS}
    )
    if worker_counts != expected_worker_counts:
        raise AssertionError(
            "expected records from both callbacks: expected={}, actual={}".format(
                dict(expected_worker_counts),
                dict(worker_counts),
            )
        )

    hparams_call = dashboard_client.last_hparams_call
    if hparams_call is None:
        raise AssertionError("fresh callback did not call viz.hparams()")
    query = hparams_call.get("query")
    if not isinstance(query, str) or not query:
        raise AssertionError("fresh callback did not use query-based selection")
    if hparams_call.get("env_ids") is not None:
        raise AssertionError("fresh callback still used callback-local env_ids")
    if "tag.optuna_dashboard_env" not in query:
        raise AssertionError("HParams query does not use the stable Dashboard tag")

    return sorted(actual_env_ids), worker_counts


def main() -> None:
    args = parse_args()
    run_id = str(time.time_ns())
    dashboard_env = args.env or "optuna_shared_callbacks_{}".format(run_id)
    study_name = "shared-callbacks-{}".format(run_id)
    inspector = make_client(args, dashboard_env)
    if not inspector.check_connection(timeout_seconds=3):
        raise SystemExit(
            "Cannot connect to Visdom at {}:{}. Start the server first with "
            "`python3 -m visdom.server`.".format(args.server, args.port)
        )

    storage = optuna.storages.InMemoryStorage()
    optuna.create_study(
        study_name=study_name,
        direction="minimize",
        storage=storage,
    )

    studies = [
        optuna.load_study(
            study_name=study_name,
            storage=storage,
            sampler=optuna.samplers.RandomSampler(seed=args.seed + index),
        )
        for index in range(len(WORKERS))
    ]
    callbacks = [
        OptunaCallback(
            make_client(args, dashboard_env),
            dashboard_env=dashboard_env,
            objective_names=["loss"],
            tags={"worker": worker},
            create_dashboard=True,
            refresh_every=args.refresh_every,
            raise_on_error=True,
        )
        for worker in WORKERS
    ]

    with ThreadPoolExecutor(max_workers=len(WORKERS)) as executor:
        futures = [
            executor.submit(
                run_worker,
                study,
                callback,
                args.trials_per_worker,
            )
            for study, callback in zip(studies, callbacks)
        ]
        for future in futures:
            future.result()

    final_study = optuna.load_study(study_name=study_name, storage=storage)

    # This callback has not logged a trial. It represents a restarted process.
    restarted_client = RecordingVisdom(make_client(args, dashboard_env))
    restarted_callback = OptunaCallback(
        restarted_client,
        dashboard_env=dashboard_env,
        objective_names=["loss"],
        create_dashboard=True,
        raise_on_error=True,
    )
    if not restarted_callback.update_dashboard(final_study):
        raise AssertionError("fresh callback failed to rebuild the Dashboard")

    pane = load_hparams(inspector, dashboard_env)
    env_ids, worker_counts = verify_hparams(
        pane,
        final_study,
        restarted_callback,
        restarted_client,
        dashboard_env,
    )

    print("\nOptuna shared Dashboard test passed.")
    print("Trials: {}".format(len(env_ids)))
    print("Callbacks: {}".format(dict(worker_counts)))
    print("Selection mode: query")
    print("Fresh callback rebuild: passed")
    print("Dashboard environment: {}".format(dashboard_env))
    print("Dashboard URL: {}".format(dashboard_url(inspector, dashboard_env)))


if __name__ == "__main__":
    main()

```
## Screenshots (if appropriate):

https://github.com/user-attachments/assets/5b79c156-b60f-4963-b511-2b3b7e1c0c85



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Summary by Sourcery

Make Optuna dashboards resilient across restarts and shared callbacks while expanding visualization support for multi-objective studies and trial timelines.

New Features:
- Add multi-objective Optuna dashboard support, including objective-specific history and Pareto-front visualizations.
- Add stable dashboard tagging so trial selections can be rebuilt across callback instances and shared workers.

Bug Fixes:
- Fix Optuna dashboard trial selection after process restarts and across independent callbacks by replacing callback-local environment lists with tag-based queries.
- Prevent concurrent dashboard refreshes within a callback from overwriting newer updates.
- Preserve visibility and hoverability for very short trials without distorting their timeline durations.

Enhancements:
- Escape study and dashboard names safely in dashboard queries.
- Limit automatic live refreshes to explicitly identified HParams panes while requiring explicit refreshes for query-based selections.

Documentation:
- Document multi-objective studies, stable dashboard tags, shared-worker dashboard configuration, and single-objective limitations for intermediate values and pruning.

Tests:
- Add unit coverage for intermediate-value logging, multi-objective metrics and visualizations, error handling, and dashboard figure generation.

Chores:
- Reserve the stable dashboard tag among Optuna's integration tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-objective Optuna dashboard support, including Pareto-front visualization for studies with 2–3 objectives.
  * HParams selections now recover trials across callback instances and process restarts using stable dashboard tags.
  * Timeline visualizations preserve true trial durations and mark each trial’s actual start time.
  * Added guidance for multi-process and multi-node dashboard setups.

* **Bug Fixes**
  * Dashboard refreshes are now serialized for more consistent results.
  * Live HParams panes refresh only when their explicitly selected runs change.
  * Invalid dashboard and objective names now produce clear validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->