### PR TITLE
perf : Run the server under asyncio with a graceful stop, and lay out the window an append creates (AsyncIo -6)

### DIFF
--- a/.agents/context/testing.md
+++ b/.agents/context/testing.md
@@ -145,9 +145,9 @@ as a gate, so an unmarked file is in neither job and is effectively only covered
 The invariant to preserve: **`-m unit` and `-m integration` must sum to the whole suite.**
 
 ```bash
-pytest py/tests --collect-only -q -o addopts="" | tail -1   # 2148
-pytest -m unit --collect-only -q -o addopts="" | tail -1    # 1416
-pytest -m integration --collect-only -q -o addopts="" | tail -1  # 732
+pytest py/tests --collect-only -q -o addopts="" | tail -1   # 2161
+pytest -m unit --collect-only -q -o addopts="" | tail -1    # 1417
+pytest -m integration --collect-only -q -o addopts="" | tail -1  # 744
 ```
 
 If those stop adding up, a file lost its marker. The counts assume the optional test

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -106,7 +106,9 @@ paths:
         rows or columns), appending text, managing image history, updating
         embeddings selections, adding/removing traces, and modifying plot
         options or layout properties. If `append` is true and the window does
-        not exist, a new window is created.
+        not exist, a new window is created -- laid out with `layout_create`
+        when the request carries it, since an append itself sends an empty
+        `layout` by design.
       requestBody:
         required: true
         content:
@@ -1811,6 +1813,18 @@ components:
           $ref: "#/components/schemas/WindowOptions"
         layout:
           $ref: "#/components/schemas/PlotlyLayout"
+        layout_create:
+          allOf:
+            - $ref: "#/components/schemas/PlotlyLayout"
+          description: >
+            Layout to use only if this request has to create the window --
+            that is, when `append` is true and `win` does not exist yet. An
+            append deliberately sends an empty `layout` so that it never
+            restyles a window that is already there, which leaves a
+            create-on-append with no layout at all; sending `layout_create`
+            lets a client append and create in one call instead of asking
+            `/win_exists` first. Ignored when the window already exists, and
+            ignored when a non-empty `layout` is also present.
 
     GetWindowDataRequest:
       type: object

--- a/py/tests/integration/autosave.py
+++ b/py/tests/integration/autosave.py
@@ -444,7 +444,12 @@ class TestDeleteOutlastsAQueuedSave(unittest.TestCase):
         self.assertNotIn("expt", self.app.state)
 
     def test_the_removal_is_queued_behind_the_save_rather_than_run_at_once(self):
-        """Running it on the loop is what let the save overtake it."""
+        """Running it on the loop is what let the save overtake it.
+
+        ``purge_env`` is what goes to the worker rather than ``delete_env``
+        itself: erasing the undo stack belongs in the same task, behind the
+        same queue, as the removal of the env file.
+        """
         self.queue_autosave()
 
         DeleteEnvHandler.wrap_func(self.handler, {"eid": "expt"})

--- a/py/tests/integration/environment_lifecycle.py
+++ b/py/tests/integration/environment_lifecycle.py
@@ -22,6 +22,7 @@ import unittest
 
 import pytest
 
+from visdom.server import app as app_module
 from visdom.server.app import Application
 
 from testutils.http import VisdomHTTPTestCase
@@ -132,6 +133,18 @@ class TestReload(VisdomHTTPTestCase):
         self.assertEqual(
             restarted.state["persist"]["jsons"]["w1"]["content"], "I survive"
         )
+
+
+class TestApplicationSettings(VisdomHTTPTestCase):
+    def test_building_an_application_leaves_the_settings_template_alone(self):
+        """``__init__`` used to write derived values back into the module dict,
+        so a second server inherited the first one's cookie secret."""
+        before = dict(app_module.tornado_settings)
+
+        built = Application(port=8097, env_path=self.env_path, base_url="/sub")
+
+        self.assertEqual(app_module.tornado_settings, before)
+        self.assertEqual(built.settings["static_url_prefix"], "/sub/static/")
 
 
 if __name__ == "__main__":

--- a/py/tests/integration/socket_lifecycle.py
+++ b/py/tests/integration/socket_lifecycle.py
@@ -20,6 +20,7 @@ dispatch, which is what ``integration`` means in this suite.
 
 import asyncio
 import json
+import types
 
 import pytest
 
@@ -225,6 +226,79 @@ def test_reopening_keeps_the_socket_under_its_first_sid(app):
 
     sub.on_close()
     assert list(app.subs) == [first_sid]
+
+
+# -- Shutdown ----------------------------------------------------------------
+
+
+def test_shutdown_closes_every_open_connection(app):
+    """``close_connections`` hangs up on subscribers and sources alike."""
+    first = open_sub(app)
+    second = open_sub(app)
+    source = open_source(app)
+
+    app.server_state.close_connections()
+
+    assert app.subs == {}
+    assert app.sources == {}
+    assert first.sid not in app.subs
+    assert second.sid not in app.subs
+    assert source.sid not in app.sources
+
+
+def test_shutdown_clears_the_registries_the_handlers_share(app):
+    """The state's own containers are emptied, not replaced.
+
+    Shutdown used to rebind ``app.subs`` to a fresh list, which left the
+    dictionary that ``ServerState`` and every handler hold still full.
+    """
+    subs = app.server_state.subs
+    sources = app.server_state.sources
+    open_sub(app)
+    open_source(app)
+
+    app.server_state.close_connections()
+
+    assert app.server_state.subs is subs
+    assert app.server_state.sources is sources
+    assert subs == {}
+    assert sources == {}
+
+
+def test_shutdown_forgets_a_connection_that_fails_to_close(app):
+    """One socket raising on close does not strand the others."""
+
+    class Unclosable:
+        def close(self):
+            raise RuntimeError("socket already gone")
+
+    app.subs["broken"] = Unclosable()
+    sub = open_sub(app)
+
+    app.server_state.close_connections()
+
+    assert app.subs == {}
+    assert sub.sid not in app.subs
+
+
+def test_shutdown_stops_the_polling_reaper(app):
+    """The monitor that reaps idle polling sockets is stopped too."""
+    stopped = []
+    app.server_state._socket_wrap_monitor = types.SimpleNamespace(
+        stop=lambda: stopped.append(True)
+    )
+
+    app.server_state.close_connections()
+
+    assert stopped == [True]
+
+
+def test_shutdown_without_connections_is_a_noop(app):
+    """Stopping a server nobody connected to is harmless."""
+    app.server_state.close_connections()
+
+    assert app.subs == {}
+    assert app.sources == {}
 
 
 # -- Message queue -----------------------------------------------------------

--- a/py/tests/integration/storage_wiring.py
+++ b/py/tests/integration/storage_wiring.py
@@ -52,7 +52,9 @@ from visdom.utils.server_utils import (
     ensure_env_loaded,
     load_env,
     pop_deleted,
+    purge_env,
     push_deleted,
+    push_deleted_off_loop,
     warm_env,
 )
 
@@ -376,6 +378,17 @@ def test_shutdown_drains_the_queue_before_the_final_save(app):
     app.shutdown_storage()
 
     assert order == ["queued-write", "final-save"]
+
+
+def test_a_second_shutdown_does_not_write_again(app):
+    """The graceful stop drains, then the atexit hook calls it once more."""
+    saves = []
+    app.storage.save_all = lambda state: saves.append(state)
+
+    app.shutdown_storage()
+    app.shutdown_storage()
+
+    assert len(saves) == 1
 
 
 def test_shutdown_flushes_state_through_storage(app):
@@ -832,6 +845,49 @@ def test_socket_delete_env_finishes_only_once_the_files_are_gone(
 
     assert not spy_store.env_exists("expt")
     assert count_deleted(spy_store, "expt") == 0
+
+
+def test_delete_env_outlasts_a_close_already_queued(spy_store, env_path):
+    """A pane closed a moment earlier cannot leave undo history behind.
+
+    Both jobs land on one storage worker in submission order, so the close's
+    ``push_deleted`` runs *first* and writes the stack. Clearing it on the loop
+    therefore cleared nothing: the push put the file back, ``delete_env``
+    removes the env file and nothing else, and the stack outlived the
+    environment for the next env to reuse the id and undo panes out of.
+    """
+    spy_store.save_env("expt", env_payload())
+    handler = FakeHandler(
+        state={"expt": env_payload()}, storage=spy_store, env_path=env_path
+    )
+
+    async def close_then_delete():
+        with ThreadPoolExecutor(max_workers=1) as worker:
+            handler.storage_executor = worker
+            close = push_deleted_off_loop(handler, "expt", "win_0", {"id": "win_0"})
+            removal = DeleteEnvHandler.wrap_func(handler, {"eid": "expt"})
+            await close
+            await removal
+
+    asyncio.run(close_then_delete())
+
+    assert spy_store.calls["save_undo"] == ["expt"]
+    assert count_deleted(spy_store, "expt") == 0
+    assert not spy_store.env_exists("expt")
+
+
+def test_delete_env_clears_the_undo_history_before_the_file(spy_store, env_path):
+    """Within the one task, the stack goes first, so a failed unlink of the env
+    still leaves nothing to undo it with."""
+    spy_store.save_env("expt", env_payload())
+    push_deleted(spy_store, "expt", "win_0", {"id": "win_0"})
+
+    purge_env(spy_store, "expt")
+
+    order = [method for method, _thread in spy_store.threads]
+    assert order.index("clear_undo") < order.index("delete_env")
+    assert count_deleted(spy_store, "expt") == 0
+    assert not spy_store.env_exists("expt")
 
 
 def test_socket_save_writes_the_new_env_off_the_loop(spy_store, env_path):

--- a/py/tests/integration/window_lifecycle.py
+++ b/py/tests/integration/window_lifecycle.py
@@ -129,6 +129,41 @@ class TestUpdateMissingWindow(VisdomHTTPTestCase):
         self.assertTrue(self.win_exists("auto_created"))
 
 
+class TestCreateOnAppendLayout(VisdomHTTPTestCase):
+    """``layout_create`` styles the window an append had to create.
+
+    An append sends ``layout: {}`` on purpose -- it must never restyle a window
+    that already exists -- so the window this branch creates used to come out
+    with no layout at all, which is the only reason a client asks
+    ``/win_exists`` before every append. ``layout_create`` carries the layout
+    the client would have created with, and is read on this branch alone.
+    """
+
+    SCATTER = [{"type": "scatter", "x": [1, 2], "y": [3, 4], "name": "t1"}]
+
+    def append_scatter(self, win, **extra):
+        return self.update(win, self.SCATTER, append=True, **extra)
+
+    def layout_of(self, win):
+        return self.get_win_data(win)["content"]["layout"]
+
+    def test_layout_create_lays_out_the_window_the_append_created(self):
+        self.append_scatter("made", layout={}, layout_create={"title": "from create"})
+        self.assertEqual(self.layout_of("made"), {"title": "from create"})
+
+    def test_layout_create_leaves_an_existing_window_alone(self):
+        """The append contract: a window that is already there is never restyled."""
+        win = self.create_window(self.SCATTER, layout={"title": "original"})
+        resp = self.append_scatter(win, layout={}, layout_create={"title": "ignored"})
+        self.assertEqual(resp.code, 200, resp.body)
+        self.assertEqual(self.layout_of(win), {"title": "original"})
+
+    def test_a_non_object_layout_create_is_rejected(self):
+        resp = self.append_scatter("made", layout={}, layout_create="title")
+        self.assertEqual(resp.code, 400)
+        self.assertFalse(self.win_exists("made"))
+
+
 class TestWindowOrdering(VisdomHTTPTestCase):
     def test_windows_are_indexed_in_creation_order(self):
         wins = [self.create_text_window(content=str(n)) for n in range(3)]

--- a/py/tests/unit/server_utils.py
+++ b/py/tests/unit/server_utils.py
@@ -16,6 +16,7 @@ import pytest
 from visdom.data_model.json_store import JSONStore
 from visdom.utils.server_utils import (
     LazyEnvData,
+    create_args_for_append,
     escape_eid,
     extract_eid,
     hash_password,
@@ -131,6 +132,21 @@ def test_hash_password_full_login_flow():
     stored = hash_password(client_hash)
     salt = stored.split("$")[0]
     assert hash_password(client_hash, salt=salt) == stored
+
+
+# ------------------------------------------------- create_args_for_append ----
+
+
+def test_layout_create_only_fills_in_the_empty_layout_an_append_sends():
+    """``layout_create`` is a fallback: an explicit ``layout`` still wins, and
+    the key stays present either way because ``window()`` indexes it."""
+    empty = {"data": [], "layout": {}, "layout_create": {"title": "t"}}
+    assert create_args_for_append(empty)["layout"] == {"title": "t"}
+
+    both = {"layout": {"title": "explicit"}, "layout_create": {"title": "fallback"}}
+    assert create_args_for_append(both)["layout"] == {"title": "explicit"}
+
+    assert create_args_for_append({"data": []})["layout"] == {}
 
 
 # --------------------------------------------------------------- stringify ----

--- a/py/visdom/server/app.py
+++ b/py/visdom/server/app.py
@@ -69,6 +69,10 @@ from visdom.server.defaults import (
     DEFAULT_SAVE_THRESHOLD,
 )
 
+# Template only -- never mutate it. ``__init__`` copies it per instance because
+# several of these values are derived from constructor arguments, and writing
+# them back here leaked one server's base_url and cookie secret into the next
+# ``Application`` built in the same process.
 tornado_settings = {
     "autoescape": None,
     "debug": "/dbg/" in __file__,
@@ -110,10 +114,12 @@ class Application(tornado.web.Application):
         self.last_access = time.time()
         self.wrap_socket = use_frontend_client_polling
 
+        settings = dict(tornado_settings)
+
         if user_credential:
             self.login_enabled = True
             with open(DEFAULT_ENV_PATH + "COOKIE_SECRET", "r") as fn:
-                tornado_settings["cookie_secret"] = fn.read()
+                settings["cookie_secret"] = fn.read()
 
         self.server_state = ServerState(
             state=self.state,
@@ -137,15 +143,13 @@ class Application(tornado.web.Application):
         )
         self.server_state.live_updates = make_live_queue(self.server_state)
 
-        tornado_settings["static_url_prefix"] = self.base_url + "/static/"
+        settings["static_url_prefix"] = self.base_url + "/static/"
         # A traceback and the raw request are debugging aids, not something to
         # hand to whoever provoked the error. `debug` was forced on for every
         # server, which put both on the 500 page -- and, being tornado's debug
         # flag, also turned on autoreload. Follow the operator's logging level
         # instead, and keep the two concerns separate.
-        tornado_settings["show_error_details"] = logging.getLogger().isEnabledFor(
-            logging.DEBUG
-        )
+        settings["show_error_details"] = logging.getLogger().isEnabledFor(logging.DEBUG)
         experiments_url = "%s/experiments" % self.base_url
         server_state_args = {"server_state": self.server_state}
         handlers = [
@@ -205,7 +209,7 @@ class Application(tornado.web.Application):
             (r"%s/health" % self.base_url, HealthHandler),
             (r"%s(.*)" % self.base_url, IndexHandler, server_state_args),
         ]
-        super(Application, self).__init__(handlers, **tornado_settings)
+        super(Application, self).__init__(handlers, **settings)
 
     def get_last_access(self):
         if len(self.subs) > 0 or len(self.sources) > 0:
@@ -237,11 +241,6 @@ class Application(tornado.web.Application):
     def dirty_envs(self):
         """Compatibility view of environments pending persistence."""
         return self.server_state.dirty_envs
-
-    @property
-    def saving_envs(self):
-        """Compatibility view of environments with a write in flight."""
-        return self.server_state.saving_envs
 
     @property
     def autosave(self):

--- a/py/visdom/server/handlers/web_handlers.py
+++ b/py/visdom/server/handlers/web_handlers.py
@@ -35,6 +35,7 @@ from visdom.utils.shared_utils import (
 from visdom.utils.server_utils import (
     check_auth,
     check_readonly,
+    create_args_for_append,
     delete_env_off_loop,
     ensure_env_loaded,
     ensure_env_present,
@@ -415,6 +416,8 @@ class UpdateHandler(BaseHandler):
             raise tornado.web.HTTPError(
                 400, reason="request must include one of: data, layout, or opts"
             )
+        if not isinstance(args.get("layout_create", {}), dict):
+            raise tornado.web.HTTPError(400, reason="layout_create must be an object")
         eid = extract_eid(args)
 
         if eid not in handler.state:
@@ -425,7 +428,7 @@ class UpdateHandler(BaseHandler):
             # that window
             append = args.get("append")
             if append:
-                p = window(args)
+                p = window(create_args_for_append(args))
                 register_window(handler, p, eid)
             else:
                 handler.write("win does not exist")

--- a/py/visdom/server/run_server.py
+++ b/py/visdom/server/run_server.py
@@ -10,6 +10,7 @@
 Provides simple entrypoints to set up and run the main visdom server.
 """
 
+import asyncio
 import atexit
 import argparse
 import getpass
@@ -21,7 +22,6 @@ import ssl
 import sys
 import errno
 import socket
-from tornado import ioloop
 import tornado.httpserver
 import tornado.netutil
 from visdom.server.app import Application
@@ -90,6 +90,89 @@ def start_server(
     save_threshold=DEFAULT_SAVE_THRESHOLD,
 ):
     logging.info("Server started")
+    # Reading the certificate before anything is constructed keeps a bad path
+    # from leaving a storage worker and an open port behind.
+    ssl_ctx = _build_ssl_context(ssl_certfile, ssl_keyfile)
+    asyncio.run(
+        _serve(
+            port=port,
+            hostname=hostname,
+            base_url=base_url,
+            env_path=env_path,
+            readonly=readonly,
+            print_func=print_func,
+            user_credential=user_credential,
+            use_frontend_client_polling=use_frontend_client_polling,
+            bind_local=bind_local,
+            eager_data_loading=eager_data_loading,
+            ssl_ctx=ssl_ctx,
+            save_interval=save_interval,
+            save_threshold=save_threshold,
+        )
+    )
+
+
+def _build_ssl_context(ssl_certfile, ssl_keyfile):
+    """Load the certificate pair, or return ``None`` when TLS is not configured."""
+    if not (ssl_certfile and ssl_keyfile):
+        return None
+    if not os.path.isfile(ssl_certfile):
+        raise FileNotFoundError(f"SSL certificate file not found: {ssl_certfile}")
+    if not os.path.isfile(ssl_keyfile):
+        raise FileNotFoundError(f"SSL key file not found: {ssl_keyfile}")
+    ssl_ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    ssl_ctx.load_cert_chain(ssl_certfile, ssl_keyfile)
+    logging.info("SSL enabled")
+    return ssl_ctx
+
+
+def _install_stop_handlers(stop):
+    """Ask for a graceful stop on SIGINT/SIGTERM, falling back to SystemExit.
+
+    ``loop.add_signal_handler`` runs the callback *on* the loop, so the drain
+    below is an ordinary awaited shutdown rather than something racing an
+    interpreter teardown. It is POSIX-and-main-thread only, hence the fallback
+    to the old ``signal.signal`` behaviour everywhere else -- Windows, and any
+    caller running the server from a worker thread.
+    """
+    loop = asyncio.get_running_loop()
+    for signame in ("SIGINT", "SIGTERM"):
+        sig = getattr(signal, signame, None)
+        if sig is None:
+            continue
+        try:
+            loop.add_signal_handler(sig, stop.set)
+        except (NotImplementedError, RuntimeError, ValueError):
+            if sig == getattr(signal, "SIGTERM", None):
+                try:
+                    signal.signal(sig, _exit_cleanly)
+                except ValueError:
+                    pass
+
+
+async def _serve(
+    port,
+    hostname,
+    base_url,
+    env_path,
+    readonly,
+    print_func,
+    user_credential,
+    use_frontend_client_polling,
+    bind_local,
+    eager_data_loading,
+    ssl_ctx,
+    save_interval,
+    save_threshold,
+):
+    """Build the server on a running loop, then serve until asked to stop.
+
+    Everything here used to run before ``IOLoop.current().start()``, so the
+    autosave timer and the storage executor were attached to a loop that
+    tornado conjured out of the current asyncio policy. Constructing them
+    inside ``asyncio.run`` means there is exactly one loop, it is already
+    running, and it is closed on the way out.
+    """
     app = Application(
         port=port,
         base_url=base_url,
@@ -103,16 +186,6 @@ def start_server(
     )
     bind_addr = "127.0.0.1" if bind_local else None
     family = socket.AF_INET if bind_local else socket.AF_UNSPEC
-
-    ssl_ctx = None
-    if ssl_certfile and ssl_keyfile:
-        if not os.path.isfile(ssl_certfile):
-            raise FileNotFoundError(f"SSL certificate file not found: {ssl_certfile}")
-        if not os.path.isfile(ssl_keyfile):
-            raise FileNotFoundError(f"SSL key file not found: {ssl_keyfile}")
-        ssl_ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-        ssl_ctx.load_cert_chain(ssl_certfile, ssl_keyfile)
-        logging.info("SSL enabled")
 
     server = tornado.httpserver.HTTPServer(
         app, max_buffer_size=1024**3, ssl_options=ssl_ctx
@@ -134,8 +207,13 @@ def start_server(
     logging.info("Application Started")
     logging.info(f"Working directory: {os.path.abspath(env_path)}")
 
+    # Still registered: the graceful path below covers a signal or a normal
+    # exit, this covers the ones that never unwind through it. The drain is
+    # idempotent, so running twice costs nothing.
     atexit.register(app.shutdown_storage)
-    signal.signal(signal.SIGTERM, _exit_cleanly)
+
+    stop = asyncio.Event()
+    _install_stop_handlers(stop)
 
     app.server_state.start_autosave()
 
@@ -149,9 +227,19 @@ def start_server(
     else:
         print_func(port)
 
-    ioloop.IOLoop.current().start()
-    app.subs = []
-    app.sources = []
+    try:
+        await stop.wait()
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        pass
+    finally:
+        logging.info("Shutting down")
+        server.stop()
+        # Through the state that owns them: rebinding ``app.subs`` left both
+        # the live sockets and the dictionaries the handlers share untouched.
+        app.server_state.close_connections()
+        # Blocking, but nothing is being served by now: the listening sockets
+        # are closed and this is the last thing the loop does.
+        app.shutdown_storage()
 
 
 def main(print_func=None):

--- a/py/visdom/server/server_state.py
+++ b/py/visdom/server/server_state.py
@@ -147,12 +147,6 @@ class ServerState:
         self.sources = sources
         self.storage = storage
 
-        # Disk work runs on a single worker, so writes stay ordered with
-        # respect to each other and to the deletes queued behind them.
-        self.storage_executor = ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix="visdom-storage"
-        )
-
         # Startup configuration (effectively immutable after construction).
         self.env_path = env_path
         self.port = port
@@ -188,6 +182,7 @@ class ServerState:
         self.storage_executor = ThreadPoolExecutor(
             max_workers=1, thread_name_prefix="visdom-storage"
         )
+        self._storage_shut_down = False
         # Set by the application once the handlers it drives can be imported;
         # a queue built here would need experiments_handler, which needs the
         # handlers that need this module.
@@ -331,7 +326,16 @@ class ServerState:
         Draining next stops an already-queued write from landing after the
         final save and putting a stale env back on disk. The final save covers
         whatever was still marked dirty, so the marks are cleared with it.
+
+        Idempotent: the graceful shutdown calls this, and the ``atexit`` hook
+        that covers a teardown which never reaches it calls it again. A second
+        pass must not re-run ``save_all`` -- the executor is already gone, so
+        anything written after the first pass could only be state the process
+        never served.
         """
+        if self._storage_shut_down:
+            return
+        self._storage_shut_down = True
         self.stop_autosave()
         self.storage_executor.shutdown(wait=True)
         self.storage.save_all(self.state)
@@ -371,3 +375,24 @@ class ServerState:
     def stop_socket_monitor(self):
         if self._socket_wrap_monitor is not None:
             self._socket_wrap_monitor.stop()
+
+    # ----- shutdown ----- #
+
+    def close_connections(self):
+        """Close every open client connection and forget it.
+
+        Shutdown used to rebind ``Application.subs``/``sources`` to empty
+        lists, which left the sockets themselves open and this state -- the
+        holder of the real dictionaries every handler registers into --
+        untouched. Closing a connection lets its handler unregister itself;
+        clearing the containers afterwards covers a connection whose close
+        path never ran, and a handler that closes twice is harmless.
+        """
+        self.stop_socket_monitor()
+        for connections in (self.subs, self.sources):
+            for connection in list(connections.values()):
+                try:
+                    connection.close()
+                except Exception:
+                    logging.exception("Failed to close a client connection")
+            connections.clear()

--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -545,6 +545,30 @@ def update_window(p, args):
     return p
 
 
+def create_args_for_append(args):
+    """Args to build a window with, for an append to a window that isn't there.
+
+    A client that appends deliberately sends an empty ``layout``: the layout is
+    derived from ``opts`` only on the call that creates a window, because an
+    append to an existing window must never restyle it. That leaves the
+    create-on-append branch of ``/update`` with nothing to lay the new window
+    out with, which is the whole reason a client has to ask ``/win_exists``
+    before every append.
+
+    ``layout_create`` closes that gap: a client sends the layout it *would*
+    have used to create the window alongside the append, and it is read only
+    here, on the branch that really does create one. An append that lands on an
+    existing window never reaches this function, so the key changes nothing for
+    it. Clients that don't send the key are unaffected -- the layout stays
+    whatever ``layout`` held, defaulting to ``{}`` rather than raising when the
+    request omits it entirely.
+    """
+    layout = args.get("layout")
+    if not layout:
+        layout = args.get("layout_create")
+    return dict(args, layout=layout if isinstance(layout, dict) else {})
+
+
 def window(args):
     """Build a window dict structure for sending to client"""
     uid = args.get("win", get_new_window_id())

--- a/website/docs/getting-started/command-line-options.md
+++ b/website/docs/getting-started/command-line-options.md
@@ -34,6 +34,14 @@ reaching disk does not hold up the requests arriving while it is written.
 Setting both to 0 restores the older behaviour of saving only when asked, and once
 more at shutdown.
 
+### Stopping the server
+
+`Ctrl-C` or `docker stop` (`SIGTERM`) shuts down in order: the listening socket
+closes, queued writes finish, and every changed environment is saved before the
+process exits. Nothing you plotted is lost by stopping the server normally, so
+there is no need to call `vis.save()` first. A `SIGKILL` still cannot be caught,
+and loses whatever the last autosave did not cover.
+
 ## Authentication
 
 :::danger Security


### PR DESCRIPTION
## Description

Two server side changes:

- **`layout_create` on `/update`**  the layout to use *only* when an append has to create the window. An append sends an empty `layout` on purpose so it never restyles an existing window, which left create-on-append with no layout at all. Ignored when the window already exists.

- **`asyncio.run` startup and graceful shutdown**  the server runs on an already-running loop instead `IOLoop.current().start()`, and stops cleanly on `SIGINT`/`SIGTERM` listening sockets close, queued writes drain, then every changed environment is saved. 

## Motivation and Context

A client had to call `/win_exists` before every append just to style a window it might create.

## How Has This Been Tested?

Full suite green (2103 tests, `-m "not server"`),

## Screenshots (if appropriate):


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactor or cleanup (changes to existing code for improv)

## Checklist:

- [ ] I adapted the version number under `py/visdom/VERSION` accordhttps://semver.org/)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

## Summary by Sourcery

Improve server responsiveness and shutdown reliability while allowing append requests to style newly created windows.

New Features:
- Support styling windows created by append requests through the new create-only layout option.
- Run the server on a unified asyncio event loop with graceful signal-driven shutdown.

Bug Fixes:
- Prevent append-created windows from losing their intended layout.
- Keep application settings isolated between server instances and ensure cold environment copies are persisted correctly.
- Ensure socket and HTTP operations complete their required persistence before responding while keeping storage and CPU-intensive work off the event loop.

Enhancements:
- Close client connections, stop socket monitoring, drain queued writes, and persist dirty environments during shutdown.
- Move environment, undo-history, experiment, search, comparison, upload, and authentication work onto appropriate executors.

Documentation:
- Document graceful shutdown behavior and persistence guarantees.

Tests:
- Expand integration coverage for create-on-append layouts, asynchronous persistence, executor usage, application isolation, and graceful shutdown.

Chores:
- Update test collection guidance and ignore generated files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Append requests can provide a separate layout for newly created windows.
  - Server shutdown now gracefully closes connections and completes queued saves.
- **Bug Fixes**
  - Improved protection against data loss and stale environment state during deletion, shutdown, and concurrent operations.
  - Application settings remain isolated between server instances.
- **Documentation**
  - Added guidance on graceful shutdown behavior, including Ctrl-C, Docker stop, and SIGKILL.
- **Tests**
  - Expanded coverage for window creation, shutdown, storage operations, concurrency, and application settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->