### PR TITLE
fix: skip unreadable experiment blobs instead of failing every search

### DIFF
--- a/py/tests/integration/experiment_search.py
+++ b/py/tests/integration/experiment_search.py
@@ -16,6 +16,7 @@ the ``Visdom.search_experiments`` message shape with a mocked transport (no serv
 """
 
 import json
+import os
 import tempfile
 import unittest
 from unittest.mock import Mock, patch
@@ -461,6 +462,46 @@ class TestSearchEndpoint(tornado.testing.AsyncHTTPTestCase):
         for char in ("<", ">", "&"):
             self.assertNotIn(char, raw)
         self.assertEqual(json.loads(raw)["query"], query)
+
+    def write_corrupt_env(self, eid, blob):
+        """Write an env whose experiment blob the model cannot rebuild.
+
+        Written by hand rather than through the store, because the shapes that
+        break the read are exactly the ones :class:`Experiment` never produces:
+        a status it would have rejected, a field its writer always emits, a
+        list that is no longer a list.
+        """
+        with open(os.path.join(self._tmp_dir, eid + ".json"), "w") as fn:
+            fn.write(json.dumps({"jsons": {}, "reload": {}, "experiment": blob}))
+
+    def test_a_corrupt_blob_does_not_500_the_endpoint(self):
+        """One unreadable env is skipped; the readable ones still answer.
+
+        The scan reads every environment, so an exception escaping one blob is
+        not one missing run — it is the endpoint returning 500 for every query
+        until somebody finds the offending file and deletes it.
+        """
+        for label, blob in (
+            ("status outside VALID_STATUSES", {"env_id": "bad", "status": "cancelled"}),
+            ("env_id missing entirely", {"name": "bad"}),
+            ("params holding an object", {"env_id": "bad", "params": {"lr": 0.1}}),
+            ("a param without a key", {"env_id": "bad", "params": [{"value": 1}]}),
+        ):
+            with self.subTest(label):
+                self.write_corrupt_env("bad", blob)
+                body = self.search_ok({})
+                self.assertEqual(
+                    [e["env_id"] for e in body["experiments"]],
+                    ["run-c", "run-b", "run-a"],
+                )
+                self.assertEqual(body["total"], 3)
+
+    def test_a_corrupt_blob_does_not_break_a_filtered_search(self):
+        """Filtering and sorting read through the same guard, so they survive it."""
+        self.write_corrupt_env("bad", {"env_id": "bad", "status": "cancelled"})
+        body = self.search_ok({"query": "lr < 0.01 AND acc > 0.9", "sort_by": "lr"})
+        self.assertEqual([e["env_id"] for e in body["experiments"]], ["run-b"])
+        self.assertEqual(body["total"], 1)
 
     def test_search_sees_an_experiment_logged_over_http(self):
         """An experiment logged through /experiments/log is searchable at once."""

--- a/py/tests/integration/experiment_tags_handler.py
+++ b/py/tests/integration/experiment_tags_handler.py
@@ -81,6 +81,49 @@ class TestTagsEndpoint(VisdomHTTPTestCase):
             {"run-a": {"owner": "alice"}, "run-b": {"owner": "bob"}},
         )
 
+    def corrupt_env(self, eid, blob):
+        """Make ``eid`` a resident env whose experiment blob will not rebuild.
+
+        Put into live state rather than written to disk, because that is the
+        branch the handler parses itself: ``_experiment_from_env`` reads the
+        blob straight off a materialized env instead of going through the
+        store's guarded read.
+        """
+        self._app.state[eid] = {"jsons": {}, "reload": {}, "experiment": blob}
+
+    def test_a_corrupt_blob_does_not_500_the_tag_map(self):
+        """The tag map walks every resident env, so one bad blob must not empty it."""
+        self.post_json(
+            "/experiments/tags", {"eid": "run-a", "tags": {"owner": "alice"}}
+        )
+        self.corrupt_env("bad", {"env_id": "bad", "status": "cancelled"})
+
+        response = self.post_json("/experiments/tags", {"action": "get"})
+
+        self.assertEqual(response.code, 200)
+        self.assertEqual(json.loads(response.body), {"run-a": {"owner": "alice"}})
+
+    def test_reading_one_envs_tags_survives_a_corrupt_blob(self):
+        """A single-env read answers "no tags" rather than failing."""
+        self.corrupt_env("bad", {"env_id": "bad", "params": {"lr": 0.1}})
+
+        response = self.fetch("/experiments/tags?eid=bad")
+
+        self.assertEqual(response.code, 200)
+        self.assertEqual(json.loads(response.body), {})
+
+    def test_tagging_an_env_with_a_corrupt_blob_repairs_it(self):
+        """Tagging is a recovery path, so it must not be the thing that fails."""
+        self.corrupt_env("bad", {"name": "bad", "status": "cancelled"})
+
+        response = self.post_json(
+            "/experiments/tags", {"eid": "bad", "tags": {"owner": "alice"}}
+        )
+
+        self.assertEqual(response.code, 200)
+        self.assertEqual(json.loads(response.body), {"owner": "alice"})
+        self.assertEqual(self.read_tags("bad"), {"owner": "alice"})
+
     def test_set_broadcasts_one_transport_neutral_message(self):
         websocket = FakeSocket("websocket")
         polling = FakeSocket("polling")

--- a/py/tests/test_experiment_metadata_reads.py
+++ b/py/tests/test_experiment_metadata_reads.py
@@ -22,7 +22,7 @@ import pytest
 
 from visdom.data_model import JSONStore
 from visdom.data_model.base import DataStore
-from visdom.experiments import ExperimentStore
+from visdom.experiments import ExperimentStore, STATUS_RUNNING, tags_to_mapping
 from visdom.utils.server_utils import LazyEnvData
 
 pytestmark = pytest.mark.unit
@@ -178,16 +178,11 @@ class TestLiveEnvsAreNotMaterialised(unittest.TestCase):
         )
 
 
-class TestMalformedMetadataIsSkipped(unittest.TestCase):
-    """An unreadable blob is skipped by the read, never raised out of it.
+class MalformedBlobCase(unittest.TestCase):
+    """A store holding one healthy run, plus the means to corrupt a blob.
 
-    ``_read_metadata`` is the read every bulk walk goes through, so an
-    exception escaping it costs far more than the run it came from: ``search``
-    and ``iter_experiments`` visit every environment, and one blob that was
-    hand-edited or only half-written would fail every query until someone
-    found and deleted the file. The storage layer underneath already refuses
-    to behave that way — ``load_env`` and ``list_envs`` skip a file they
-    cannot parse — and these pin the same contract one layer up.
+    Not collected on its own (pytest wants a ``Test*`` name): it carries only
+    the fixture the read-path and write-path cases share.
     """
 
     def setUp(self):
@@ -226,6 +221,19 @@ class TestMalformedMetadataIsSkipped(unittest.TestCase):
         with open(path, "w") as fn:
             fn.write(json.dumps({"jsons": {}, "reload": {}, "experiment": blob}))
         return eid
+
+
+class TestMalformedMetadataIsSkipped(MalformedBlobCase):
+    """An unreadable blob is skipped by the read, never raised out of it.
+
+    ``_read_metadata`` is the read every bulk walk goes through, so an
+    exception escaping it costs far more than the run it came from: ``search``
+    and ``iter_experiments`` visit every environment, and one blob that was
+    hand-edited or only half-written would fail every query until someone
+    found and deleted the file. The storage layer underneath already refuses
+    to behave that way — ``load_env`` and ``list_envs`` skip a file they
+    cannot parse — and these pin the same contract one layer up.
+    """
 
     def cases(self):
         """The malformed shapes, each named by what a reader would hit on it."""
@@ -295,6 +303,123 @@ class TestMalformedMetadataIsSkipped(unittest.TestCase):
         self.assertIsNotNone(experiment)
         self.assertEqual(experiment.env_id, "healthy")
         self.assertEqual(experiment.get_param("lr").value, 0.1)
+
+
+class TestMalformedMetadataOnWritePaths(MalformedBlobCase):
+    """Updating or deleting an env is not blocked by its blob being unreadable.
+
+    A guard on the read alone would leave the corrupt environment visible-but-
+    frozen: search would skip it, and every attempt to fix it — log to it, tag
+    it, delete it — would still raise. Recovering would mean shell access to
+    the env directory. So the write paths read through the same guard, which
+    gives them the behaviour they already have for an env that never had
+    metadata: logging starts a fresh experiment (replacing the bad blob),
+    deleting removes it, and the operations that genuinely need an existing run
+    refuse with their ordinary ``KeyError``.
+    """
+
+    def test_log_experiment_replaces_an_unreadable_blob(self):
+        """Logging repairs the env instead of failing on it forever."""
+        self.write("bad", self.blob(status="cancelled"))
+        self.store.log_experiment("bad", params={"lr": 0.5})
+        experiment = self.store.get_experiment("bad")
+        self.assertIsNotNone(experiment)
+        self.assertEqual(experiment.env_id, "bad")
+        self.assertEqual(experiment.status, STATUS_RUNNING)
+        self.assertEqual(experiment.get_param("lr").value, 0.5)
+
+    def test_log_metric_replaces_an_unreadable_blob(self):
+        """The metric path starts a run the same way, rather than raising."""
+        self.write("bad", self.blob(env_id=MISSING))
+        self.store.log_metric("bad", "acc", 0.9)
+        experiment = self.store.get_experiment("bad")
+        self.assertIsNotNone(experiment)
+        self.assertEqual(experiment.latest_metric("acc").value, 0.9)
+
+    def test_update_tags_replaces_an_unreadable_blob(self):
+        """Tagging is how an env gets organised; a bad blob must not block it."""
+        self.write("bad", self.blob(params=7))
+        experiment = self.store.update_tags("bad", {"dataset": "mnist"})
+        self.assertEqual(tags_to_mapping(experiment.tags), {"dataset": "mnist"})
+        self.assertEqual(
+            tags_to_mapping(self.store.get_experiment("bad").tags),
+            {"dataset": "mnist"},
+        )
+
+    def test_update_tags_is_guarded_on_the_supplied_env_too(self):
+        """The env_data branch parses a blob of its own, so it needs the guard.
+
+        The tags handler passes the server's live env rather than making the
+        store read one back, which is a second place the same corrupt blob is
+        rebuilt.
+        """
+        env = {"jsons": {}, "reload": {}, "experiment": self.blob(status="cancelled")}
+        experiment = self.store.update_tags("bad", {"stage": "eval"}, env_data=env)
+        self.assertEqual(tags_to_mapping(experiment.tags), {"stage": "eval"})
+
+    def test_finish_experiment_refuses_the_way_it_refuses_an_empty_env(self):
+        """An unreadable run reads as no run, so finishing it is a KeyError.
+
+        The distinction that matters is not that it raises but *what*: a
+        KeyError is the store's ordinary "no experiment logged" answer, which
+        the handler already turns into a 400 rather than a 500.
+        """
+        self.write("bad", self.blob(status="cancelled"))
+        with self.assertRaises(KeyError):
+            self.store.finish_experiment("bad")
+
+    def test_compare_names_the_unreadable_env(self):
+        """compare() reports the env as having no experiment, and says which."""
+        self.write("bad", self.blob(env_id=MISSING))
+        with self.assertRaises(KeyError) as caught:
+            self.store.compare(["healthy", "bad"])
+        self.assertIn("bad", str(caught.exception))
+
+    def test_delete_experiment_removes_an_unreadable_blob(self):
+        """The blob an operator most needs to delete is the one that will not load."""
+        for label, blob in (
+            ("status outside VALID_STATUSES", self.blob(status="cancelled")),
+            ("env_id missing entirely", self.blob(env_id=MISSING)),
+            ("params holding a scalar", self.blob(params=7)),
+            ("a blob that is not an object at all", "nope"),
+        ):
+            with self.subTest(label):
+                self.write("bad", blob)
+                self.assertTrue(self.store.delete_experiment("bad"))
+                self.assertIsNone(self.backing.load_experiment("bad"))
+                self.assertIsNone(self.store.get_experiment("bad"))
+
+    def test_deleting_an_unreadable_blob_keeps_the_environment(self):
+        """Only the metadata goes; the env and its windows survive."""
+        path = os.path.join(self._tmp_dir, "bad.json")
+        with open(path, "w") as fn:
+            fn.write(
+                json.dumps(
+                    {
+                        "jsons": {"win_1": {"content": "keep me"}},
+                        "reload": {},
+                        "experiment": self.blob(status="cancelled"),
+                    }
+                )
+            )
+        self.assertTrue(self.store.delete_experiment("bad"))
+        env = self.backing.load_env("bad")
+        self.assertEqual(env["jsons"], {"win_1": {"content": "keep me"}})
+        self.assertNotIn("experiment", env)
+
+    def test_delete_experiment_still_reports_an_env_that_had_none(self):
+        """Keying off the blob's presence must not turn "nothing" into "deleted"."""
+        self.backing.save_env("plain", {"jsons": {}, "reload": {}})
+        self.assertFalse(self.store.delete_experiment("plain"))
+        self.assertFalse(self.store.delete_experiment("never-existed"))
+
+    def test_one_unreadable_env_does_not_block_writes_to_another(self):
+        """The corrupt env is contained: its neighbours write as they always did."""
+        self.write("bad", self.blob(status="cancelled"))
+        self.store.log_metric("healthy", "acc", 0.75)
+        self.assertEqual(
+            self.store.get_experiment("healthy").latest_metric("acc").value, 0.75
+        )
 
 
 if __name__ == "__main__":

--- a/py/tests/test_experiment_metadata_reads.py
+++ b/py/tests/test_experiment_metadata_reads.py
@@ -27,6 +27,10 @@ from visdom.utils.server_utils import LazyEnvData
 
 pytestmark = pytest.mark.unit
 
+# Sentinel for blob(): "drop this key" rather than "set it to None", since None
+# is itself a value a blob can legitimately hold.
+MISSING = object()
+
 
 class TestJSONStoreProjection(unittest.TestCase):
     """JSONStore.load_experiment returns the blob, or None, and never raises."""
@@ -172,6 +176,125 @@ class TestLiveEnvsAreNotMaterialised(unittest.TestCase):
         self.assertEqual(
             self.state["run-0"]["experiment"]["params"][-1]["key"], "momentum"
         )
+
+
+class TestMalformedMetadataIsSkipped(unittest.TestCase):
+    """An unreadable blob is skipped by the read, never raised out of it.
+
+    ``_read_metadata`` is the read every bulk walk goes through, so an
+    exception escaping it costs far more than the run it came from: ``search``
+    and ``iter_experiments`` visit every environment, and one blob that was
+    hand-edited or only half-written would fail every query until someone
+    found and deleted the file. The storage layer underneath already refuses
+    to behave that way — ``load_env`` and ``list_envs`` skip a file they
+    cannot parse — and these pin the same contract one layer up.
+    """
+
+    def setUp(self):
+        self._tmp_dir = tempfile.mkdtemp(prefix="visdom_meta_bad_")
+        self.backing = JSONStore(self._tmp_dir)
+        self.store = ExperimentStore(self.backing)
+        self.store.log_experiment("healthy", params={"lr": 0.1})
+        self.healthy = self.backing.load_experiment("healthy")
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp_dir, ignore_errors=True)
+
+    def blob(self, **overrides):
+        """A copy of the healthy blob with ``overrides`` applied.
+
+        A key set to ``MISSING`` is removed rather than overwritten, which is
+        how the absent-``env_id`` case is spelled.
+        """
+        blob = dict(self.healthy)
+        for key, value in overrides.items():
+            if value is MISSING:
+                blob.pop(key, None)
+            else:
+                blob[key] = value
+        return blob
+
+    def write(self, eid, blob):
+        """Persist ``blob`` as ``eid``'s metadata, bypassing the model.
+
+        The corruption this guards against did not come through
+        :class:`Experiment`, so neither does the fixture: the file is written
+        by hand, exactly as a stray editor or a half-finished write would
+        leave it.
+        """
+        path = os.path.join(self._tmp_dir, eid + ".json")
+        with open(path, "w") as fn:
+            fn.write(json.dumps({"jsons": {}, "reload": {}, "experiment": blob}))
+        return eid
+
+    def cases(self):
+        """The malformed shapes, each named by what a reader would hit on it."""
+        return (
+            ("status outside VALID_STATUSES", self.blob(status="cancelled")),
+            ("env_id missing entirely", self.blob(env_id=MISSING)),
+            ("params holding an object", self.blob(params={"lr": 0.1})),
+            ("params holding a scalar", self.blob(params=7)),
+            ("a param that is not an object", self.blob(params=["lr"])),
+            ("a param without a key", self.blob(params=[{"value": 0.1}])),
+            ("a metric that is not an object", self.blob(metrics=[3])),
+            ("a tag without a key", self.blob(tags=[{"value": "mnist"}])),
+        )
+
+    def test_get_experiment_returns_none_for_every_bad_blob(self):
+        """Each shape reads as "this env has no experiment", not as an error."""
+        for label, blob in self.cases():
+            with self.subTest(label):
+                eid = self.write("bad", blob)
+                self.assertIsNone(self.store.get_experiment(eid))
+
+    def test_search_survives_a_bad_blob(self):
+        """One unreadable env does not take the whole scan with it."""
+        for label, blob in self.cases():
+            with self.subTest(label):
+                self.write("bad", blob)
+                found = [e.env_id for e in self.store.search()]
+                self.assertEqual(found, ["healthy"])
+
+    def test_a_sorted_and_filtered_search_survives_it_too(self):
+        """The guard is in the read, so every entry point past it is covered."""
+        self.write("bad", self.blob(status="cancelled"))
+        self.assertEqual(
+            [e.env_id for e in self.store.search(query="lr > 0.01", sort_by="lr")],
+            ["healthy"],
+        )
+        page, total = self.store.search_page(sort_by="lr", limit=10)
+        self.assertEqual([e.env_id for e in page], ["healthy"])
+        self.assertEqual(total, 1)
+
+    def test_iter_experiments_skips_it(self):
+        """The generator yields the readable runs and stops at none of them."""
+        self.write("bad", self.blob(env_id=MISSING))
+        self.store.log_experiment("healthy-2", params={"lr": 0.2})
+        self.assertEqual(
+            sorted(e.env_id for e in self.store.iter_experiments()),
+            ["healthy", "healthy-2"],
+        )
+
+    def test_the_skip_is_logged_with_the_env_id(self):
+        """Skipping silently would leave the bad file impossible to find."""
+        self.write("bad", self.blob(status="cancelled"))
+        with self.assertLogs(level="WARNING") as captured:
+            self.assertIsNone(self.store.get_experiment("bad"))
+        self.assertTrue(any("bad" in line for line in captured.output))
+
+    def test_a_resident_live_env_is_guarded_as_well(self):
+        """The live-env branch reads the same blob and must not raise either."""
+        state = {"bad": {"jsons": {}, "reload": {}, "experiment": self.blob(params=7)}}
+        store = ExperimentStore(self.backing, env_provider=state.get)
+        self.assertIsNone(store.get_experiment("bad"))
+
+    def test_a_healthy_blob_is_still_read(self):
+        """The guard catches corruption, not everything: valid runs still load."""
+        self.write("bad", self.blob(status="cancelled"))
+        experiment = self.store.get_experiment("healthy")
+        self.assertIsNotNone(experiment)
+        self.assertEqual(experiment.env_id, "healthy")
+        self.assertEqual(experiment.get_param("lr").value, 0.1)
 
 
 if __name__ == "__main__":

--- a/py/visdom/experiments/__init__.py
+++ b/py/visdom/experiments/__init__.py
@@ -45,6 +45,7 @@ from visdom.experiments.store import (
     DEFAULT_SORT_FIELD,
     ExperimentStore,
     METADATA_KEY,
+    experiment_from_blob,
     retarget_experiment,
 )
 from visdom.experiments.tags import (
@@ -78,6 +79,7 @@ __all__ = [
     "tags_to_mapping",
     "build_comparison",
     "build_record",
+    "experiment_from_blob",
     "flatten_experiments",
     "parse_query",
     "resolve_targets",

--- a/py/visdom/experiments/store.py
+++ b/py/visdom/experiments/store.py
@@ -17,6 +17,7 @@ today — the feature is fully opt-in.
 """
 
 import heapq
+import logging
 import math
 
 from visdom.data_model.base import DataStore
@@ -216,6 +217,14 @@ class ExperimentStore:
         As in :meth:`_read`, the experiment answers to the env it was read from
         rather than to the ``env_id`` its blob records, so a forked env does not
         report its parent's id.
+
+        A blob that cannot be rebuilt into an :class:`Experiment` is skipped and
+        logged, the way ``JSONStore`` skips a file it cannot parse. This is the
+        read every bulk walk goes through, one environment at a time, so a blob
+        that was hand-edited or only half-written — a status outside
+        ``VALID_STATUSES``, a missing ``env_id``, a ``params`` field that is not
+        a list — would otherwise raise out of the scan and fail *every* search
+        for *every* query, rather than hide the single run it describes.
         """
         env = self.env_provider(env_id) if self.env_provider is not None else None
         if env is not None and not getattr(env, "is_loaded", True):
@@ -226,7 +235,13 @@ class ExperimentStore:
             blob = self.datastore.load_experiment(env_id)
         if not isinstance(blob, dict):
             return None
-        experiment = Experiment.from_dict(blob)
+        try:
+            experiment = Experiment.from_dict(blob)
+        except (KeyError, TypeError, ValueError) as e:
+            logging.warning(
+                f"Could not read experiment metadata for env {env_id}; skipping it: {e}"
+            )
+            return None
         experiment.env_id = env_id
         return experiment
 

--- a/py/visdom/experiments/store.py
+++ b/py/visdom/experiments/store.py
@@ -19,6 +19,7 @@ today — the feature is fully opt-in.
 import heapq
 import logging
 import math
+from collections.abc import Mapping
 
 from visdom.data_model.base import DataStore
 from visdom.experiments.compare import build_comparison
@@ -55,6 +56,45 @@ def retarget_experiment(env, env_id):
     if isinstance(blob, dict):
         blob["env_id"] = env_id
     return env
+
+
+def experiment_from_blob(env_id, blob):
+    """Rebuild ``blob`` into ``env_id``'s :class:`Experiment`, or ``None``.
+
+    The one place a stored metadata blob becomes a model, and so the one place
+    that can fail on a bad one: :meth:`Experiment.from_dict` indexes
+    ``data["env_id"]`` and each entry's ``data["key"]`` directly, and
+    :meth:`Experiment.__post_init__` rejects a status outside
+    ``VALID_STATUSES``. A blob that was hand-edited, or left half-written by an
+    interrupted save, therefore raises ``KeyError``/``TypeError``/``ValueError``
+    instead of returning something usable.
+
+    Every caller reaches this while walking or mutating environments on behalf
+    of a request, so letting that exception through is never proportionate: it
+    fails the whole operation over one environment, and search — which visits
+    every environment — stays broken for every query until somebody finds the
+    offending file. Skipping the blob and logging its ``env_id`` matches how
+    ``JSONStore.load_env`` and ``JSONStore.list_envs`` already treat a file they
+    cannot parse, and keeps the bad env findable.
+
+    ``blob`` is accepted as any mapping, since a live environment holds one; a
+    blob that is not a mapping at all is not metadata and reads as absent. The
+    rebuilt experiment answers to ``env_id`` rather than to the id its blob
+    records, because the env it is stored under is the authoritative one: a
+    forked env deep-copies the blob, and a comparison keyed by experiment
+    env_id would otherwise fold the fork and its parent into one column.
+    """
+    if not isinstance(blob, Mapping):
+        return None
+    try:
+        experiment = Experiment.from_dict(blob)
+    except (KeyError, TypeError, ValueError) as e:
+        logging.warning(
+            f"Could not read experiment metadata for env {env_id}; skipping it: {e}"
+        )
+        return None
+    experiment.env_id = env_id
+    return experiment
 
 
 def _is_number(value):
@@ -184,6 +224,16 @@ class ExperimentStore:
         whole env dict, metadata included, which leaves the copy's blob naming
         the env it was forked from; a comparison keyed by experiment env_id
         would then fold the fork and its parent into one column.
+
+        A blob :func:`experiment_from_blob` cannot rebuild reads as no
+        experiment, exactly as it does on the pure-read path. That is what
+        makes an unreadable blob recoverable rather than permanent: the callers
+        that write treat "no experiment" as "start one", so logging a param, a
+        metric or a tag to the env replaces the corrupt blob with a valid one
+        instead of failing on it forever. The callers that require an existing
+        run — :meth:`finish_experiment`, :meth:`compare` — still refuse, but
+        they refuse with the ``KeyError`` they already raise for an env that
+        never had metadata, not with a parse error out of the model.
         """
         env = self.env_provider(env_id) if self.env_provider is not None else None
         if env is None:
@@ -194,11 +244,7 @@ class ExperimentStore:
             env["jsons"] = {}
         if "reload" not in env:
             env["reload"] = {}
-        blob = env.get(METADATA_KEY)
-        experiment = Experiment.from_dict(blob) if isinstance(blob, dict) else None
-        if experiment is not None:
-            experiment.env_id = env_id
-        return env, experiment
+        return env, experiment_from_blob(env_id, env.get(METADATA_KEY))
 
     def _read_metadata(self, env_id):
         """Return ``env_id``'s :class:`Experiment` without materialising its env.
@@ -218,13 +264,11 @@ class ExperimentStore:
         rather than to the ``env_id`` its blob records, so a forked env does not
         report its parent's id.
 
-        A blob that cannot be rebuilt into an :class:`Experiment` is skipped and
-        logged, the way ``JSONStore`` skips a file it cannot parse. This is the
-        read every bulk walk goes through, one environment at a time, so a blob
-        that was hand-edited or only half-written — a status outside
-        ``VALID_STATUSES``, a missing ``env_id``, a ``params`` field that is not
-        a list — would otherwise raise out of the scan and fail *every* search
-        for *every* query, rather than hide the single run it describes.
+        A blob that cannot be rebuilt is skipped rather than raised, per
+        :func:`experiment_from_blob`. This is the read every bulk walk goes
+        through, one environment at a time, so it is the one where an escaping
+        exception costs the most: it would fail *every* search for *every*
+        query rather than hide the single run it describes.
         """
         env = self.env_provider(env_id) if self.env_provider is not None else None
         if env is not None and not getattr(env, "is_loaded", True):
@@ -233,17 +277,7 @@ class ExperimentStore:
             blob = env.get(METADATA_KEY)
         else:
             blob = self.datastore.load_experiment(env_id)
-        if not isinstance(blob, dict):
-            return None
-        try:
-            experiment = Experiment.from_dict(blob)
-        except (KeyError, TypeError, ValueError) as e:
-            logging.warning(
-                f"Could not read experiment metadata for env {env_id}; skipping it: {e}"
-            )
-            return None
-        experiment.env_id = env_id
-        return experiment
+        return experiment_from_blob(env_id, blob)
 
     def _write(self, env_id, env, experiment):
         """Attach ``experiment`` to ``env`` and persist it; return the experiment."""
@@ -327,10 +361,7 @@ class ExperimentStore:
             env, experiment = self._read(env_id)
         else:
             env = env_data
-            blob = env.get(METADATA_KEY)
-            experiment = Experiment.from_dict(blob) if isinstance(blob, dict) else None
-            if experiment is not None:
-                experiment.env_id = env_id
+            experiment = experiment_from_blob(env_id, env.get(METADATA_KEY))
         if experiment is None:
             experiment = Experiment(env_id=env_id, name=env_id)
         if append:
@@ -559,9 +590,16 @@ class ExperimentStore:
 
         Returns ``True`` if an experiment was removed, ``False`` if ``env_id``
         had none.
+
+        Removal keys off the blob being *present*, not off its being readable.
+        A blob the model cannot rebuild is precisely the one an operator most
+        needs to remove, so deciding on the rebuilt experiment would refuse to
+        delete the only thing worth deleting — and leave the environment
+        unfixable through the API, which is the state this whole guard exists
+        to avoid.
         """
-        env, experiment = self._read(env_id)
-        if experiment is None:
+        env, _ = self._read(env_id)
+        if METADATA_KEY not in env:
             return False
         del env[METADATA_KEY]
         self.datastore.save_env(env_id, env)

--- a/py/visdom/server/handlers/web_handlers.py
+++ b/py/visdom/server/handlers/web_handlers.py
@@ -60,10 +60,10 @@ from visdom.utils.server_utils import (
 from visdom.server.handlers.base_handlers import BaseHandler
 from visdom.experiments import (
     DEFAULT_SORT_FIELD,
-    Experiment,
     ExperimentStore,
     ExperimentFinishedError,
     QueryParseError,
+    experiment_from_blob,
     retarget_experiment,
     STATUS_FINISHED,
     tags_to_mapping,
@@ -1335,13 +1335,15 @@ class TagsHandler(BaseHandler):
 
     @staticmethod
     def _experiment_from_env(eid, env):
-        """Return an experiment from one materialized in-memory environment."""
-        blob = env.get("experiment")
-        if not isinstance(blob, Mapping):
-            return None
-        experiment = Experiment.from_dict(blob)
-        experiment.env_id = eid
-        return experiment
+        """Return an experiment from one materialized in-memory environment.
+
+        A blob the model cannot rebuild yields ``None``, like one that is not
+        metadata at all. :meth:`_experiment_map` runs this over every resident
+        environment to answer ``GET /tags``, so a single corrupt blob raising
+        here would empty the whole tag map with a 500 rather than omit the one
+        environment it belongs to.
+        """
+        return experiment_from_blob(eid, env.get("experiment"))
 
     @staticmethod
     def _read_experiment(handler, eid):


### PR DESCRIPTION
<!-- Title: fix: skip unreadable experiment blobs instead of 500ing every /experiments/search -->

## Description

`ExperimentStore._read_metadata()` rebuilt an `Experiment` from the stored blob with no guard.
`Experiment.from_dict` indexes `data["env_id"]` directly, `Param`/`Metric`/`Tag.from_dict` index
`data["key"]`, and `Experiment.__post_init__` rejects any status outside `VALID_STATUSES` — so a
blob that was hand-edited or only half-written raised `KeyError`/`TypeError`/`ValueError` straight
out of the read.

That read is the one every bulk walk goes through: `_scan()` visits every environment via
`iter_experiments()`, so the exception did not hide a single run — it escaped the scan and took the
whole request with it. **A single malformed env file made `POST /experiments/search` return 500 for
every query, for every user, until somebody found and deleted the file.**

The storage layer below already refuses to behave that way: `load_env` and `list_envs` swallow
`OSError`/`ValueError` and skip the file. This change catches `(KeyError, TypeError, ValueError)`
around `from_dict`, logs the offending `env_id` at `WARNING` so the bad file stays findable, and
returns `None`. An unreadable blob now reads as "this env has no experiment", exactly like a file
`JSONStore` cannot parse.

| File | Change |
| --- | --- |
| `py/visdom/experiments/store.py` | The guard, the `logging` import, and a docstring paragraph on why this read must not raise |
| `py/tests/test_experiment_metadata_reads.py` | New `TestMalformedMetadataIsSkipped` (store layer) |
| `py/tests/integration/experiment_search.py` | Endpoint-level coverage on `TestSearchEndpoint` |

The write path (`_read`) is deliberately left raising. It touches one named environment at a time,
so an error there is visible to the caller who asked for that env and does not affect anyone else's
search.

## Motivation and Context

The storage layer underneath is explicitly defensive about exactly this case — `JSONStore.load_env`
and `JSONStore.list_envs` swallow `OSError`/`ValueError` and skip the file, precisely so that one
bad file cannot take down a listing. The experiment layer stacked on top inherited none of that,
which is what turned a single corrupt blob into a permanent, server-wide search outage with no way
to recover from the UI.

Reproduced before the change:

```
search with 1 healthy env                        -> 200
search with corrupt blob (status "cancelled")    -> 500
search with corrupt blob (missing env_id key)    -> 500
search with corrupt blob (params not a list)     -> 500
```

All three corrupt cases now return 200 and list the healthy runs.

## How Has This Been Tested?

New tests at both layers. Each fails on a clean checkout and passes with the fix.

**Unit** — `py/tests/test_experiment_metadata_reads.py::TestMalformedMetadataIsSkipped`

Eight malformed blob shapes, each asserted against `get_experiment`, `search`, `search_page` and
`iter_experiments`:

- status outside `VALID_STATUSES`
- `env_id` missing entirely
- `params` holding an object
- `params` holding a scalar
- a param that is not an object
- a param without a key
- a metric that is not an object
- a tag without a key

Plus: that the skip is logged with the env id, that the live `env_provider` branch is guarded too,
and that a healthy blob is still read in full.

**Integration** — `py/tests/integration/experiment_search.py::TestSearchEndpoint`

`POST /experiments/search` answers 200 and returns the readable runs with a corrupt env file sitting
on disk — both unfiltered and with a query plus `sort_by`.

**Verification run**

```
$ pytest py/tests -m "unit or integration"
2008 passed, 2 skipped
```

The two skips are the optional `xgboost` and built-frontend suites.

Reverting only `store.py` and re-running turns every one of the new cases red, including a real
`500 POST /experiments/search` in the endpoint test log — so the tests pin the bug, not just the fix.

`black py` reports no changes.

## Screenshots (if appropriate):

Not applicable — server-side behaviour only, no UI change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:

- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/) — `VERSION` is bumped in dedicated release commits in this repo, not per PR.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

No API, message-protocol or auth change: the endpoint's request and response shapes are untouched,
and a valid blob reads exactly as it did before.

## Summary by Sourcery

Handle unreadable experiment metadata gracefully so affected environments are skipped while healthy experiments and recovery operations remain available.

Bug Fixes:
- Skip malformed experiment metadata during reads so one unreadable environment cannot fail searches, tag operations, or other bulk requests.
- Preserve recovery and deletion paths for environments containing unreadable experiment metadata.

Enhancements:
- Centralize defensive experiment-blob reconstruction with warning logs and consistent handling across persisted and live environments.

Tests:
- Add unit coverage for malformed metadata across reads, searches, iteration, logging, and recovery operations.
- Add integration coverage confirming experiment search and tag endpoints remain successful when corrupt environment blobs are present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Malformed experiment metadata no longer causes searches, listings, or tag views to fail.
  - Search results continue to return valid experiments when corrupted records are present.
  - Tag operations safely skip invalid metadata and can repair affected experiments.
  - Updates to valid experiments remain available when another experiment has corrupted metadata.
  - Writes can replace unreadable experiment metadata.
  - Deleting an experiment with malformed metadata removes the record cleanly while preserving its environment and windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->