### PR TITLE
feat: add opts.aspectmode to control 3D plot axis scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -952,6 +952,11 @@ The following `opts` are supported:
 - `opts.markerborderwidth`: marker border line width (`float`; default = 0.5)
 - `opts.legend`           : `table` containing legend names
 - `opts.textlabels`       : text label for each point (`list`: default = `None`)
+- `opts.aspectmode`       : how the three axes of a 3D plot are scaled (`string`; default = `'auto'`). One of:
+  - `auto`   : each axis stretched independently to fill the view -- fine for abstract data, but distorts real-world geometry (a sphere looks like an ellipsoid).
+  - `data`   : axes share one scale taken from the data's own extents -- use this for point clouds, SLAM maps, trajectories, or anything where shape must be preserved.
+  - `cube`   : force an equal-length bounding box on all three axes, ignoring the data extents.
+  - `manual` : use the ratio you pass in `layoutopts` as `{'plotly': {'scene': {'aspectratio': {'x': .., 'y': .., 'z': ..}}}}` (falls back to `1:1:1` if none given).
 - `opts.layoutopts`       : dict of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 - `opts.traceopts`        : dict mapping trace names or indices to dicts of additional options that the graph backend accepts. For example `traceopts = {'plotly': {'myTrace': {'mode': 'markers'}}}`.
 - `opts.webgl`            : use WebGL for plotting (`boolean`; default = `false`). It is faster if a plot contains too many points. Use sparingly as browsers won't allow more than a couple of WebGL contexts on a single page.
@@ -998,6 +1003,7 @@ The following `opts` are supported:
 - `opts.linecolor`   : line colors (`np.array`; default = None)
 - `opts.dash`        : line dash type for each line (`np.array`; default = 'solid'), one of `solid`, `dash`, `dashdot` or `dash`, size should match number of lines being drawn
 - `opts.legend`      : `table` containing legend names
+- `opts.aspectmode`  : axis scaling for 3D line plots (`string`; default = `'auto'`); `auto` stretches each axis to fit, `data` keeps the true shape from the data extents, `cube` forces an equal box, `manual` uses `layoutopts` `scene.aspectratio`.
 - `opts.layoutopts`  : `dict` of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 - `opts.traceopts`   : `dict` mapping trace names or indices to `dict`s of additional options that plot.ly accepts for a trace.
 - `opts.webgl`       : use WebGL for plotting (`boolean`; default = `false`). It is faster if a plot contains too many points. Use sparingly as browsers won't allow more than a couple of WebGL contexts on a single page.
@@ -1191,6 +1197,7 @@ The following `opts` are supported:
 - `opts.colormap`: colormap (`string`; default = `'Viridis'`)
 - `opts.xmin`    : clip minimum value (`number`; default = `X:min()`)
 - `opts.xmax`    : clip maximum value (`number`; default = `X:max()`)
+- `opts.aspectmode`  : axis scaling for the 3D surface (`string`; default = `'auto'`); `auto` stretches each axis to fit, `data` keeps the true shape from the data extents, `cube` forces an equal box, `manual` uses `layoutopts` `scene.aspectratio`.
 - `opts.layoutopts`  : `dict` of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 
 #### vis.contour
@@ -1225,6 +1232,7 @@ The following `opts` are supported:
 
 - `opts.color`: color (`string`)
 - `opts.opacity`: opacity of polygons (`number` between 0 and 1)
+- `opts.aspectmode`: axis scaling for a 3D (`Nx3`) mesh (`string`; default = `'auto'`); `auto` stretches each axis to fit, `data` keeps the true shape from the data extents, `cube` forces an equal box, `manual` uses `layoutopts` `scene.aspectratio`.
 - `opts.layoutopts`  : `dict` of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 
 #### vis.sankey

--- a/README.md
+++ b/README.md
@@ -953,10 +953,10 @@ The following `opts` are supported:
 - `opts.legend`           : `table` containing legend names
 - `opts.textlabels`       : text label for each point (`list`: default = `None`)
 - `opts.aspectmode`       : how the three axes of a 3D plot are scaled (`string`; default = `'auto'`). One of:
-  - `auto`   : each axis stretched independently to fill the view -- fine for abstract data, but distorts real-world geometry (a sphere looks like an ellipsoid).
-  - `data`   : axes share one scale taken from the data's own extents -- use this for point clouds, SLAM maps, trajectories, or anything where shape must be preserved.
-  - `cube`   : force an equal-length bounding box on all three axes, ignoring the data extents.
-  - `manual` : use the ratio given in `opts.aspectratio` (falls back to `1:1:1` if not set).
+  - `auto`   : proportional to the data extents (like `data`), but Plotly switches to `cube` when one axis spans more than 4x the others -- so a plot with one dominant dimension silently renders distorted.
+  - `data`   : always proportional to the data extents, so 1 unit looks the same on every axis -- use this for point clouds, SLAM maps, trajectories, or anything where shape must be preserved.
+  - `cube`   : all three axes drawn the same length regardless of the data, deliberately distorting proportions to fill a cube.
+  - `manual` : proportions taken from `opts.aspectratio` (falls back to `1:1:1` if not set).
 - `opts.aspectratio`      : per-axis scale for `manual` mode, a dict `{'x': .., 'y': .., 'z': ..}` (`dict`; default = `None`).
 - `opts.layoutopts`       : dict of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 - `opts.traceopts`        : dict mapping trace names or indices to dicts of additional options that the graph backend accepts. For example `traceopts = {'plotly': {'myTrace': {'mode': 'markers'}}}`.
@@ -1004,7 +1004,7 @@ The following `opts` are supported:
 - `opts.linecolor`   : line colors (`np.array`; default = None)
 - `opts.dash`        : line dash type for each line (`np.array`; default = 'solid'), one of `solid`, `dash`, `dashdot` or `dash`, size should match number of lines being drawn
 - `opts.legend`      : `table` containing legend names
-- `opts.aspectmode`  : axis scaling for 3D line plots (`string`; default = `'auto'`); `auto` stretches each axis to fit, `data` keeps the true shape from the data extents, `cube` forces an equal box, `manual` uses `opts.aspectratio`.
+- `opts.aspectmode`  : axis scaling for 3D line plots (`string`; default = `'auto'`); `auto` is proportional to the data but flips to `cube` when one axis is over 4x the others, `data` stays proportional so shape is preserved, `cube` forces all axes to equal length, `manual` uses `opts.aspectratio`.
 - `opts.aspectratio` : per-axis scale `{'x': .., 'y': .., 'z': ..}` for `manual` mode (`dict`; default = `None`).
 - `opts.layoutopts`  : `dict` of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 - `opts.traceopts`   : `dict` mapping trace names or indices to `dict`s of additional options that plot.ly accepts for a trace.
@@ -1199,7 +1199,7 @@ The following `opts` are supported:
 - `opts.colormap`: colormap (`string`; default = `'Viridis'`)
 - `opts.xmin`    : clip minimum value (`number`; default = `X:min()`)
 - `opts.xmax`    : clip maximum value (`number`; default = `X:max()`)
-- `opts.aspectmode`  : axis scaling for the 3D surface (`string`; default = `'auto'`); `auto` stretches each axis to fit, `data` keeps the true shape from the data extents, `cube` forces an equal box, `manual` uses `opts.aspectratio`.
+- `opts.aspectmode`  : axis scaling for the 3D surface (`string`; default = `'auto'`); `auto` is proportional to the data but flips to `cube` when one axis is over 4x the others, `data` stays proportional so shape is preserved, `cube` forces all axes to equal length, `manual` uses `opts.aspectratio`.
 - `opts.aspectratio` : per-axis scale `{'x': .., 'y': .., 'z': ..}` for `manual` mode (`dict`; default = `None`).
 - `opts.layoutopts`  : `dict` of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 
@@ -1235,7 +1235,7 @@ The following `opts` are supported:
 
 - `opts.color`: color (`string`)
 - `opts.opacity`: opacity of polygons (`number` between 0 and 1)
-- `opts.aspectmode`: axis scaling for a 3D (`Nx3`) mesh (`string`; default = `'auto'`); `auto` stretches each axis to fit, `data` keeps the true shape from the data extents, `cube` forces an equal box, `manual` uses `opts.aspectratio`.
+- `opts.aspectmode`: axis scaling for a 3D (`Nx3`) mesh (`string`; default = `'auto'`); `auto` is proportional to the data but flips to `cube` when one axis is over 4x the others, `data` stays proportional so shape is preserved, `cube` forces all axes to equal length, `manual` uses `opts.aspectratio`.
 - `opts.aspectratio`: per-axis scale `{'x': .., 'y': .., 'z': ..}` for `manual` mode (`dict`; default = `None`).
 - `opts.layoutopts`  : `dict` of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 

--- a/README.md
+++ b/README.md
@@ -956,7 +956,8 @@ The following `opts` are supported:
   - `auto`   : each axis stretched independently to fill the view -- fine for abstract data, but distorts real-world geometry (a sphere looks like an ellipsoid).
   - `data`   : axes share one scale taken from the data's own extents -- use this for point clouds, SLAM maps, trajectories, or anything where shape must be preserved.
   - `cube`   : force an equal-length bounding box on all three axes, ignoring the data extents.
-  - `manual` : use the ratio you pass in `layoutopts` as `{'plotly': {'scene': {'aspectratio': {'x': .., 'y': .., 'z': ..}}}}` (falls back to `1:1:1` if none given).
+  - `manual` : use the ratio given in `opts.aspectratio` (falls back to `1:1:1` if not set).
+- `opts.aspectratio`      : per-axis scale for `manual` mode, a dict `{'x': .., 'y': .., 'z': ..}` (`dict`; default = `None`).
 - `opts.layoutopts`       : dict of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 - `opts.traceopts`        : dict mapping trace names or indices to dicts of additional options that the graph backend accepts. For example `traceopts = {'plotly': {'myTrace': {'mode': 'markers'}}}`.
 - `opts.webgl`            : use WebGL for plotting (`boolean`; default = `false`). It is faster if a plot contains too many points. Use sparingly as browsers won't allow more than a couple of WebGL contexts on a single page.
@@ -1003,7 +1004,8 @@ The following `opts` are supported:
 - `opts.linecolor`   : line colors (`np.array`; default = None)
 - `opts.dash`        : line dash type for each line (`np.array`; default = 'solid'), one of `solid`, `dash`, `dashdot` or `dash`, size should match number of lines being drawn
 - `opts.legend`      : `table` containing legend names
-- `opts.aspectmode`  : axis scaling for 3D line plots (`string`; default = `'auto'`); `auto` stretches each axis to fit, `data` keeps the true shape from the data extents, `cube` forces an equal box, `manual` uses `layoutopts` `scene.aspectratio`.
+- `opts.aspectmode`  : axis scaling for 3D line plots (`string`; default = `'auto'`); `auto` stretches each axis to fit, `data` keeps the true shape from the data extents, `cube` forces an equal box, `manual` uses `opts.aspectratio`.
+- `opts.aspectratio` : per-axis scale `{'x': .., 'y': .., 'z': ..}` for `manual` mode (`dict`; default = `None`).
 - `opts.layoutopts`  : `dict` of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 - `opts.traceopts`   : `dict` mapping trace names or indices to `dict`s of additional options that plot.ly accepts for a trace.
 - `opts.webgl`       : use WebGL for plotting (`boolean`; default = `false`). It is faster if a plot contains too many points. Use sparingly as browsers won't allow more than a couple of WebGL contexts on a single page.
@@ -1197,7 +1199,8 @@ The following `opts` are supported:
 - `opts.colormap`: colormap (`string`; default = `'Viridis'`)
 - `opts.xmin`    : clip minimum value (`number`; default = `X:min()`)
 - `opts.xmax`    : clip maximum value (`number`; default = `X:max()`)
-- `opts.aspectmode`  : axis scaling for the 3D surface (`string`; default = `'auto'`); `auto` stretches each axis to fit, `data` keeps the true shape from the data extents, `cube` forces an equal box, `manual` uses `layoutopts` `scene.aspectratio`.
+- `opts.aspectmode`  : axis scaling for the 3D surface (`string`; default = `'auto'`); `auto` stretches each axis to fit, `data` keeps the true shape from the data extents, `cube` forces an equal box, `manual` uses `opts.aspectratio`.
+- `opts.aspectratio` : per-axis scale `{'x': .., 'y': .., 'z': ..}` for `manual` mode (`dict`; default = `None`).
 - `opts.layoutopts`  : `dict` of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 
 #### vis.contour
@@ -1232,7 +1235,8 @@ The following `opts` are supported:
 
 - `opts.color`: color (`string`)
 - `opts.opacity`: opacity of polygons (`number` between 0 and 1)
-- `opts.aspectmode`: axis scaling for a 3D (`Nx3`) mesh (`string`; default = `'auto'`); `auto` stretches each axis to fit, `data` keeps the true shape from the data extents, `cube` forces an equal box, `manual` uses `layoutopts` `scene.aspectratio`.
+- `opts.aspectmode`: axis scaling for a 3D (`Nx3`) mesh (`string`; default = `'auto'`); `auto` stretches each axis to fit, `data` keeps the true shape from the data extents, `cube` forces an equal box, `manual` uses `opts.aspectratio`.
+- `opts.aspectratio`: per-axis scale `{'x': .., 'y': .., 'z': ..}` for `manual` mode (`dict`; default = `None`).
 - `opts.layoutopts`  : `dict` of any additional options that the graph backend accepts for a layout. For example `layoutopts = {'plotly': {'legend': {'x':0, 'y':0}}}`.
 
 #### vis.sankey

--- a/py/tests/unit/plots.py
+++ b/py/tests/unit/plots.py
@@ -274,6 +274,44 @@ def test_scatter_name_based_update_1d_x_1d_y(capture_send):
     assert data["y"] == [4.0, 5.0, 6.0]
 
 
+def test_scatter_3d_aspectmode_forwarded_to_scene(capture_send):
+    """aspectmode opt reaches layout.scene for a 3D scatter."""
+    X = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    sent = capture_send(lambda v: v.scatter(X, opts={"aspectmode": "data"}))
+    assert sent["payload"]["layout"]["scene"]["aspectmode"] == "data"
+
+
+def test_scatter_3d_aspectmode_absent_by_default(capture_send):
+    """No aspectmode key is emitted when the opt is not set."""
+    X = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    sent = capture_send(lambda v: v.scatter(X))
+    assert "aspectmode" not in sent["payload"]["layout"]["scene"]
+
+
+def test_scatter_2d_ignores_aspectmode(capture_send):
+    """A 2D scatter builds no scene, so aspectmode has nowhere to land."""
+    X = np.array([[1.0, 2.0], [3.0, 4.0]])
+    sent = capture_send(lambda v: v.scatter(X, opts={"aspectmode": "data"}))
+    assert "scene" not in sent["payload"]["layout"]
+
+
+def test_scatter_invalid_aspectmode_raises(offline_client):
+    """An unknown aspectmode value raises in _assert_opts."""
+    X = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    with pytest.raises(AssertionError):
+        offline_client.scatter(X, opts={"aspectmode": "bogus"})
+
+
+def test_line_3d_aspectmode_forwarded_to_scene(capture_send):
+    """aspectmode opt reaches layout.scene for a 3D line."""
+    Y = np.array([1.0, 2.0, 3.0])
+    Z = np.array([4.0, 5.0, 6.0])
+    sent = capture_send(
+        lambda v: v.line(Y, X=Y, Z=Z, is3d=True, opts={"aspectmode": "cube"})
+    )
+    assert sent["payload"]["layout"]["scene"]["aspectmode"] == "cube"
+
+
 # ------------------------------------------------------------------- heatmap ----
 
 
@@ -594,6 +632,12 @@ def test_surf_layout_is_3d(capture_send):
     assert "scene" in sent["payload"]["layout"]
 
 
+def test_surf_aspectmode_forwarded_to_scene(capture_send):
+    """aspectmode opt reaches layout.scene for surf."""
+    sent = capture_send(lambda v: v.surf(np.ones((2, 2)), opts={"aspectmode": "data"}))
+    assert sent["payload"]["layout"]["scene"]["aspectmode"] == "data"
+
+
 # ------------------------------------------------------------------- contour ----
 
 
@@ -606,6 +650,31 @@ def test_contour_type_is_contour(capture_send):
 def test_contour_layout_is_flat(capture_send):
     """contour renders flat, without the 3D scene surf builds."""
     sent = capture_send(lambda v: v.contour(np.ones((2, 2))))
+    assert "scene" not in sent["payload"]["layout"]
+
+
+# ---------------------------------------------------------------------- mesh ----
+
+
+def test_mesh_3d_builds_scene_layout(capture_send):
+    """An Nx3 mesh renders as mesh3d with a 3D scene layout."""
+    X = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+    sent = capture_send(lambda v: v.mesh(X))
+    assert sent["payload"]["data"][0]["type"] == "mesh3d"
+    assert "scene" in sent["payload"]["layout"]
+
+
+def test_mesh_3d_aspectmode_forwarded_to_scene(capture_send):
+    """aspectmode opt reaches layout.scene for a 3D mesh."""
+    X = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+    sent = capture_send(lambda v: v.mesh(X, opts={"aspectmode": "data"}))
+    assert sent["payload"]["layout"]["scene"]["aspectmode"] == "data"
+
+
+def test_mesh_2d_layout_is_flat(capture_send):
+    """An Nx2 mesh builds no 3D scene."""
+    X = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+    sent = capture_send(lambda v: v.mesh(X))
     assert "scene" not in sent["payload"]["layout"]
 
 

--- a/py/tests/unit/plots.py
+++ b/py/tests/unit/plots.py
@@ -295,20 +295,45 @@ def test_scatter_2d_ignores_aspectmode(capture_send):
     assert "scene" not in sent["payload"]["layout"]
 
 
-def test_scatter_invalid_aspectmode_raises(offline_client):
-    """An unknown aspectmode value raises in _assert_opts."""
+@pytest.mark.parametrize("bad", ["bogus", ""], ids=["unknown", "empty"])
+def test_scatter_invalid_aspectmode_raises(offline_client, bad):
+    """A non-enum aspectmode value raises in _assert_opts, falsy included."""
     X = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
     with pytest.raises(AssertionError):
-        offline_client.scatter(X, opts={"aspectmode": "bogus"})
+        offline_client.scatter(X, opts={"aspectmode": bad})
+
+
+def test_scatter_3d_aspectratio_forwarded_to_scene(capture_send):
+    """aspectratio opt reaches layout.scene for manual mode."""
+    X = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    ratio = {"x": 1, "y": 1, "z": 0.5}
+    sent = capture_send(
+        lambda v: v.scatter(X, opts={"aspectmode": "manual", "aspectratio": ratio})
+    )
+    scene = sent["payload"]["layout"]["scene"]
+    assert scene["aspectmode"] == "manual"
+    assert scene["aspectratio"] == ratio
+
+
+def test_scatter_aspectratio_missing_axis_raises(offline_client):
+    """An aspectratio dict without all of x, y, z raises."""
+    X = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    with pytest.raises(AssertionError):
+        offline_client.scatter(X, opts={"aspectratio": {"x": 1, "y": 1}})
 
 
 def test_line_3d_aspectmode_forwarded_to_scene(capture_send):
-    """aspectmode opt reaches layout.scene for a 3D line."""
+    """aspectmode reaches layout.scene and x/y/z stay on their own axes."""
     Y = np.array([1.0, 2.0, 3.0])
-    Z = np.array([4.0, 5.0, 6.0])
+    X = np.array([10.0, 20.0, 30.0])
+    Z = np.array([100.0, 200.0, 300.0])
     sent = capture_send(
-        lambda v: v.line(Y, X=Y, Z=Z, is3d=True, opts={"aspectmode": "cube"})
+        lambda v: v.line(Y, X=X, Z=Z, is3d=True, opts={"aspectmode": "cube"})
     )
+    trace = sent["payload"]["data"][0]
+    assert trace["x"] == [10.0, 20.0, 30.0]
+    assert trace["y"] == [1.0, 2.0, 3.0]
+    assert trace["z"] == [100.0, 200.0, 300.0]
     assert sent["payload"]["layout"]["scene"]["aspectmode"] == "cube"
 
 

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -273,6 +273,7 @@ def _opts2layout(opts, is3d=False):
             "xaxis": _axisformat3d("x", opts),
             "yaxis": _axisformat3d("y", opts),
             "zaxis": _axisformat3d("z", opts),
+            "aspectmode": opts.get("aspectmode"),
         }
     else:
         layout["xaxis"] = _axisformat("x", opts)
@@ -423,6 +424,14 @@ def _assert_opts(opts):
 
     if opts.get("mode"):
         assert isstr(opts.get("mode")), "mode should be a string"
+
+    if opts.get("aspectmode"):
+        assert opts.get("aspectmode") in (
+            "auto",
+            "cube",
+            "data",
+            "manual",
+        ), "aspectmode should be one of 'auto', 'cube', 'data', 'manual'"
 
     if opts.get("markersymbol"):
         assert isstr(opts.get("markersymbol")), "marker symbol should be string"
@@ -2801,6 +2810,8 @@ class Visdom(object):
         - `opts.dash`             : dash type (`np.array`; default = 'solid'`)
         - `opts.textlabels`       : text label for each point (`list`: default = `None`)
         - `opts.legend`           : `list` or `tuple` containing legend names
+        - `opts.aspectmode`       : 3D axis scaling: `'auto'`, `'cube'`, `'data'`
+                                    or `'manual'` (`string`; default = `'auto'`)
         """
         if opts and opts.get("store_history") and update is not None:
             raise ValueError(
@@ -3059,6 +3070,8 @@ class Visdom(object):
         - `opts.linecolor`   : line colors (`np.array`; default = None)
         - `opts.dash`        : line dash type (`np.array`; default = None)
         - `opts.legend`      : `list` or `tuple` containing legend names
+        - `opts.aspectmode`  : 3D axis scaling: `'auto'`, `'cube'`, `'data'` or
+                               `'manual'` (`string`; default = `'auto'`)
 
         If `update` is specified, the figure will be updated without
         creating a new plot -- this can be used for efficient updating.
@@ -3884,9 +3897,11 @@ class Visdom(object):
 
         The following `opts` are supported:
 
-        - `opts.colormap`: colormap (`string`; default = `'Viridis'`)
-        - `opts.xmin`    : clip minimum value (`number`; default = `X:min()`)
-        - `opts.xmax`    : clip maximum value (`number`; default = `X:max()`)
+        - `opts.colormap`  : colormap (`string`; default = `'Viridis'`)
+        - `opts.xmin`      : clip minimum value (`number`; default = `X:min()`)
+        - `opts.xmax`      : clip maximum value (`number`; default = `X:max()`)
+        - `opts.aspectmode`: 3D axis scaling: `'auto'`, `'cube'`, `'data'` or
+                             `'manual'` (`string`; default = `'auto'`)
         """
 
         return self._surface(X=X, stype="surface", opts=opts, win=win, env=env)
@@ -4219,6 +4234,8 @@ class Visdom(object):
 
         - `opts.color`: color (`string`)
         - `opts.opacity`: opacity of polygons (`number` between 0 and 1)
+        - `opts.aspectmode`: 3D axis scaling: `'auto'`, `'cube'`, `'data'` or
+          `'manual'` (`string`; default = `'auto'`; 3D mesh only)
         """
         opts = {} if opts is None else opts
         _title2str(opts)
@@ -4253,7 +4270,7 @@ class Visdom(object):
                 "data": data,
                 "win": win,
                 "eid": env,
-                "layout": _opts2layout(opts),
+                "layout": _opts2layout(opts, is3d),
                 "opts": opts,
             }
         )

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -439,6 +439,9 @@ def _assert_opts(opts):
         assert isinstance(ar, dict) and all(
             k in ar for k in ("x", "y", "z")
         ), "aspectratio should be a dict with 'x', 'y' and 'z' keys"
+        assert all(
+            isnum(ar[k]) and math.isfinite(ar[k]) and ar[k] > 0 for k in ("x", "y", "z")
+        ), "aspectratio values should be finite positive numbers"
 
     if opts.get("markersymbol"):
         assert isstr(opts.get("markersymbol")), "marker symbol should be string"

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -274,6 +274,7 @@ def _opts2layout(opts, is3d=False):
             "yaxis": _axisformat3d("y", opts),
             "zaxis": _axisformat3d("z", opts),
             "aspectmode": opts.get("aspectmode"),
+            "aspectratio": opts.get("aspectratio"),
         }
     else:
         layout["xaxis"] = _axisformat("x", opts)
@@ -425,13 +426,19 @@ def _assert_opts(opts):
     if opts.get("mode"):
         assert isstr(opts.get("mode")), "mode should be a string"
 
-    if opts.get("aspectmode"):
+    if opts.get("aspectmode") is not None:
         assert opts.get("aspectmode") in (
             "auto",
             "cube",
             "data",
             "manual",
         ), "aspectmode should be one of 'auto', 'cube', 'data', 'manual'"
+
+    if opts.get("aspectratio") is not None:
+        ar = opts.get("aspectratio")
+        assert isinstance(ar, dict) and all(
+            k in ar for k in ("x", "y", "z")
+        ), "aspectratio should be a dict with 'x', 'y' and 'z' keys"
 
     if opts.get("markersymbol"):
         assert isstr(opts.get("markersymbol")), "marker symbol should be string"
@@ -2812,6 +2819,8 @@ class Visdom(object):
         - `opts.legend`           : `list` or `tuple` containing legend names
         - `opts.aspectmode`       : 3D axis scaling: `'auto'`, `'cube'`, `'data'`
                                     or `'manual'` (`string`; default = `'auto'`)
+        - `opts.aspectratio`      : `{'x', 'y', 'z'}` scale dict, applied when
+                                    `aspectmode` is `'manual'`
         """
         if opts and opts.get("store_history") and update is not None:
             raise ValueError(
@@ -3072,6 +3081,7 @@ class Visdom(object):
         - `opts.legend`      : `list` or `tuple` containing legend names
         - `opts.aspectmode`  : 3D axis scaling: `'auto'`, `'cube'`, `'data'` or
                                `'manual'` (`string`; default = `'auto'`)
+        - `opts.aspectratio` : `{'x', 'y', 'z'}` scale dict for `'manual'` mode
 
         If `update` is specified, the figure will be updated without
         creating a new plot -- this can be used for efficient updating.
@@ -3902,6 +3912,7 @@ class Visdom(object):
         - `opts.xmax`      : clip maximum value (`number`; default = `X:max()`)
         - `opts.aspectmode`: 3D axis scaling: `'auto'`, `'cube'`, `'data'` or
                              `'manual'` (`string`; default = `'auto'`)
+        - `opts.aspectratio`: `{'x', 'y', 'z'}` scale dict for `'manual'` mode
         """
 
         return self._surface(X=X, stype="surface", opts=opts, win=win, env=env)
@@ -4236,6 +4247,7 @@ class Visdom(object):
         - `opts.opacity`: opacity of polygons (`number` between 0 and 1)
         - `opts.aspectmode`: 3D axis scaling: `'auto'`, `'cube'`, `'data'` or
           `'manual'` (`string`; default = `'auto'`; 3D mesh only)
+        - `opts.aspectratio`: `{'x', 'y', 'z'}` scale dict for `'manual'` mode
         """
         opts = {} if opts is None else opts
         _title2str(opts)


### PR DESCRIPTION
## Description
Adds opts.aspectmode for 3D plots (scatter, line, surf, mesh). It is passed straight through to Plotly's `layout["scene"]["aspectmode"]`, letting users control how the three axes are scaled relative to each other:

  - auto (default) - each axis stretched independently to fill the view (current behavior, unchanged)
  - data - axes share one scale from the data extents, so shape is preserved
  - cube - equal-length box on all three axes
  - manual - uses the ratio from layoutopts `scene.aspectratio`


## Motivation and Context
3D scatter/line/mesh/surf auto-scale each axis independently, so a point cloud or trajectory renders distorted - a sphere looks like an ellipsoid. `aspectmode="data"` fixes this without manual per-axis range pinning.

## How Has This Been Tested?
Added unit tests in `py/tests/unit/plots.py` covering scatter, line, surf, mesh: aspectmode reaches layout.scene, absent by default, ignored on 2D, invalid value raises, and mesh Nx3 builds a scene.

## Screenshots (if appropriate):
<img width="1559" height="497" alt="image" src="https://github.com/user-attachments/assets/58f0fb4c-0094-4ed6-8b4a-1c59a0a2b079" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

## Summary by Sourcery

Enable users to control relative axis scaling in supported 3D plots while preserving existing defaults.

New Features:
- Add configurable axis scaling for 3D scatter, line, surface, and mesh plots through `aspectmode` and optional `aspectratio` settings.
- Support 3D mesh scene generation while preserving flat layouts for 2D meshes.

Enhancements:
- Validate supported aspect modes and positive, complete aspect ratios before rendering.
- Document 3D axis scaling options and behavior across the supported plotting APIs.

Documentation:
- Document `aspectmode` and `aspectratio` options for 3D scatter, line, surface, and mesh plots.

Tests:
- Add coverage for forwarding aspect settings, default and invalid behavior, 2D handling, and 3D mesh scene creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added 3D plot aspect controls for scatter, line, surface, and mesh visualizations.
  * Supports automatic, data-based, cubic, and manual axis scaling.
  * Manual scaling allows separate ratios for the X, Y, and Z axes.
  * Mesh plots apply 3D aspect settings to three-dimensional coordinates while preserving flat behavior for two-dimensional inputs.
  * Invalid aspect modes and aspect ratios are rejected with validation errors.

* **Documentation**
  * Clarified aspect mode behavior and configuration options in the plotting documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->