### PR TITLE
Fix unconditional np.squeeze() crashing bar/histogram/sunburst on size-1 inputs

### DIFF
--- a/py/tests/unit/client_payloads_graph.py
+++ b/py/tests/unit/client_payloads_graph.py
@@ -74,6 +74,18 @@ def test_sunburst_sends_values_when_given(capture_send):
     assert trace(sent)["values"] == [1, 2]
 
 
+def test_sunburst_size_one_values_renders(capture_send):
+    """Regression test for #1787: a single-value `values` array used to
+    collapse to a 0-d array via an unconditional np.squeeze() and fail the
+    ndim assert, even though labels/parents were already correctly guarded."""
+    sent = capture_send(
+        lambda v: v.sunburst(
+            labels=np.array(["a"]), parents=np.array([""]), values=np.array([7])
+        )
+    )
+    assert trace(sent)["values"] == [7]
+
+
 def test_sunburst_reads_its_styling_from_opts(capture_send):
     """The four style opts are spelled differently in the trace than in opts."""
     sent = capture_send(

--- a/py/tests/unit/plots.py
+++ b/py/tests/unit/plots.py
@@ -428,6 +428,29 @@ def test_bar_legend_with_rownames_on_1d_raises(offline_client):
         offline_client.bar(np.array([1.0, 2.0, 3.0]), opts=opts)
 
 
+def test_bar_size_one_x_renders(capture_send):
+    """Regression test for #1787: a single-value X used to collapse to a
+    0-d array via an unconditional np.squeeze() and fail the ndim assert."""
+    sent = capture_send(lambda v: v.bar(np.array([5.0])))
+    assert sent["payload"]["data"][0]["y"] == [5.0]
+
+
+def test_bar_size_one_y_renders(capture_send):
+    """Regression test for #1787: a single-value Y hit the same unconditional
+    np.squeeze() bug as X, one call deeper in bar()."""
+    sent = capture_send(lambda v: v.bar(np.array([5.0]), Y=np.array([10.0])))
+    assert sent["payload"]["data"][0]["x"] == [10.0]
+
+
+def test_bar_2d_row_vector_still_squeezes(capture_send):
+    """A 2D row vector must still collapse to a single 1D trace, matching
+    np.squeeze()'s original behavior -- only the size-1 case should be
+    guarded, not squeezing in general."""
+    sent = capture_send(lambda v: v.bar(np.array([[1.0, 2.0, 3.0, 4.0, 5.0]])))
+    assert len(sent["payload"]["data"]) == 1
+    assert sent["payload"]["data"][0]["y"] == [1.0, 2.0, 3.0, 4.0, 5.0]
+
+
 def test_bar_stacked_sets_barmode(capture_send):
     """stacked=True stacks the columns instead of grouping them."""
     X = np.array([[1.0, 2.0], [3.0, 4.0]])
@@ -474,6 +497,13 @@ def test_histogram_bin_edges_span_data_range(capture_send):
     x = sent["payload"]["data"][0]["x"]
     assert x[0] == 0.0
     assert x[-1] == 99.0
+
+
+def test_histogram_size_one_x_renders(capture_send):
+    """Regression test for #1787: a single-value X used to collapse to a
+    0-d array via an unconditional np.squeeze() and fail the ndim assert."""
+    sent = capture_send(lambda v: v.histogram(np.array([42.0])))
+    assert sum(sent["payload"]["data"][0]["y"]) == 1
 
 
 # ------------------------------------------------------------------- boxplot ----

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -3643,9 +3643,8 @@ class Visdom(object):
         - `opts.stacked` : stack multiple columns in `X`
             - `opts.legend`  : `list` containing legend labels
         """
-        X = np.asarray(X)
-        if X.ndim > 2:
-            X = np.squeeze(X)
+        X = np.atleast_1d(np.squeeze(np.asarray(X)))
+
         assert X.ndim == 1 or X.ndim == 2, "X should be one or two-dimensional"
         if X.ndim == 1:
             if opts is not None and opts.get("legend") is not None:
@@ -3657,11 +3656,7 @@ class Visdom(object):
             else:
                 X = X[:, None]
         if Y is not None:
-            Y = np.asarray(Y)
-            if Y.ndim > 1:
-               Y = np.squeeze(Y)
-            if Y.ndim == 0:
-                Y = Y.reshape(1)
+            Y = np.atleast_1d(np.squeeze(np.asarray(Y)))
             assert Y.ndim == 1, "Y should be one-dimensional"
             assert len(X) == len(Y), "sizes of X and Y should match"
         else:
@@ -3715,11 +3710,7 @@ class Visdom(object):
 
         - `opts.numbins`: number of bins (`number`; default = 30)
         """
-        X = np.asarray(X)
-        if X.ndim > 1:
-            X = np.squeeze(X)
-        if X.ndim == 0:
-            X = X.reshape(1)
+        X = np.atleast_1d(np.squeeze(np.asarray(X)))
         assert X.ndim == 1, "X should be one-dimensional"
 
         opts = {} if opts is None else opts
@@ -4161,10 +4152,7 @@ class Visdom(object):
                 values = np.asarray(values, dtype=np.float64)
             except (TypeError, ValueError):
                 raise AssertionError("values must be numeric")
-            if values.ndim > 1:
-                values = np.squeeze(values)
-            if values.ndim == 0:
-                values = values.reshape(1)
+            values = np.atleast_1d(np.squeeze(values))
             assert values.ndim == 1, "values should be one-dimensional"
             assert len(values) == len(
                 labels

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -3643,7 +3643,9 @@ class Visdom(object):
         - `opts.stacked` : stack multiple columns in `X`
             - `opts.legend`  : `list` containing legend labels
         """
-        X = np.squeeze(X)
+        X = np.asarray(X)
+        if X.ndim > 2:
+            X = np.squeeze(X)
         assert X.ndim == 1 or X.ndim == 2, "X should be one or two-dimensional"
         if X.ndim == 1:
             if opts is not None and opts.get("legend") is not None:
@@ -3655,7 +3657,11 @@ class Visdom(object):
             else:
                 X = X[:, None]
         if Y is not None:
-            Y = np.squeeze(Y)
+            Y = np.asarray(Y)
+            if Y.ndim > 1:
+               Y = np.squeeze(Y)
+            if Y.ndim == 0:
+                Y = Y.reshape(1)
             assert Y.ndim == 1, "Y should be one-dimensional"
             assert len(X) == len(Y), "sizes of X and Y should match"
         else:
@@ -3709,8 +3715,11 @@ class Visdom(object):
 
         - `opts.numbins`: number of bins (`number`; default = 30)
         """
-
-        X = np.squeeze(X)
+        X = np.asarray(X)
+        if X.ndim > 1:
+            X = np.squeeze(X)
+        if X.ndim == 0:
+            X = X.reshape(1)
         assert X.ndim == 1, "X should be one-dimensional"
 
         opts = {} if opts is None else opts
@@ -4152,7 +4161,10 @@ class Visdom(object):
                 values = np.asarray(values, dtype=np.float64)
             except (TypeError, ValueError):
                 raise AssertionError("values must be numeric")
-            values = np.squeeze(values)
+            if values.ndim > 1:
+                values = np.squeeze(values)
+            if values.ndim == 0:
+                values = values.reshape(1)
             assert values.ndim == 1, "values should be one-dimensional"
             assert len(values) == len(
                 labels


### PR DESCRIPTION
## Description
`bar()`, `histogram()`, and `sunburst()` called `np.squeeze()` unconditionally on their inputs. For size-1 arrays like `[5]` (shape `(1,)`), this collapsed them to 0-d arrays *before* the `ndim` assertions ran, causing those assertions to fail even though the input was valid.

Updated based on review feedback to preserve `np.squeeze()`'s original behavior for 2D row/column vectors (e.g. `[[1,2,3,4,5]]` still collapses to `(5,))`, while still preventing the size-1 crash.


```python
X = np.atleast_1d(np.squeeze(X))
```

`sunburst()`'s `labels`/`parents` params were already correctly guarded with `np.atleast_1d()` — only `values` had the bug.

## Motivation and Context
Fixes #1787 . Size-1 inputs are a legitimate, common case (e.g. a single bar, single-bin histogram, or single-segment sunburst), and they crashed with a server-side `AssertionError` instead of rendering. This is the same bug class already partially fixed in #1751 / #1762 for `pie()`, `boxplot()`, `stem()`, and `_surface()` — `bar()`, `histogram()`, and `sunburst()` had the identical unguarded pattern but weren't covered by that fix.

## How Has This Been Tested?
Manually reproduced the crash on the original code with the exact repro steps from #1787:
```python
viz.bar(X=[5])          # AssertionError: X should be one or two-dimensional
viz.histogram(X=[42])   # AssertionError: X should be one-dimensional
viz.sunburst(labels=["A"], parents=[""], values=[7])  # AssertionError: values should be one-dimensional
```
After the fix, all three calls succeed and render correctly in the UI (single bar, single-bin histogram, single-segment sunburst).

Also ran the full existing test suite (`pytest py/tests/`) to confirm no regressions: **2079 passed, 3 skipped** (skips are unrelated, due to missing optional deps `xgboost`/`bs4`/`lxml`).

## Screenshots (if appropriate):
<img width="1160" height="605" alt="Screenshot 2026-09-02 at 6 13 43 PM" src="https://github.com/user-attachments/assets/802a05f2-d0fc-4ed2-86c3-ce71a908fc4c" />




## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Summary by Sourcery

Prevent size-one inputs from collapsing to zero-dimensional arrays in bar, histogram, and sunburst plots.

Bug Fixes:
- Allow bar, histogram, and sunburst to render valid size-one inputs instead of failing dimensionality assertions.

Enhancements:
- Preserve existing squeezing behavior for multi-element row and column vectors while normalizing scalar results to one-dimensional arrays.

Tests:
- Add regression coverage for single-value bar, histogram, and sunburst inputs, including bar X/Y handling and preserved row-vector squeezing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to skip preflight checks when updating image-history and scatter visualizations.
  * Added support for configuring 3D plot aspect modes and positive aspect ratios across applicable visualizations.
* **Bug Fixes**
  * Improved average precision calculations for precision-recall curves with tied recall values.
  * Fixed bar, histogram, and sunburst plots so scalar and single-value inputs render correctly.
  * Preserved expected row-vector behavior by collapsing them into a single plot trace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->