### PR TITLE
Add environment filtering and improve deletion behavior

### DIFF
--- a/js/api/ApiProvider.js
+++ b/js/api/ApiProvider.js
@@ -24,13 +24,17 @@ const ApiProvider = ({ children }) => {
 
   // Send a low-level message to the server
   const sendSocketMessage = (data) => {
-    if (!_socket.current) {
+    const socket = _socket.current;
+    if (
+      !socket ||
+      (socket.readyState !== undefined && socket.readyState !== WebSocket.OPEN)
+    ) {
       // eslint-disable-next-line no-console
       console.error(
         '[Visdom API] Cannot send message: WebSocket is not connected.',
         data
       );
-      return;
+      return false;
     }
 
     let msg = null;
@@ -39,15 +43,17 @@ const ApiProvider = ({ children }) => {
     } catch (e) {
       // eslint-disable-next-line no-console
       console.error('[Visdom API] Failed to serialize message:', e, data);
-      return;
+      return false;
     }
 
     try {
-      _socket.current.send(msg);
+      socket.send(msg);
+      return true;
     } catch (e) {
       // WebSocket may be CLOSING or CLOSED state
       // eslint-disable-next-line no-console
       console.error('[Visdom API] Failed to send message:', e, data);
+      return false;
     }
   };
 
@@ -297,7 +303,7 @@ const ApiProvider = ({ children }) => {
 
   // Send request to delete an environment
   const sendEnvDelete = (envID, previousEnv) => {
-    sendSocketMessage({
+    return sendSocketMessage({
       cmd: 'delete_env',
       prev_eid: previousEnv,
       eid: envID,

--- a/js/main.js
+++ b/js/main.js
@@ -550,6 +550,13 @@ const App = () => {
     const nextEnvIDs = remainingEnvIDs.length > 0 ? remainingEnvIDs : ['main'];
     const selectionChanged = remainingEnvIDs.length !== selection.envIDs.length;
 
+    const deleteMessagesSent = envsToDelete.every((env) =>
+      sendEnvDelete(env, env === previousEnv ? nextEnvIDs[0] : previousEnv)
+    );
+    if (!deleteMessagesSent) {
+      return false;
+    }
+
     if (selectionChanged) {
       setSelection((prev) => ({
         ...prev,
@@ -585,12 +592,10 @@ const App = () => {
       setFocusedPaneID(null);
     }
 
-    envsToDelete.forEach((env) => {
-      sendEnvDelete(env, env === previousEnv ? nextEnvIDs[0] : previousEnv);
-    });
     if (selectionChanged) {
       sendEnvQuery(nextEnvIDs, showAllEnvWindows);
     }
+    return true;
   };
 
   const onTagsSave = (env, tags) => {

--- a/js/main.js
+++ b/js/main.js
@@ -542,45 +542,52 @@ const App = () => {
     localStorage.setItem('envIDs', JSON.stringify(selectedNodes));
     sendEnvQuery(selectedNodes, showAllEnvWindows);
   };
-  const onEnvDelete = (env2delete, previousEnv) => {
-    if (env2delete === previousEnv) {
-      previousEnv = 'main';
-    }
+  const onEnvDelete = (envsToDelete, previousEnv) => {
+    const deletedEnvs = new Set(envsToDelete);
+    const remainingEnvIDs = selection.envIDs.filter(
+      (env) => !deletedEnvs.has(env)
+    );
+    const nextEnvIDs = remainingEnvIDs.length > 0 ? remainingEnvIDs : ['main'];
+    const selectionChanged = remainingEnvIDs.length !== selection.envIDs.length;
 
-    setSelection((prev) => {
-      let EnvIds = prev.envIDs.filter((env) => env !== env2delete);
-      return {
+    if (selectionChanged) {
+      setSelection((prev) => ({
         ...prev,
-        envIDs: EnvIds,
-      };
-    });
+        envIDs: nextEnvIDs,
+      }));
+      localStorage.setItem('envIDs', JSON.stringify(nextEnvIDs));
+    }
 
     setStoreMeta((prev) => {
       const layoutLists = new Map(prev.layoutLists);
-      layoutLists.delete(env2delete);
       const tagsByEnv = { ...prev.tagsByEnv };
-      delete tagsByEnv[env2delete];
-      let EnvIds = prev.envList.filter((env) => env !== env2delete);
+      deletedEnvs.forEach((env) => {
+        layoutLists.delete(env);
+        delete tagsByEnv[env];
+      });
       return {
         ...prev,
-        envList: EnvIds,
+        envList: prev.envList.filter((env) => !deletedEnvs.has(env)),
         layoutLists: layoutLists,
         tagsByEnv: tagsByEnv,
       };
     });
 
-    setStoreData((prev) => {
-      if (selection.envIDs.includes(env2delete)) {
-        return {
-          ...prev,
-          panes: {},
-          layout: [],
-        };
-      }
-      return prev;
-    });
+    if (selectionChanged) {
+      setStoreData((prev) => ({
+        ...prev,
+        panes: {},
+        layout: [],
+      }));
+      setFocusedPaneID(null);
+    }
 
-    sendEnvDelete(env2delete, previousEnv);
+    envsToDelete.forEach((env) => {
+      sendEnvDelete(env, env === previousEnv ? nextEnvIDs[0] : previousEnv);
+    });
+    if (selectionChanged) {
+      sendEnvQuery(nextEnvIDs, showAllEnvWindows);
+    }
   };
 
   const onTagsSave = (env, tags) => {

--- a/js/main.js
+++ b/js/main.js
@@ -554,6 +554,9 @@ const App = () => {
       setSelection((prev) => ({
         ...prev,
         envIDs: nextEnvIDs,
+        layoutID: deletedEnvs.has(prev.envIDs[0])
+          ? DEFAULT_LAYOUT
+          : prev.layoutID,
       }));
       localStorage.setItem('envIDs', JSON.stringify(nextEnvIDs));
     }

--- a/js/main.js
+++ b/js/main.js
@@ -543,19 +543,21 @@ const App = () => {
     sendEnvQuery(selectedNodes, showAllEnvWindows);
   };
   const onEnvDelete = (envsToDelete, previousEnv) => {
-    const deletedEnvs = new Set(envsToDelete);
+    const fallbackEnv =
+      selection.envIDs.find((env) => !envsToDelete.includes(env)) || 'main';
+    const sentEnvs = envsToDelete.filter((env) =>
+      sendEnvDelete(env, env === previousEnv ? fallbackEnv : previousEnv)
+    );
+    if (sentEnvs.length === 0) {
+      return [];
+    }
+
+    const deletedEnvs = new Set(sentEnvs);
     const remainingEnvIDs = selection.envIDs.filter(
       (env) => !deletedEnvs.has(env)
     );
     const nextEnvIDs = remainingEnvIDs.length > 0 ? remainingEnvIDs : ['main'];
     const selectionChanged = remainingEnvIDs.length !== selection.envIDs.length;
-
-    const deleteMessagesSent = envsToDelete.every((env) =>
-      sendEnvDelete(env, env === previousEnv ? nextEnvIDs[0] : previousEnv)
-    );
-    if (!deleteMessagesSent) {
-      return false;
-    }
 
     if (selectionChanged) {
       setSelection((prev) => ({
@@ -595,7 +597,7 @@ const App = () => {
     if (selectionChanged) {
       sendEnvQuery(nextEnvIDs, showAllEnvWindows);
     }
-    return true;
+    return sentEnvs;
   };
 
   const onTagsSave = (env, tags) => {

--- a/js/modals/EnvModal.js
+++ b/js/modals/EnvModal.js
@@ -270,7 +270,14 @@ function EnvModal(props) {
             if (selectedEnvsSet.has(activeEnv)) {
               sortedEnvs.push(activeEnv);
             }
-            onEnvDelete(sortedEnvs, activeEnv);
+            const deletionRequested = onEnvDelete(sortedEnvs, activeEnv);
+            if (!deletionRequested) {
+              showToast(
+                'Unable to delete environments because the server connection is unavailable.',
+                'error'
+              );
+              return;
+            }
             if (
               deletedEnvs.includes(tagEnv) &&
               !deletedEnvs.includes(activeEnv)

--- a/js/modals/EnvModal.js
+++ b/js/modals/EnvModal.js
@@ -271,6 +271,14 @@ function EnvModal(props) {
               sortedEnvs.push(activeEnv);
             }
             onEnvDelete(sortedEnvs, activeEnv);
+            if (
+              deletedEnvs.includes(tagEnv) &&
+              !deletedEnvs.includes(activeEnv)
+            ) {
+              setTagEnv(activeEnv || 'main');
+              setTagSaveStatus('idle');
+              setTagSaveError('');
+            }
             setSelectedEnvs([]);
             showToast(
               deletedEnvs.length === 1

--- a/js/modals/EnvModal.js
+++ b/js/modals/EnvModal.js
@@ -12,6 +12,7 @@ import ReactModal from 'react-modal';
 
 import ApiContext from '../api/ApiContext';
 import { MODAL_STYLE } from '../settings';
+import { showToast } from '../toasts/toastEvents';
 
 const MAX_TAG_NAME_LENGTH = 50;
 const MAX_TAGS_PER_ENV = 20;
@@ -58,12 +59,14 @@ function EnvModal(props) {
   const [tagRows, setTagRows] = useState([]);
   const [tagSaveStatus, setTagSaveStatus] = useState('idle');
   const [tagSaveError, setTagSaveError] = useState('');
+  const [envFilter, setEnvFilter] = useState('');
   const [selectedEnvs, setSelectedEnvs] = useState([]);
   useEffect(() => {
     setInputText(activeEnv);
     setTagEnv(activeEnv || envList[0] || '');
     setTagSaveStatus('idle');
     setTagSaveError('');
+    setEnvFilter('');
     setSelectedEnvs([]);
   }, [activeEnv, show]);
 
@@ -131,7 +134,11 @@ function EnvModal(props) {
   // rendering
   // ---------
 
-  const selectableEnvs = envList.filter((env) => env !== 'main');
+  const normalizedEnvFilter = envFilter.trim().toLowerCase();
+  const filteredEnvs = envList.filter((env) =>
+    env.toLowerCase().includes(normalizedEnvFilter)
+  );
+  const selectableEnvs = filteredEnvs.filter((env) => env !== 'main');
   const selectedEnvsSet = new Set(selectedEnvs);
   const isAllSelected =
     selectableEnvs.length > 0 &&
@@ -169,6 +176,18 @@ function EnvModal(props) {
       <br />
       Select environments to delete:
       <br />
+      <input
+        aria-label="Filter environments"
+        className="form-control"
+        type="search"
+        placeholder="Filter environments..."
+        value={envFilter}
+        onChange={(ev) => {
+          setEnvFilter(ev.target.value);
+          setSelectedEnvs([]);
+        }}
+        style={{ marginBottom: '10px', width: '100%' }}
+      />
       <div className="form-inline">
         <div
           style={{
@@ -198,39 +217,43 @@ function EnvModal(props) {
           </label>
           <hr style={{ margin: '5px 0' }} />
 
-          {envList.map((env) => (
-            <label
-              key={env}
-              style={{
-                display: 'block',
-                fontWeight: 'normal',
-                cursor: env === 'main' ? 'not-allowed' : 'pointer',
-                color: env === 'main' ? '#999' : '#333',
-                wordBreak: 'break-all',
-              }}
-            >
-              <input
-                type="checkbox"
-                style={{ marginRight: '8px' }}
-                value={env}
-                disabled={!canWrite || env === 'main'}
-                checked={selectedEnvsSet.has(env)}
-                onChange={(ev) => {
-                  if (ev.target.checked) {
-                    setSelectedEnvs((prev) =>
-                      Array.from(new Set([...prev, env]))
-                    );
-                  } else {
-                    setSelectedEnvs((prev) => prev.filter((e) => e !== env));
-                  }
+          {filteredEnvs.length === 0 ? (
+            <div style={{ color: '#777' }}>No environments match.</div>
+          ) : (
+            filteredEnvs.map((env) => (
+              <label
+                key={env}
+                style={{
+                  display: 'block',
+                  fontWeight: 'normal',
+                  cursor: env === 'main' ? 'not-allowed' : 'pointer',
+                  color: env === 'main' ? '#999' : '#333',
+                  wordBreak: 'break-all',
                 }}
-              />
-              {env}{' '}
-              {env === 'main' && (
-                <span style={{ fontSize: '0.8em' }}>(protected)</span>
-              )}
-            </label>
-          ))}
+              >
+                <input
+                  type="checkbox"
+                  style={{ marginRight: '8px' }}
+                  value={env}
+                  disabled={!canWrite || env === 'main'}
+                  checked={selectedEnvsSet.has(env)}
+                  onChange={(ev) => {
+                    if (ev.target.checked) {
+                      setSelectedEnvs((prev) =>
+                        Array.from(new Set([...prev, env]))
+                      );
+                    } else {
+                      setSelectedEnvs((prev) => prev.filter((e) => e !== env));
+                    }
+                  }}
+                />
+                {env}{' '}
+                {env === 'main' && (
+                  <span style={{ fontSize: '0.8em' }}>(protected)</span>
+                )}
+              </label>
+            ))
+          )}
         </div>
 
         <button
@@ -241,16 +264,20 @@ function EnvModal(props) {
             selectedEnvsSet.has('main')
           }
           onClick={() => {
+            const deletedEnvs = [...selectedEnvs];
             // push active env at last to prevent breaking the queue
-            let sortedEnvs = selectedEnvs.filter((env) => env !== activeEnv);
+            let sortedEnvs = deletedEnvs.filter((env) => env !== activeEnv);
             if (selectedEnvsSet.has(activeEnv)) {
               sortedEnvs.push(activeEnv);
             }
-            sortedEnvs.forEach((env) => {
-              onEnvDelete(env, activeEnv);
-            });
+            onEnvDelete(sortedEnvs, activeEnv);
             setSelectedEnvs([]);
-            onModalClose();
+            showToast(
+              deletedEnvs.length === 1
+                ? `Successfully deleted environment "${deletedEnvs[0]}".`
+                : `Successfully deleted ${deletedEnvs.length} environments.`,
+              'success'
+            );
           }}
         >
           Delete Selected

--- a/js/modals/EnvModal.js
+++ b/js/modals/EnvModal.js
@@ -66,9 +66,12 @@ function EnvModal(props) {
     setTagEnv(activeEnv || envList[0] || '');
     setTagSaveStatus('idle');
     setTagSaveError('');
+  }, [activeEnv, show]);
+
+  useEffect(() => {
     setEnvFilter('');
     setSelectedEnvs([]);
-  }, [activeEnv, show]);
+  }, [show]);
 
   useEffect(() => {
     setTagRows(rowsFromTags(tags[tagEnv]));
@@ -184,7 +187,6 @@ function EnvModal(props) {
         value={envFilter}
         onChange={(ev) => {
           setEnvFilter(ev.target.value);
-          setSelectedEnvs([]);
         }}
         style={{ marginBottom: '10px', width: '100%' }}
       />
@@ -270,23 +272,34 @@ function EnvModal(props) {
             if (selectedEnvsSet.has(activeEnv)) {
               sortedEnvs.push(activeEnv);
             }
-            const deletionRequested = onEnvDelete(sortedEnvs, activeEnv);
-            if (!deletionRequested) {
+            const requestedDeletions = onEnvDelete(sortedEnvs, activeEnv);
+            if (requestedDeletions.length === 0) {
               showToast(
                 'Unable to delete environments because the server connection is unavailable.',
                 'error'
               );
               return;
             }
+            const requestedDeletionSet = new Set(requestedDeletions);
+            const failedDeletions = deletedEnvs.filter(
+              (env) => !requestedDeletionSet.has(env)
+            );
             if (
-              deletedEnvs.includes(tagEnv) &&
-              !deletedEnvs.includes(activeEnv)
+              requestedDeletionSet.has(tagEnv) &&
+              !requestedDeletionSet.has(activeEnv)
             ) {
               setTagEnv(activeEnv || 'main');
               setTagSaveStatus('idle');
               setTagSaveError('');
             }
-            setSelectedEnvs([]);
+            setSelectedEnvs(failedDeletions);
+            if (failedDeletions.length > 0) {
+              showToast(
+                'Some environment deletion requests could not be sent.',
+                'error'
+              );
+              return;
+            }
             showToast(
               deletedEnvs.length === 1
                 ? `Successfully deleted environment "${deletedEnvs[0]}".`

--- a/playwright/tests/modal.spec.js
+++ b/playwright/tests/modal.spec.js
@@ -78,6 +78,12 @@ test.describe.serial('Test Env Modal', () => {
     await page.locator('button', { hasText: 'fork' }).click();
     await page.locator(envmodal).press('Escape');
 
+    // create a third fork for filtered Select All testing
+    await page.locator(envbutton).click();
+    await page.locator(envmodal + 'input[type="text"]').fill(env + '_fork3');
+    await page.locator('button', { hasText: 'fork' }).click();
+    await page.locator(envmodal).press('Escape');
+
     // check if fork is still the old one
     await closeEnvs(page);
     await openEnv(page, env + '_fork');
@@ -94,27 +100,82 @@ test.describe.serial('Test Env Modal', () => {
   });
 
   test('Remove Env', async ({ page }) => {
-    // batch delete both forks at once
+    // filter to one environment and delete it individually
     await page.locator(envbutton).click();
-    await page
-      .locator(envmodal + `input[type="checkbox"][value="${env}_fork"]`)
-      .check();
+    const filterInput = page.getByLabel('Filter environments');
+    await filterInput.fill(env + '_fork2');
+    await expect(
+      page.locator(envmodal + `input[type="checkbox"][value="${env}_fork2"]`)
+    ).toBeVisible();
+    await expect(
+      page.locator(envmodal + `input[type="checkbox"][value="${env}_fork"]`)
+    ).toHaveCount(0);
     await page
       .locator(envmodal + `input[type="checkbox"][value="${env}_fork2"]`)
       .check();
     await page.locator('button', { hasText: 'Delete Selected' }).click();
+    await expect(page.locator(envmodal)).toBeVisible();
+    await expect(
+      page.locator('.visdom-toast-success', {
+        hasText: `Successfully deleted environment "${env}_fork2".`,
+      })
+    ).toBeVisible();
+
+    // Select All applies only to the remaining filtered environments
+    await filterInput.fill(env + '_fork');
+    await page.getByLabel('Select All').check();
+    await expect(
+      page.locator(envmodal + `input[type="checkbox"][value="${env}_fork"]`)
+    ).toBeChecked();
+    await expect(
+      page.locator(envmodal + `input[type="checkbox"][value="${env}_fork3"]`)
+    ).toBeChecked();
+    await expect(
+      page.locator(envmodal + `input[type="checkbox"][value="${env}"]`)
+    ).toHaveCount(0);
+    await page.locator('button', { hasText: 'Delete Selected' }).click();
+    await expect(page.locator(envmodal)).toBeVisible();
+    await expect(
+      page.locator('.visdom-toast-success', {
+        hasText: 'Successfully deleted 2 environments.',
+      })
+    ).toBeVisible();
+
+    // deleting the active environment falls back to main without closing
+    await filterInput.fill(env);
+    const activeEnvCheckbox = page.locator(
+      envmodal + `input[type="checkbox"][value="${env}"]`
+    );
+    await expect(activeEnvCheckbox).toBeVisible();
+    await activeEnvCheckbox.check();
+    await page.locator('button', { hasText: 'Delete Selected' }).click();
+    await expect(page.locator(envmodal)).toBeVisible();
+    await expect(page.getByLabel('Environment name')).toHaveValue('main');
+    await expect(
+      page.locator('.visdom-toast-success', {
+        hasText: `Successfully deleted environment "${env}".`,
+      })
+    ).toBeVisible();
+
+    await page.locator(envmodal).press('Escape');
     await expect(page.locator(envmodal)).toHaveCount(0);
 
     await page.locator('.rc-tree-select').click();
     await expandAllEnvGroups(page);
     const tree = page.locator('.rc-tree-select-tree');
-    await expect(tree.locator(`span[title="${env}"]`)).toBeVisible({
+    await expect(tree.locator('span[title="main"]')).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(tree.locator(`span[title="${env}"]`)).toHaveCount(0, {
       timeout: 5000,
     });
     await expect(tree.locator(`span[title="${env}_fork"]`)).toHaveCount(0, {
       timeout: 5000,
     });
     await expect(tree.locator(`span[title="${env}_fork2"]`)).toHaveCount(0, {
+      timeout: 5000,
+    });
+    await expect(tree.locator(`span[title="${env}_fork3"]`)).toHaveCount(0, {
       timeout: 5000,
     });
     await closeEnvDropdown(page);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`js/modals/EnvModal.js`: Add environment filtering, filtered Select All, persistent modal, and deletion notifications.

`js/main.js`: Handle batch deletion and switch from deleted active environments.

`playwright/tests/modal.spec.js`: Add tests for delete filtering

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When users have thousands of runs, there is currently no way to delete them in batches. Instead, they have to either delete all runs at once or delete them one by one.

This PR focuses on providing a search filter based on user-entered keywords. This makes it possible to efficiently delete runs in batches, since run names usually follow a consistent naming pattern, such as `mnist_lr_search_trial_0001` and `mnist_lr_search_trial_0002`.

For example, users can simply search for `mnist_lr_search_` to filter all matching runs and delete them together.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, experiments you ran to see how -->
<!--- your change affects existing areas of the code and their behaviors, etc. -->
<!--- One method of testing is to run the `demo.py` script from the examples -->
<!--- both on your branch and a clean branch and ensure that none of the functionality -->
<!--- appears different. Be sure to install from source when testing. -->
Run locally to test the environment filtering feature.

## Screenshots (if appropriate):
1. If the currently active environment is deleted, the UI should automatically switch to the main environment.
2. If the deleted environment is not currently active, the active environment should remain unchanged.
3. If multiple environments are selected and only some of them are deleted, the UI should keep the remaining environments selected instead of switching to main.

https://github.com/user-attachments/assets/1ab9d40b-e6c6-49f0-91d5-da986ed77764

The following video shows how the search bar works.

https://github.com/user-attachments/assets/bd99f366-5a7b-44b8-aba2-738533cc3fd2




## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Summary by Sourcery

Enable efficient filtered batch environment deletion while maintaining consistent selection and active-environment behavior.

New Features:
- Add keyword-based environment filtering with filtered Select All support for batch deletion.

Bug Fixes:
- Preserve valid environment selections and automatically fall back to the main environment when deleted selections leave none available.
- Report deletion success or unavailable server connections through user-facing notifications.

Enhancements:
- Keep the environment modal open after deletion and update active environment, layout, tags, and displayed data consistently for single and batch deletions.
- Improve WebSocket request handling by validating connection state and returning send status.

Tests:
- Expand Playwright coverage for filtered deletion, filtered Select All, persistent modal behavior, deletion notifications, and active-environment fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filter environments in the deletion list, with a no-match message when applicable.
  * Select and delete multiple filtered environments at once.
  * Receive success or error notifications for deletion attempts.
  * Keep the environment modal open after deletion for continued management.

* **Bug Fixes**
  * Failed deletion requests no longer update the interface.
  * Partial deletions preserve unsuccessful selections and report the failure.
  * Deleting the active environment switches to an available environment, or `main` when none remain.
  * Environment selections, layouts, tags, and the environment tree update correctly after successful deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->