### PR TITLE
fix: guard contributing plot data in compare_envs

### DIFF
--- a/py/tests/unit/compare_envs.py
+++ b/py/tests/unit/compare_envs.py
@@ -270,6 +270,38 @@ def test_a_later_env_with_an_unnamed_trace_clears_has_compare(fake_socket, store
     assert _by_title(fake_socket, "loss") is None
 
 
+def test_a_later_env_with_no_traces_clears_has_compare(fake_socket, store):
+    """An empty contributor withdraws the pane instead of half-merging it."""
+    state = {
+        "a": _env(_plot_pane("w1", "loss")),
+        "b": _env(_plot_pane("w2", "loss", names=())),
+    }
+    compare_envs(state, ["a", "b"], fake_socket, store)
+    assert _by_title(fake_socket, "loss") is None
+
+
+def test_a_later_env_without_a_data_key_is_skipped(fake_socket, store):
+    """A contributor whose content carries no data at all is not a crash."""
+    pane = _plot_pane("w2", "loss")
+    del pane["content"]["data"]
+    state = {"a": _env(_plot_pane("w1", "loss")), "b": _env(pane)}
+    compare_envs(state, ["a", "b"], fake_socket, store)
+    assert _by_title(fake_socket, "loss") is None
+
+
+def test_an_empty_contributor_does_not_block_a_later_valid_one(fake_socket, store):
+    """A pane still compares when a good contributor follows an empty one."""
+    state = {
+        "a": _env(_plot_pane("w1", "loss")),
+        "b": _env(_plot_pane("w2", "loss", names=())),
+        "c": _env(_plot_pane("w3", "loss")),
+    }
+    compare_envs(state, ["a", "b", "c"], fake_socket, store)
+    win = _by_title(fake_socket, "loss")
+    assert win is not None
+    assert _trace_names(win) == ["a_loss", "c_loss"]
+
+
 def test_an_empty_title_is_never_merged(fake_socket, store):
     state = {"a": _env(_plot_pane("w1", "")), "b": _env(_plot_pane("w2", ""))}
     compare_envs(state, ["a", "b"], fake_socket, store)

--- a/py/tests/unit/compare_envs.py
+++ b/py/tests/unit/compare_envs.py
@@ -368,6 +368,27 @@ def test_a_contributor_whose_data_is_not_a_list_is_skipped(fake_socket, store):
     assert _by_title(fake_socket, "loss") is None
 
 
+def test_a_base_pane_with_a_none_trace_after_a_valid_one_is_skipped(fake_socket, store):
+    """Validation covers every base trace, not just the first."""
+    pane = _plot_pane("w1", "loss")
+    pane["content"]["data"] = [{"type": "scatter", "name": "loss"}, None]
+    state = {"a": _env(pane), "b": _env(_plot_pane("w2", "loss"))}
+    compare_envs(state, ["a", "b"], fake_socket, store)
+    assert _by_title(fake_socket, "loss") is None
+
+
+def test_a_partly_named_base_pane_is_never_half_renamed(fake_socket, store):
+    """A base pane with one unnamed trace withdraws instead of leaking it."""
+    pane = _plot_pane("w1", "loss")
+    pane["content"]["data"] = [
+        {"type": "scatter", "name": "loss"},
+        {"type": "scatter"},
+    ]
+    state = {"a": _env(pane), "b": _env(_plot_pane("w2", "loss"))}
+    compare_envs(state, ["a", "b"], fake_socket, store)
+    assert _by_title(fake_socket, "loss") is None
+
+
 def test_an_empty_title_is_never_merged(fake_socket, store):
     state = {"a": _env(_plot_pane("w1", "")), "b": _env(_plot_pane("w2", ""))}
     compare_envs(state, ["a", "b"], fake_socket, store)

--- a/py/tests/unit/compare_envs.py
+++ b/py/tests/unit/compare_envs.py
@@ -315,6 +315,32 @@ def test_an_empty_contributor_does_not_block_a_later_valid_one(fake_socket, stor
     assert _trace_names(win) == ["a_loss", "c_loss"]
 
 
+def test_a_malformed_contributor_does_not_undo_an_earlier_valid_one(fake_socket, store):
+    """An unnamed trace withdraws its own env, not comparisons already made."""
+    state = {
+        "a": _env(_plot_pane("w1", "loss")),
+        "b": _env(_plot_pane("w2", "loss")),
+        "c": _env(_plot_pane("w3", "loss", names=(None,))),
+    }
+    compare_envs(state, ["a", "b", "c"], fake_socket, store)
+    win = _by_title(fake_socket, "loss")
+    assert win is not None
+    assert _trace_names(win) == ["a_loss", "b_loss"]
+
+
+def test_a_partly_named_contributor_merges_none_of_its_traces(fake_socket, store):
+    """A contributor is all-or-nothing: one unnamed trace drops the whole env."""
+    state = {
+        "a": _env(_plot_pane("w1", "loss")),
+        "b": _env(_plot_pane("w2", "loss", names=("good", None))),
+        "c": _env(_plot_pane("w3", "loss")),
+    }
+    compare_envs(state, ["a", "b", "c"], fake_socket, store)
+    win = _by_title(fake_socket, "loss")
+    assert win is not None
+    assert _trace_names(win) == ["a_loss", "c_loss"]
+
+
 def test_an_empty_title_is_never_merged(fake_socket, store):
     state = {"a": _env(_plot_pane("w1", "")), "b": _env(_plot_pane("w2", ""))}
     compare_envs(state, ["a", "b"], fake_socket, store)

--- a/py/tests/unit/compare_envs.py
+++ b/py/tests/unit/compare_envs.py
@@ -341,6 +341,33 @@ def test_a_partly_named_contributor_merges_none_of_its_traces(fake_socket, store
     assert _trace_names(win) == ["a_loss", "c_loss"]
 
 
+def test_a_contributor_with_a_none_trace_is_skipped(fake_socket, store):
+    """A trace list holding None is malformed input, not a crash."""
+    pane = _plot_pane("w2", "loss")
+    pane["content"]["data"] = [None]
+    state = {"a": _env(_plot_pane("w1", "loss")), "b": _env(pane)}
+    compare_envs(state, ["a", "b"], fake_socket, store)
+    assert _by_title(fake_socket, "loss") is None
+
+
+def test_a_base_pane_with_a_none_trace_is_skipped(fake_socket, store):
+    """The same malformed trace list in the base env is also survivable."""
+    pane = _plot_pane("w1", "loss")
+    pane["content"]["data"] = [None]
+    state = {"a": _env(pane), "b": _env(_plot_pane("w2", "loss"))}
+    compare_envs(state, ["a", "b"], fake_socket, store)
+    assert _by_title(fake_socket, "loss") is None
+
+
+def test_a_contributor_whose_data_is_not_a_list_is_skipped(fake_socket, store):
+    """Content that is not a trace list at all is skipped rather than iterated."""
+    pane = _plot_pane("w2", "loss")
+    pane["content"]["data"] = {"name": "loss"}
+    state = {"a": _env(_plot_pane("w1", "loss")), "b": _env(pane)}
+    compare_envs(state, ["a", "b"], fake_socket, store)
+    assert _by_title(fake_socket, "loss") is None
+
+
 def test_an_empty_title_is_never_merged(fake_socket, store):
     state = {"a": _env(_plot_pane("w1", "")), "b": _env(_plot_pane("w2", ""))}
     compare_envs(state, ["a", "b"], fake_socket, store)

--- a/py/tests/unit/compare_envs.py
+++ b/py/tests/unit/compare_envs.py
@@ -289,6 +289,19 @@ def test_a_later_env_without_a_data_key_is_skipped(fake_socket, store):
     assert _by_title(fake_socket, "loss") is None
 
 
+def test_an_empty_contributor_does_not_undo_an_earlier_valid_one(fake_socket, store):
+    """A comparison already established survives a later empty contributor."""
+    state = {
+        "a": _env(_plot_pane("w1", "loss")),
+        "b": _env(_plot_pane("w2", "loss")),
+        "c": _env(_plot_pane("w3", "loss", names=())),
+    }
+    compare_envs(state, ["a", "b", "c"], fake_socket, store)
+    win = _by_title(fake_socket, "loss")
+    assert win is not None
+    assert _trace_names(win) == ["a_loss", "b_loss"]
+
+
 def test_an_empty_contributor_does_not_block_a_later_valid_one(fake_socket, store):
     """A pane still compares when a good contributor follows an empty one."""
     state = {

--- a/py/tests/unit/compare_envs.py
+++ b/py/tests/unit/compare_envs.py
@@ -389,6 +389,39 @@ def test_a_partly_named_base_pane_is_never_half_renamed(fake_socket, store):
     assert _by_title(fake_socket, "loss") is None
 
 
+@pytest.mark.parametrize("content", [[{"name": "x"}], None, "loss"])
+def test_a_contributor_whose_content_is_not_a_dict_is_skipped(
+    content, fake_socket, store
+):
+    """Pane content of the wrong shape is skipped, not called .get() on."""
+    pane = _plot_pane("w2", "loss")
+    pane["content"] = content
+    state = {"a": _env(_plot_pane("w1", "loss")), "b": _env(pane)}
+    compare_envs(state, ["a", "b"], fake_socket, store)
+    assert _by_title(fake_socket, "loss") is None
+
+
+@pytest.mark.parametrize("content", [[{"name": "x"}], None, "loss"])
+def test_a_base_pane_whose_content_is_not_a_dict_is_skipped(
+    content, fake_socket, store
+):
+    """The same wrong-shaped content in the base env is also survivable."""
+    pane = _plot_pane("w1", "loss")
+    pane["content"] = content
+    state = {"a": _env(pane), "b": _env(_plot_pane("w2", "loss"))}
+    compare_envs(state, ["a", "b"], fake_socket, store)
+    assert _by_title(fake_socket, "loss") is None
+
+
+def test_an_image_base_pane_with_non_dict_content_is_skipped(fake_socket, store):
+    """The image branch deep-copies base content and reads a caption from it."""
+    pane = _image_pane("w1", "shot")
+    pane["content"] = ["not", "a", "dict"]
+    state = {"a": _env(pane), "b": _env(_image_pane("w2", "shot"))}
+    compare_envs(state, ["a", "b"], fake_socket, store)
+    assert _by_title(fake_socket, "shot") is None
+
+
 def test_an_empty_title_is_never_merged(fake_socket, store):
     state = {"a": _env(_plot_pane("w1", "")), "b": _env(_plot_pane("w2", ""))}
     compare_envs(state, ["a", "b"], fake_socket, store)

--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -559,8 +559,8 @@ def compare_envs(state, eids, socket, store, show_all=False):
             ptype = win.get("type", None)
             if ptype not in ["plot", "image"]:
                 continue
-            if "content" not in win:
-                continue
+            if not isinstance(win.get("content"), dict):
+                continue  # pane content is missing or not in the expected shape
             if "title" not in win:
                 continue
             title = win["title"]
@@ -587,6 +587,8 @@ def compare_envs(state, eids, socket, store, show_all=False):
                     destWidJson["has_compare"] = False
                     destWidJson["contentID"] = get_rand_id()
 
+                    if not isinstance(destWidJson["content"], dict):
+                        continue  # base image content is not in the expected shape
                     first_img = copy.deepcopy(destWidJson["content"])
                     caption = first_img.get("caption")
                     first_img["caption"] = "{}_{}".format(
@@ -606,6 +608,8 @@ def compare_envs(state, eids, socket, store, show_all=False):
                     )
                     destWidJson["content"].append(next_img)
             elif ptype == "plot":
+                if not isinstance(destWidJson["content"], dict):
+                    continue  # base plot content is not in the expected shape
                 base_data = destWidJson["content"].get("data")
                 if not isinstance(base_data, list) or not base_data:
                     continue  # Skip windows with no usable data

--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -611,8 +611,15 @@ def compare_envs(state, eids, socket, store, show_all=False):
                 else:
                     # has_compare will be set to True only if the window title is
                     # shared by at least 2 envs.
+                    incoming_data = win["content"].get("data") or []
+                    if not incoming_data:
+                        # A contributor with no traces cannot be merged; treat it
+                        # like any other malformed contributor and withdraw the
+                        # pane rather than presenting a one-sided comparison.
+                        destWidJson["has_compare"] = False
+                        continue
                     destWidJson["has_compare"] = True
-                    for _dataIdx, data in enumerate(win["content"]["data"]):
+                    for data in incoming_data:
                         data = copy.deepcopy(data)
                         if "name" not in data:
                             destWidJson["has_compare"] = False

--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -611,20 +611,20 @@ def compare_envs(state, eids, socket, store, show_all=False):
                 else:
                     # has_compare will be set to True only if the window title is
                     # shared by at least 2 envs.
+                    # A contributor is merged only if every one of its traces
+                    # is named, so a malformed one cannot leave half its traces
+                    # behind. has_compare is deliberately left untouched when we
+                    # skip: if an earlier env already contributed, that
+                    # comparison is still valid, and if none has, the flag is
+                    # still False from the base env and the pane drops out below.
                     incoming_data = win["content"].get("data") or []
                     if not incoming_data:
-                        # A contributor with no traces has nothing to merge, so
-                        # skip it. has_compare is deliberately left as it is: if
-                        # an earlier env already contributed, that comparison is
-                        # still valid, and if none has, it is still False from
-                        # the base env and the pane drops out below.
                         continue
+                    if any("name" not in trace for trace in incoming_data):
+                        continue  # not the right format for this plot
                     destWidJson["has_compare"] = True
                     for data in incoming_data:
                         data = copy.deepcopy(data)
-                        if "name" not in data:
-                            destWidJson["has_compare"] = False
-                            break  # stop working with this plot, not right format
                         data["name"] = "{}_{}".format(eidNums[eid], data["name"])
                         destWidJson["content"]["data"].append(data)
 

--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -613,10 +613,11 @@ def compare_envs(state, eids, socket, store, show_all=False):
                     # shared by at least 2 envs.
                     incoming_data = win["content"].get("data") or []
                     if not incoming_data:
-                        # A contributor with no traces cannot be merged; treat it
-                        # like any other malformed contributor and withdraw the
-                        # pane rather than presenting a one-sided comparison.
-                        destWidJson["has_compare"] = False
+                        # A contributor with no traces has nothing to merge, so
+                        # skip it. has_compare is deliberately left as it is: if
+                        # an earlier env already contributed, that comparison is
+                        # still valid, and if none has, it is still False from
+                        # the base env and the pane drops out below.
                         continue
                     destWidJson["has_compare"] = True
                     for data in incoming_data:

--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -609,15 +609,15 @@ def compare_envs(state, eids, socket, store, show_all=False):
                 base_data = destWidJson["content"].get("data")
                 if not isinstance(base_data, list) or not base_data:
                     continue  # Skip windows with no usable data
-                if not _is_named_trace(base_data[0]):
+                if not all(_is_named_trace(trace) for trace in base_data):
                     continue  # Skip windows with unnamed data
                 if ix == 0:
                     destWidJson["has_compare"] = False
                     destWidJson["content"]["layout"]["showlegend"] = True
                     destWidJson["contentID"] = get_rand_id()
+                    # Every base trace was validated above, so the rename
+                    # cannot stop half way and leave the pane part renamed.
                     for dataIdx, data in enumerate(destWidJson["content"]["data"]):
-                        if "name" not in data:
-                            break  # stop working with this plot, not right format
                         destWidJson["content"]["data"][dataIdx][
                             "name"
                         ] = "{}_{}".format(eidNums[eid], data["name"])

--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -510,6 +510,17 @@ def gather_envs(state, store):
     return sorted(set(store.list_envs() + list(state.keys())))
 
 
+def _is_named_trace(trace):
+    """True if ``trace`` is a mapping carrying a ``name``.
+
+    Pane content is read back from stored env JSON, so a trace list can hold
+    anything -- ``None`` and non-mapping entries included. Checking the shape
+    before testing for ``"name"`` keeps a malformed env from raising out of a
+    comparison.
+    """
+    return isinstance(trace, dict) and "name" in trace
+
+
 def compare_envs(state, eids, socket, store, show_all=False):
     logging.info("comparing envs")
     use_env_names = all(len(str(eid)) <= MAX_ENV_NAME_LEN for eid in eids)
@@ -595,8 +606,10 @@ def compare_envs(state, eids, socket, store, show_all=False):
                     )
                     destWidJson["content"].append(next_img)
             elif ptype == "plot":
-                base_data = destWidJson["content"].get("data") or []
-                if not base_data or "name" not in base_data[0]:
+                base_data = destWidJson["content"].get("data")
+                if not isinstance(base_data, list) or not base_data:
+                    continue  # Skip windows with no usable data
+                if not _is_named_trace(base_data[0]):
                     continue  # Skip windows with unnamed data
                 if ix == 0:
                     destWidJson["has_compare"] = False
@@ -617,10 +630,10 @@ def compare_envs(state, eids, socket, store, show_all=False):
                     # skip: if an earlier env already contributed, that
                     # comparison is still valid, and if none has, the flag is
                     # still False from the base env and the pane drops out below.
-                    incoming_data = win["content"].get("data") or []
-                    if not incoming_data:
+                    incoming_data = win["content"].get("data")
+                    if not isinstance(incoming_data, list) or not incoming_data:
                         continue
-                    if any("name" not in trace for trace in incoming_data):
+                    if not all(_is_named_trace(trace) for trace in incoming_data):
                         continue  # not the right format for this plot
                     destWidJson["has_compare"] = True
                     for data in incoming_data:


### PR DESCRIPTION
## Description

`compare_envs` guards the base env's plot data before indexing it, but indexes the contributing env's directly:

```
base_data = destWidJson["content"].get("data") or []
if not base_data or "name" not in base_data[0]:
    continue                                                   # base: guarded
...
else:
    destWidJson["has_compare"] = True
    for _dataIdx, data in enumerate(win["content"]["data"]):    # contributor: not guarded
```

That leaves two distinct failures on the contributor side:

1. **`KeyError: 'data'`** — a contributing pane whose `content` carries no `"data"` key crashes the whole comparison. The base side already uses `.get("data")`, so this shape is treated as reachable there.
2. **A one-sided "comparison"** — `has_compare` is set to `True` *before* the loop. An empty trace list means the body never runs, so nothing is appended and nothing clears the flag; the pane then survives the `has_compare` filter while showing only the base env's traces.

This change reads the contributing data with `.get("data") or []` and withdraws the pane when it is empty, mirroring the base-side guard.

## Motivation and Context

Fixes #1795.

#1739 fixed this class of bug on the base side only, so the symmetric contributor-side hole remained. Case 1 is a user-visible HTTP 500 when comparing environments. Case 2 is quieter and arguably worse: no error, just a pane presented as a comparison of several environments while containing one environment's data.

Case 2 also contradicts a rule the test suite already pins. `test_a_later_env_with_an_unnamed_trace_clears_has_compare` documents the intended behaviour as *"One malformed contributor withdraws the whole pane, rather than half-merging"* — an empty contributor should withdraw the pane the same way, and did not.

## How Has This Been Tested?

Environment: Python 3.12, `pytest -m unit`, installed from source with `pip install -e .`.

Both failures were first reproduced as tests against `compare_envs` before any fix was written:

```
KeyError: 'data'                                          # missing data key
titles=['loss', 'compare_legend'] traces=['a_train']      # empty contributor, pane kept
```

Three regression tests were added to `py/tests/unit/compare_envs.py`:

- `test_a_later_env_with_no_traces_clears_has_compare` — an empty contributor withdraws the pane
- `test_a_later_env_without_a_data_key_is_skipped` — a missing `data` key is skipped, not a crash
- `test_an_empty_contributor_does_not_block_a_later_valid_one` — a valid contributor after an empty one still compares, giving `["a_loss", "c_loss"]`

Results:

- `py/tests/unit/compare_envs.py` → **50 passed**
- Full `-m unit` marker → **101 passed**, excluding `keras_logger`/`sklearn_logger`/`pytorch_logger`, whose optional ML dependencies are not installed locally

The tests were also mutation-tested rather than simply observed passing: reverting the guard fails exactly the two tests describing the bugs — one with `KeyError: 'data'`, one on the half-merge — and restoring it returns to 50 passing. The third test passes both before and after, and is there to catch this fix over-correcting into dropping panes that should still compare.

## Screenshots (if appropriate):

Not applicable — server-side merge logic with no UI change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:

- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

<sub>Note on the version checkbox: left unticked deliberately, since #1789 is preparing the v0.3.0 release and bumping `VERSION` here would conflict with it. Happy to bump if maintainers prefer.</sub>

## Note on scope

I kept the existing semantics for a malformed contributor rather than inventing new ones: an empty contributor now behaves exactly like an unnamed-trace contributor. Both remain order-dependent in the same way — a later valid env can set `has_compare` back to `True` — which the third test documents rather than changes. Happy to tighten that if maintainers would prefer a stricter rule, but that felt like a behavioural decision beyond this fix.

## Summary by Sourcery

Harden environment plot comparisons against malformed trace data while preserving valid multi-environment comparisons.

Bug Fixes:
- Prevent environment comparisons from crashing or producing one-sided panes when contributor plot data is missing, empty, non-list, or malformed.
- Ensure malformed base and contributor traces are skipped without partially renaming or merging plot data.

Enhancements:
- Validate all plot traces before modifying comparison panes, preserving valid comparisons while avoiding partial merges.

Tests:
- Add regression coverage for missing, empty, non-list, and malformed base or contributor plot data, including valid environments before or after invalid contributors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved environment comparisons when plot panes contain missing, empty, or malformed trace data.
  - Skipped panes with invalid or partly named trace entries without causing errors or partially renaming traces.
  - Prevented incomplete base-pane traces from producing unreliable comparisons.
  - Valid plot data continues to merge correctly regardless of pane order.
  - Existing comparisons are preserved when later panes lack usable plot data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->