### PR TITLE
fix: compare wide integers instead of 500ing /experiments/search

### DIFF
--- a/py/tests/integration/experiment_search.py
+++ b/py/tests/integration/experiment_search.py
@@ -25,7 +25,7 @@ import tornado.testing
 
 from visdom import Visdom
 from visdom.data_model import JSONStore
-from visdom.experiments import ExperimentStore, QueryParseError
+from visdom.experiments import ExperimentStore, MAX_QUERY_LENGTH, QueryParseError
 from visdom.server.app import Application
 from visdom.server.handlers.web_handlers import ExperimentSearchHandler
 
@@ -456,6 +456,41 @@ class TestSearchEndpoint(tornado.testing.AsyncHTTPTestCase):
         for char in ("<", ">", "&"):
             self.assertNotIn(char, raw)
         self.assertEqual(json.loads(raw)["query"], query)
+
+    def test_a_wide_integer_literal_does_not_500(self):
+        """A query carrying an integer too wide for a float is answered, not fatal.
+
+        Nothing has to be stored for this: the literal alone used to reach
+        ``float()``, raise ``OverflowError`` and take the request with it, so
+        any caller could turn a plain query string into a 500.
+        """
+        wide = "9" * 400
+        for query in (
+            "lr < " + wide,
+            "lr > " + wide,
+            "lr = " + wide,
+            "lr != " + wide,
+        ):
+            with self.subTest(query[:12]):
+                self.assertLess(len(query), MAX_QUERY_LENGTH)
+                body = self.search_ok({"query": query})
+                self.assertEqual(body["query"], query)
+
+    def test_a_wide_integer_literal_still_filters(self):
+        """Answering is not the same as answering correctly."""
+        wide = "9" * 400
+        body = self.search_ok({"query": "lr < " + wide})
+        self.assertEqual(body["total"], 3)
+        self.assertEqual(self.search_ok({"query": "lr > " + wide})["total"], 0)
+
+    def test_a_wide_stored_param_does_not_500(self):
+        """The stored side is unbounded too, and is read on every match attempt."""
+        ExperimentStore(JSONStore(self._tmp_dir)).log_experiment(
+            "run-wide", params={"steps": 10**400}
+        )
+        body = self.search_ok({"query": "steps > 1"})
+        self.assertEqual([e["env_id"] for e in body["experiments"]], ["run-wide"])
+        self.assertEqual(self.search_ok({})["total"], 4)
 
     def test_search_sees_an_experiment_logged_over_http(self):
         """An experiment logged through /experiments/log is searchable at once."""

--- a/py/tests/unit/query.py
+++ b/py/tests/unit/query.py
@@ -313,6 +313,82 @@ class TestParseLimits(unittest.TestCase):
         self.assertTrue(parse_query(text).matches({"lr": 0.001}))
 
 
+class TestWideIntegers(unittest.TestCase):
+    """An integer too wide for a float compares instead of raising.
+
+    JSON bounds neither a stored number nor one written into a query, so both
+    sides of a comparison can hold an integer with no float representation.
+    ``float()`` does not saturate on one of those the way it does on an
+    over-large string — it raises ``OverflowError`` — and nothing between the
+    comparison and the request catches it, so the whole search answers 500.
+
+    The sort path was already hardened against this
+    (``store._is_number`` swallows the same ``OverflowError`` by design); these
+    pin the filter path to the same standard, and pin the exactness that comes
+    with not rounding through a float.
+    """
+
+    #: Wider than the ~1.8e308 a float can hold, and far inside MAX_QUERY_LENGTH.
+    WIDE = 10**400
+
+    def test_a_wide_literal_in_the_query_compares(self):
+        """The literal reaches the comparison as an int; nothing casts it."""
+        record = {"lr": 0.01}
+        wide = str(self.WIDE)
+        self.assertTrue(match("lr < " + wide, record))
+        self.assertFalse(match("lr > " + wide, record))
+        self.assertFalse(match("lr = " + wide, record))
+        self.assertTrue(match("lr != " + wide, record))
+        self.assertTrue(match("lr <= " + wide, record))
+        self.assertFalse(match("lr >= " + wide, record))
+
+    def test_a_wide_stored_value_compares(self):
+        """A param can hold one too, and every operator must survive reading it."""
+        record = {"steps": self.WIDE}
+        self.assertTrue(match("steps > 1", record))
+        self.assertFalse(match("steps < 1", record))
+        self.assertFalse(match("steps = 1", record))
+        self.assertTrue(match("steps != 1", record))
+
+    def test_wide_on_both_sides(self):
+        """Neither side is the one that has to be small."""
+        record = {"steps": self.WIDE}
+        self.assertTrue(match("steps = " + str(self.WIDE), record))
+        self.assertTrue(match("steps < " + str(self.WIDE + 1), record))
+        self.assertFalse(match("steps > " + str(self.WIDE + 1), record))
+
+    def test_a_wide_value_is_not_rounded_into_a_false_match(self):
+        """Two ints that differ past a float's mantissa stay different.
+
+        Casting through ``float`` made this match: both sides land on the same
+        1e20 once 53 bits of mantissa run out.
+        """
+        stored = 10**20
+        self.assertFalse(match("steps = %d" % (stored + 1), {"steps": stored}))
+        self.assertTrue(match("steps = %d" % stored, {"steps": stored}))
+        self.assertTrue(match("steps < %d" % (stored + 1), {"steps": stored}))
+
+    def test_a_wide_value_still_answers_contains_and_string_compares(self):
+        """The non-numeric operators were never the problem and stay put."""
+        self.assertTrue(match("steps contains 1000", {"steps": self.WIDE}))
+        self.assertFalse(match("name > 5", {"name": "abc"}))
+
+    def test_ordinary_numbers_are_unaffected(self):
+        """The cast that was removed did nothing else, so nothing else moves."""
+        record = {"lr": 0.01, "acc": 92.5, "epochs": 10}
+        self.assertTrue(match("lr < 0.05", record))
+        self.assertTrue(match("acc >= 92.5", record))
+        self.assertTrue(match("epochs = 10", record))
+        self.assertTrue(match("epochs = 10", {"epochs": "10"}))
+        self.assertTrue(match("lr = 0.010", {"lr": 0.01}))
+        self.assertFalse(match("epochs = 10", {"epochs": True}))
+
+    def test_an_over_large_float_literal_still_saturates(self):
+        """A float-shaped literal overflows to inf rather than raising, as before."""
+        self.assertTrue(match("lr < 1.0e999", {"lr": 0.01}))
+        self.assertTrue(match("lr < 1e999", {"lr": "0.01"}))
+
+
 class TestInjectionSafety(unittest.TestCase):
     """Injection-style payloads are inert: they parse to string literals or fail."""
 

--- a/py/visdom/experiments/query.py
+++ b/py/visdom/experiments/query.py
@@ -386,16 +386,35 @@ def _lookup(record: dict, key: str) -> Any:
     return cursor
 
 
-def _to_number(value: Any) -> Optional[float]:
-    """Coerce ``value`` to a float for numeric comparison, or ``None``.
+def _to_number(value: Any) -> Optional[int | float]:
+    """Coerce ``value`` to a number for comparison, or ``None``.
 
     ``bool`` is intentionally not treated as a number so that ``amp = 1`` does
     not silently match a boolean ``True``; booleans compare via :func:`_to_bool`.
+
+    A value that is already a number is returned unchanged rather than cast to
+    ``float``. JSON puts no bound on integer length, so a param can hold an
+    integer far too wide for a float — and ``float()`` does not saturate on one
+    of those, it raises ``OverflowError``. Since nothing between here and the
+    request catches it, that turns a comparison against such a value into a 500
+    for the whole search. :func:`~visdom.experiments.store._is_number` already
+    guards the sort path against exactly this; the filter path is the other
+    half of it.
+
+    Keeping the integer also keeps the comparison exact. Casting to ``float``
+    rounds anything past 53 bits of mantissa, which made two genuinely
+    different values compare equal — ``steps = 100000000000000000001`` matched
+    a run that logged ``100000000000000000000``. Python compares ``int``
+    against ``float`` without routing either through the other's precision, so
+    the values now answer for themselves.
+
+    Only a string still needs converting, and that conversion cannot raise the
+    same way: ``float`` of an over-large *string* saturates to ``inf``.
     """
     if isinstance(value, bool):
         return None
     if isinstance(value, (int, float)):
-        return float(value)
+        return value
     if isinstance(value, str):
         try:
             return float(value)
@@ -424,17 +443,23 @@ def _equals(actual: Any, expected: Any) -> bool:
         return actual_bool is not None and actual_bool == expected
     if isinstance(expected, (int, float)):
         actual_number = _to_number(actual)
-        return actual_number is not None and actual_number == float(expected)
+        return actual_number is not None and actual_number == expected
     return str(actual) == str(expected)
 
 
 def _order(actual: Any, op: str, expected: Any) -> bool:
-    """Apply an ordering operator, numerically when the literal is numeric."""
+    """Apply an ordering operator, numerically when the literal is numeric.
+
+    The literal is used as parsed, for the reason :func:`_to_number` gives: a
+    query may carry an integer wider than a float, and casting it would raise
+    ``OverflowError`` rather than saturate. ``MAX_QUERY_LENGTH`` bounds how wide
+    that is, so the comparison stays cheap.
+    """
     if isinstance(expected, (int, float)) and not isinstance(expected, bool):
         left = _to_number(actual)
         if left is None:
             return False
-        right: Any = float(expected)
+        right: Any = expected
     else:
         left = str(actual)
         right = str(expected)


### PR DESCRIPTION
## Description

Fix numeric query filtering for very large integers.

Currently, `query.py` converts both sides of numeric comparisons to `float()` before comparing them. This causes two problems:

* Very large integers can raise `OverflowError`, which escapes the request handler and results in a `500`.
* Large integers can lose precision when converted to floats, causing incorrect comparisons.

For example, a query like:

```text
lr > <400-digit integer>
```

can return a `500` even when the value is only present in the query and nothing is stored.

The same issue occurs when a stored parameter contains a very large integer.

The fix removes the unnecessary `float()` conversion from `_to_number`, `_equals`, and `_order`. Python already compares `int` and `float` values correctly, so there is no need to normalize them through `float()`.

This also preserves the exact value of large integers instead of rounding them to floating-point precision.

## Why This Fix

The sorting path already handles this case safely. `store._is_number` catches `OverflowError` for integers that are too large to convert to floats and falls back to text ordering.

Filtering should behave consistently with sorting instead of raising an exception for the same data.

## Testing

Added unit and integration tests covering:

* Very large integer literals with `<`, `>`, `<=`, `>=`, `=`, and `!=`
* Very large stored integer values
* Large integers on both sides of a comparison
* Large integer comparisons without float-precision rounding
* Normal numeric comparisons
* String and `contains` operators
* Large float literals such as `1e999`

Integration tests also verify that `/experiments/search` returns `200` and filters large values correctly.

### Verification

```text
2040 passed, 4 skipped
```

`black py` reports no changes.

## Types of Changes

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Refactor / cleanup

## Additional Notes

No API, request/response, or authentication changes are required.

The only intentional behavior change is that very large integers are now compared exactly instead of being rounded through floating-point conversion.
