### PR TITLE
fix(polling): catch event handler exceptions in setup_polling

### DIFF
--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -601,14 +601,10 @@ class Visdom(object):
                 for handler in list(self.event_handlers.get(message["target"], [])):
                     try:
                         handler(message)
-                    except Exception as e:
-                        logger.warning(
-                            "Visdom failed to handle a handler for {}: {}"
-                            "".format(message, e)
+                    except Exception:
+                        logger.exception(
+                            "Visdom failed to handle event for %s", message
                         )
-                        import traceback
-
-                        traceback.print_exc()
 
         def on_close(ws):
             self.socket_alive = False

--- a/py/visdom/__init__.py
+++ b/py/visdom/__init__.py
@@ -599,7 +599,16 @@ class Visdom(object):
                         )
             if "target" in message:
                 for handler in list(self.event_handlers.get(message["target"], [])):
-                    handler(message)
+                    try:
+                        handler(message)
+                    except Exception as e:
+                        logger.warning(
+                            "Visdom failed to handle a handler for {}: {}"
+                            "".format(message, e)
+                        )
+                        import traceback
+
+                        traceback.print_exc()
 
         def on_close(ws):
             self.socket_alive = False


### PR DESCRIPTION
## Description
Wraps event handler invocation in `setup_polling()` within a `try/except` block matching the existing behavior in `setup_socket()`.

## Motivation and Context
Fixes #1636

In polling mode (`use_polling=True` or `use_incoming_socket=False`), if a registered event handler raises an exception, the exception previously propagated uncaught and permanently terminated the background `Visdom-Socket-Thread`. This silently prevented any subsequent events from being processed.

With this change, exceptions from user event handlers in polling mode are caught, logged as warnings with tracebacks, and allow the listener thread to continue running for subsequent events.

## How Has This Been Tested?
Tested event handling in polling mode with a failing callback to confirm exceptions are caught and subsequent messages continue to be handled properly.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.

## Summary by Sourcery

Bug Fixes:
- Prevent exceptions from polling-mode event handlers from terminating the background listener, allowing subsequent events to continue being processed.