### PR TITLE
fix: bump the pane version for every type, not just plots

### DIFF
--- a/py/tests/integration/pane_version_broadcast.py
+++ b/py/tests/integration/pane_version_broadcast.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+
+# Copyright 2017-present, The Visdom Authors
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""What a subscribed browser actually receives when a pane is updated.
+
+``js/main.js`` applies an incremental ``window_update`` only when its
+``version`` is exactly one ahead of the pane the client already holds, and
+falls back to re-querying the entire environment otherwise. That makes the
+version sequence a wire contract, not an internal counter, so it is asserted
+here off a real subscriber socket rather than off the server's own state.
+
+The unit file ``py/tests/unit/pane_versioning.py`` pins the same rule at the
+handler; this one exists because the two halves of it -- the version the
+server keeps and the version it announces -- used to be able to disagree, and
+only the announced one is what the frontend gates on.
+"""
+
+import unittest
+
+import pytest
+
+from testutils import open_sub, sent
+from testutils.http import VisdomHTTPTestCase
+from testutils.payloads import content_args
+
+pytestmark = pytest.mark.integration
+
+
+class BroadcastTestCase(VisdomHTTPTestCase):
+    """Attaches a subscriber to ``main`` and reads the versions it is sent."""
+
+    def subscribe(self, eid="main"):
+        sub = open_sub(self._app)
+        sub.eid = eid
+        return sub
+
+    def update_versions(self, sub, win):
+        """Versions of the ``window_update`` packets broadcast for ``win``."""
+        return [
+            msg["version"]
+            for msg in sent(sub)
+            if isinstance(msg, dict)
+            and msg.get("command") == "window_update"
+            and msg.get("win") == win
+        ]
+
+    def assert_updates_are_consecutive(self, sub, win, count=3):
+        """The client starts at 1, so the run has to be 2, 3, ... with no gaps.
+
+        A repeated or stalled version is the failure this guards: it makes the
+        frontend drop the patch and reload the whole environment instead.
+        """
+        self.assertEqual(
+            self.update_versions(sub, win), list(range(2, 2 + count)), self.panes()
+        )
+
+
+class TestContentPaneBroadcasts(BroadcastTestCase):
+    """Panes that carry content rather than traces.
+
+    Each of these returns from ``UpdateHandler.update`` before the plot code
+    runs, which is how they came to be excluded from the version bump.
+    """
+
+    def test_text_updates_announce_consecutive_versions(self):
+        sub = self.subscribe()
+        win = self.create_text_window(content="line0")
+        for line in ("line1", "line2", "line3"):
+            self.update(win, [{"type": "text", "content": line}])
+        self.assert_updates_are_consecutive(sub, win)
+
+    def test_image_history_appends_announce_consecutive_versions(self):
+        sub = self.subscribe()
+        args = content_args(
+            "image_history",
+            {"src": "data:image/png;base64,AAA", "caption": "c0"},
+        )
+        win = self.create_window(args["data"], layout=args["layout"])
+        for caption in ("c1", "c2", "c3"):
+            self.update(
+                win,
+                [
+                    {
+                        "type": "image_history",
+                        "content": {
+                            "src": "data:image/png;base64,{}".format(caption),
+                            "caption": caption,
+                        },
+                    }
+                ],
+            )
+        self.assert_updates_are_consecutive(sub, win)
+
+    def test_plot_history_appends_announce_consecutive_versions(self):
+        sub = self.subscribe()
+        args = content_args(
+            "plot_history", {"data": [], "layout": {}, "caption": "frame0"}
+        )
+        win = self.create_window(args["data"], layout=args["layout"])
+        for i in (1, 2, 3):
+            self.update(
+                win,
+                [
+                    {
+                        "type": "plot_history",
+                        "content": {
+                            "data": [{"type": "scatter", "x": [i], "y": [i]}],
+                            "layout": {},
+                            "caption": "frame{}".format(i),
+                        },
+                    }
+                ],
+            )
+        self.assert_updates_are_consecutive(sub, win)
+
+
+class TestEmbeddingsBroadcasts(BroadcastTestCase):
+    """Embeddings build their patch by hand, bypassing ``update_packet``."""
+
+    def create_embeddings(self):
+        args = content_args(
+            "embeddings",
+            {"data": [[1, 2], [3, 4]], "labels": ["a", "b"], "selected": None},
+        )
+        return self.create_window(args["data"], layout=args["layout"])
+
+    def test_selections_announce_consecutive_versions(self):
+        sub = self.subscribe()
+        win = self.create_embeddings()
+        self.update(win, {"update_type": "EntitySelected", "selected": 1})
+        self.update(win, {"update_type": "RegionSelected", "points": [[5, 6]]})
+        self.update(win, {"update_type": "EntitySelected", "selected": 0})
+        self.assert_updates_are_consecutive(sub, win)
+
+    def test_the_patch_moves_the_client_to_the_announced_version(self):
+        """The packet's ``version`` is useless unless the patch installs it."""
+        sub = self.subscribe()
+        win = self.create_embeddings()
+        self.update(win, {"update_type": "EntitySelected", "selected": 1})
+        packet = [
+            msg
+            for msg in sent(sub)
+            if isinstance(msg, dict) and msg.get("command") == "window_update"
+        ][-1]
+        self.assertIn(
+            {"op": "replace", "path": "/version", "value": packet["version"]},
+            packet["content"],
+        )
+
+
+class TestPlotBroadcasts(BroadcastTestCase):
+    """The one pane type that already worked, kept honest."""
+
+    def test_trace_appends_announce_consecutive_versions(self):
+        sub = self.subscribe()
+        win = self.create_window(
+            [{"type": "scatter", "x": [1], "y": [1], "name": "t1"}]
+        )
+        for i in (2, 3, 4):
+            self.update(
+                win,
+                [{"type": "scatter", "x": [i], "y": [i], "name": "t1"}],
+                name="t1",
+                append=True,
+            )
+        self.assert_updates_are_consecutive(sub, win)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/py/tests/integration/pane_version_broadcast.py
+++ b/py/tests/integration/pane_version_broadcast.py
@@ -147,8 +147,12 @@ class TestEmbeddingsBroadcasts(BroadcastTestCase):
             for msg in sent(sub)
             if isinstance(msg, dict) and msg.get("command") == "window_update"
         ][-1]
+        # "add" rather than "replace": a pane the browser loaded from an env
+        # saved before panes carried a version has no ``/version`` member for
+        # "replace" to land on, and a patch that fails to apply reloads the
+        # whole environment. "add" overwrites when the member is there.
         self.assertIn(
-            {"op": "replace", "path": "/version", "value": packet["version"]},
+            {"op": "add", "path": "/version", "value": packet["version"]},
             packet["content"],
         )
 
@@ -169,6 +173,63 @@ class TestPlotBroadcasts(BroadcastTestCase):
                 append=True,
             )
         self.assert_updates_are_consecutive(sub, win)
+
+
+class TestRejectedUpdates(BroadcastTestCase):
+    """An update the server declines announces nothing.
+
+    A ``window_update`` whose version the client already holds fails the same
+    "exactly one ahead" check a stale one does, so a refusal that broadcast --
+    or that bumped without having changed anything -- sent the browser back for
+    the entire environment.
+    """
+
+    def update_packets(self, sub, win):
+        return [
+            msg
+            for msg in sent(sub)
+            if isinstance(msg, dict)
+            and msg.get("command") == "window_update"
+            and msg.get("win") == win
+        ]
+
+    def test_a_table_update_is_not_broadcast(self):
+        """``/update`` on a table is ignored; ``vis.table()`` replaces it."""
+        sub = self.subscribe()
+        args = content_args("table", [["a"]])
+        win = self.create_window(args["data"], layout=args["layout"])
+
+        self.update(win, [{"type": "table", "content": [["b"]]}])
+
+        self.assertEqual(self.update_packets(sub, win), [])
+        self.assertEqual(self.panes()[win]["version"], 1)
+
+    def test_an_unknown_embeddings_update_is_not_broadcast(self):
+        sub = self.subscribe()
+        args = content_args(
+            "embeddings",
+            {"data": [[1, 2], [3, 4]], "labels": ["a", "b"], "selected": None},
+        )
+        win = self.create_window(args["data"], layout=args["layout"])
+
+        self.update(win, {"update_type": "Nonsense"})
+
+        self.assertEqual(self.update_packets(sub, win), [])
+        self.assertEqual(self.panes()[win]["version"], 1)
+
+    def test_a_refusal_leaves_no_gap_in_the_announced_versions(self):
+        sub = self.subscribe()
+        args = content_args(
+            "embeddings",
+            {"data": [[1, 2], [3, 4]], "labels": ["a", "b"], "selected": None},
+        )
+        win = self.create_window(args["data"], layout=args["layout"])
+
+        self.update(win, {"update_type": "EntitySelected", "selected": 1})
+        self.update(win, {"update_type": "Nonsense"})
+        self.update(win, {"update_type": "RegionSelected", "points": [[5, 6]]})
+
+        self.assertEqual(self.update_versions(sub, win), [2, 3], self.panes())
 
 
 if __name__ == "__main__":

--- a/py/tests/unit/pane_versioning.py
+++ b/py/tests/unit/pane_versioning.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+
+# Copyright 2017-present, The Visdom Authors
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""``version`` rises once per accepted ``/update``, for every pane type.
+
+The frontend applies a broadcast patch only when ``cmd.version`` is exactly one
+ahead of the pane it already holds (``js/main.js``, ``updateWindow``); anything
+else makes it drop the patch and re-query the whole environment. That contract
+held for plot panes alone, because the bump lived in ``update_window()`` and
+``UpdateHandler.update`` returns before reaching it for text, image history,
+plot history and tables -- and embeddings never reach it at all, having their
+own packet builder. Those five types sat at version 1 update after update, so
+the comparison was permanently ``1 == 2`` and the incremental protocol was
+dead for the most common panes in the library.
+
+So the assertions here are per pane type rather than per branch: the bump now
+sits in ``update_packet``, and what needs pinning is that no dispatch arm can
+skip it. Each type is also checked for the ``/version`` op in the patch it
+broadcasts, since a server-side bump the patch does not carry desynchronises
+the frontend exactly as badly as no bump at all.
+"""
+
+import copy
+
+import pytest
+
+from visdom.server.defaults import (
+    DEFAULT_MAX_IMAGE_HISTORY,
+    DEFAULT_MAX_OLD_CONTENT,
+    DEFAULT_MAX_PLOT_HISTORY,
+    DEFAULT_MAX_TEXT_LINES,
+)
+from visdom.server.handlers.web_handlers import UpdateHandler
+from visdom.utils.shared_utils import get_rand_id
+
+pytestmark = pytest.mark.unit
+
+
+def _pane(ptype, **extra):
+    pane = {
+        "command": "window",
+        "version": 1,
+        "id": "win_{}".format(ptype),
+        "title": ptype,
+        "inflate": True,
+        "width": None,
+        "height": None,
+        "contentID": get_rand_id(),
+        "type": ptype,
+        "i": 0,
+    }
+    pane.update(extra)
+    return pane
+
+
+def _update_packet(p, args):
+    """One ``/update`` through the handler, with the production caps."""
+    return UpdateHandler.update_packet(
+        p,
+        copy.deepcopy(args),
+        DEFAULT_MAX_TEXT_LINES,
+        DEFAULT_MAX_OLD_CONTENT,
+        DEFAULT_MAX_IMAGE_HISTORY,
+        DEFAULT_MAX_PLOT_HISTORY,
+    )
+
+
+def _text():
+    return _pane("text", content="line0"), {"data": [{"content": "line1"}]}
+
+
+def _image_history():
+    pane = _pane(
+        "image_history",
+        content=[{"src": "data:image/png;base64,AAA", "caption": "img0"}],
+        selected=0,
+        show_slider=True,
+    )
+    args = {
+        "data": [
+            {
+                "type": "image_history",
+                "content": {
+                    "src": "data:image/png;base64,BBB",
+                    "caption": "img1",
+                },
+            }
+        ]
+    }
+    return pane, args
+
+
+def _plot_history():
+    pane = _pane(
+        "plot_history",
+        content=[{"data": [], "layout": {}, "caption": "frame0"}],
+        selected=0,
+        show_slider=True,
+    )
+    args = {
+        "data": [
+            {
+                "type": "plot_history",
+                "content": {
+                    "data": [{"type": "scatter", "x": [1], "y": [1]}],
+                    "layout": {},
+                    "caption": "frame1",
+                },
+            }
+        ]
+    }
+    return pane, args
+
+
+def _table():
+    pane = _pane("table", content=[["a"]], editable=True)
+    return pane, {"data": [{"type": "table", "content": [["b"]]}]}
+
+
+def _scatter():
+    pane = _pane(
+        "plot",
+        content={
+            "data": [{"type": "scatter", "x": [1], "y": [1], "name": "t1"}],
+            "layout": {},
+        },
+    )
+    args = {
+        "data": [{"type": "scatter", "x": [2], "y": [2], "name": "t1"}],
+        "name": "t1",
+        "append": True,
+    }
+    return pane, args
+
+
+def _heatmap():
+    pane = _pane(
+        "plot",
+        content={
+            "data": [
+                {
+                    "type": "heatmap",
+                    "z": [[1, 2]],
+                    "x": ["a", "b"],
+                    "y": ["c"],
+                    "name": "hm",
+                }
+            ],
+            "layout": {},
+        },
+    )
+    args = {
+        "data": [{"type": "heatmap", "z": [[3, 4]], "x": None, "y": ["d"]}],
+        "updateDir": "appendRow",
+        "append": True,
+    }
+    return pane, args
+
+
+# The types ``UpdateHandler.wrap_func`` accepts, one builder each. Embeddings
+# are absent on purpose: they take the ``update_embeddings_packet`` route and
+# are covered separately below.
+BUILDERS = {
+    "text": _text,
+    "image_history": _image_history,
+    "plot_history": _plot_history,
+    "table": _table,
+    "scatter": _scatter,
+    "heatmap": _heatmap,
+}
+
+
+def _embeddings_pane():
+    return _pane(
+        "embeddings",
+        content={
+            "data": [[1, 2], [3, 4]],
+            "labels": ["a", "b"],
+            "selected": None,
+            "has_previous": False,
+        },
+        old_content=[],
+    )
+
+
+def _versions_in(patch):
+    return [op["value"] for op in patch if op.get("path") == "/version"]
+
+
+# -- Every pane type bumps ---------------------------------------------------
+
+
+@pytest.mark.parametrize("ptype", sorted(BUILDERS))
+def test_one_update_bumps_the_version(ptype):
+    pane, args = BUILDERS[ptype]()
+    pane, _ = _update_packet(pane, args)
+    assert pane["version"] == 2
+
+
+@pytest.mark.parametrize("ptype", sorted(BUILDERS))
+def test_repeated_updates_bump_once_each(ptype):
+    """Four updates, four bumps -- the frontend's check allows no gaps."""
+    pane, args = BUILDERS[ptype]()
+    for expected in (2, 3, 4, 5):
+        pane, _ = _update_packet(pane, args)
+        assert pane["version"] == expected
+
+
+@pytest.mark.parametrize("ptype", sorted(BUILDERS))
+def test_the_patch_carries_the_new_version(ptype):
+    """The broadcast patch has to move the frontend's copy along with it.
+
+    A bump the patch leaves out desynchronises the two sides on the very next
+    update, which is the same full reload the bump exists to avoid.
+    """
+    pane, args = BUILDERS[ptype]()
+    pane, patch = _update_packet(pane, args)
+    assert _versions_in(patch) == [pane["version"]]
+
+
+@pytest.mark.parametrize("ptype", sorted(BUILDERS))
+def test_a_pane_without_a_version_is_given_one(ptype):
+    """Envs saved before panes carried a version must not raise ``KeyError``."""
+    pane, args = BUILDERS[ptype]()
+    del pane["version"]
+    pane, _ = _update_packet(pane, args)
+    assert pane["version"] == 2
+
+
+# -- Embeddings --------------------------------------------------------------
+
+
+def test_entity_selection_bumps_the_version():
+    pane = _embeddings_pane()
+    UpdateHandler.update_embeddings_packet(
+        pane,
+        {"data": {"update_type": "EntitySelected", "selected": 1}},
+        DEFAULT_MAX_OLD_CONTENT,
+    )
+    assert pane["version"] == 2
+
+
+def test_region_selection_bumps_the_version():
+    pane = _embeddings_pane()
+    UpdateHandler.update_embeddings_packet(
+        pane,
+        {"data": {"update_type": "RegionSelected", "points": [[5, 6]]}},
+        DEFAULT_MAX_OLD_CONTENT,
+    )
+    assert pane["version"] == 2
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        {"data": {"update_type": "EntitySelected", "selected": 1}},
+        {"data": {"update_type": "RegionSelected", "points": [[5, 6]]}},
+    ],
+    ids=["entity", "region"],
+)
+def test_the_embeddings_patch_carries_the_new_version(args):
+    pane = _embeddings_pane()
+    patch = UpdateHandler.update_embeddings_packet(pane, args, DEFAULT_MAX_OLD_CONTENT)
+    assert _versions_in(patch) == [pane["version"]]
+
+
+def test_an_unknown_embeddings_update_leaves_the_version_alone():
+    """Nothing was applied, so there is no revision to announce."""
+    pane = _embeddings_pane()
+    patch = UpdateHandler.update_embeddings_packet(
+        pane, {"data": {"update_type": "Nonsense"}}, DEFAULT_MAX_OLD_CONTENT
+    )
+    assert patch == []
+    assert pane["version"] == 1

--- a/py/tests/unit/pane_versioning.py
+++ b/py/tests/unit/pane_versioning.py
@@ -23,6 +23,14 @@ sits in ``update_packet``, and what needs pinning is that no dispatch arm can
 skip it. Each type is also checked for the ``/version`` op in the patch it
 broadcasts, since a server-side bump the patch does not carry desynchronises
 the frontend exactly as badly as no bump at all.
+
+The other half of the rule is that a version is only spent on an update that
+was actually applied. ``update()`` declines several of them -- a ``/update``
+aimed at a table pane, a slider move on a pane holding no frames, a heatmap
+append whose shape or column names do not fit the plot -- and an unrecognised
+embeddings ``update_type`` applies nothing either. Bumping for one of those
+announces a revision that carries no change, so the second half of this file
+pins the refusals: no bump, no patch, and nothing put on the wire.
 """
 
 import copy
@@ -138,7 +146,13 @@ def _scatter():
     return pane, args
 
 
-def _heatmap():
+def _heatmap(labels=False):
+    """An unlabelled heatmap appends rows indefinitely.
+
+    Passing ``labels`` gives the plot column names, which puts ``update()``
+    into the branch that checks an append's names against the plot's -- the
+    one that turns duplicates and mismatches away.
+    """
     pane = _pane(
         "plot",
         content={
@@ -146,8 +160,8 @@ def _heatmap():
                 {
                     "type": "heatmap",
                     "z": [[1, 2]],
-                    "x": ["a", "b"],
-                    "y": ["c"],
+                    "x": ["a", "b"] if labels else None,
+                    "y": ["c"] if labels else None,
                     "name": "hm",
                 }
             ],
@@ -155,21 +169,29 @@ def _heatmap():
         },
     )
     args = {
-        "data": [{"type": "heatmap", "z": [[3, 4]], "x": None, "y": ["d"]}],
+        "data": [
+            {
+                "type": "heatmap",
+                "z": [[3, 4]],
+                "x": None,
+                "y": ["d"] if labels else None,
+            }
+        ],
         "updateDir": "appendRow",
         "append": True,
     }
     return pane, args
 
 
-# The types ``UpdateHandler.wrap_func`` accepts, one builder each. Embeddings
-# are absent on purpose: they take the ``update_embeddings_packet`` route and
-# are covered separately below.
+# The types ``UpdateHandler.wrap_func`` accepts and applies, one builder each.
+# Embeddings are absent on purpose: they take the ``update_embeddings_packet``
+# route and are covered separately below. So is ``table``, whose builder feeds
+# the rejected-update cases instead -- ``update()`` refuses a ``/update`` on a
+# table outright, so there is never a revision for it to announce.
 BUILDERS = {
     "text": _text,
     "image_history": _image_history,
     "plot_history": _plot_history,
-    "table": _table,
     "scatter": _scatter,
     "heatmap": _heatmap,
 }
@@ -277,3 +299,157 @@ def test_an_unknown_embeddings_update_leaves_the_version_alone():
     )
     assert patch == []
     assert pane["version"] == 1
+
+
+# -- Rejected updates --------------------------------------------------------
+
+
+def _table_update():
+    """``/update`` on a table: ``update()`` logs it and applies nothing."""
+    return _table()
+
+
+def _empty_image_slider():
+    """A slider move on a pane holding no frames -- nothing to select."""
+    pane = _pane("image_history", content=[], selected=0, show_slider=True)
+    return pane, {"data": [{"type": "image_update_selected", "selected": 2}]}
+
+
+def _duplicate_heatmap_labels():
+    """An append carrying a column name the plot already has."""
+    pane, args = _heatmap(labels=True)
+    args["data"][0]["y"] = ["c"]
+    return pane, args
+
+
+def _mismatched_heatmap_row():
+    """An append whose rows are wider than the plot's."""
+    pane, args = _heatmap(labels=True)
+    args["data"][0]["z"] = [[3, 4, 5]]
+    return pane, args
+
+
+def _unnamed_heatmap_append():
+    """An append with no column names for a plot that has them."""
+    pane, args = _heatmap(labels=True)
+    args["data"][0]["y"] = None
+    return pane, args
+
+
+REJECTED = {
+    "table": _table_update,
+    "empty_image_slider": _empty_image_slider,
+    "duplicate_heatmap_labels": _duplicate_heatmap_labels,
+    "mismatched_heatmap_row": _mismatched_heatmap_row,
+    "unnamed_heatmap_append": _unnamed_heatmap_append,
+}
+
+
+@pytest.mark.parametrize("case", sorted(REJECTED))
+def test_a_rejected_update_is_not_a_revision(case):
+    """Nothing was applied, so there is no new state to number or to send."""
+    pane, args = REJECTED[case]()
+    before = copy.deepcopy(pane)
+    pane, patch = _update_packet(pane, args)
+    assert patch == []
+    assert pane == before
+
+
+@pytest.mark.parametrize("case", sorted(REJECTED))
+def test_repeated_rejections_never_advance_the_version(case):
+    pane, args = REJECTED[case]()
+    for _ in range(4):
+        pane, _ = _update_packet(pane, args)
+    assert pane["version"] == 1
+
+
+def test_a_rejection_leaves_no_gap_in_the_sequence():
+    """The accepted update after a refusal is the client's next number.
+
+    A refusal that bumped would put the pane two ahead of the browser, and the
+    frontend takes a patch only when it is exactly one ahead -- so the next
+    real update would be dropped and the whole environment re-queried, which is
+    the reload the bump exists to prevent.
+    """
+    pane, accepted = _heatmap()
+    pane, _ = _update_packet(pane, accepted)
+    assert pane["version"] == 2
+
+    too_wide = copy.deepcopy(accepted)
+    too_wide["data"][0]["z"] = [[1, 2, 3]]
+    pane, patch = _update_packet(pane, too_wide)
+    assert patch == []
+
+    pane, patch = _update_packet(pane, accepted)
+    assert pane["version"] == 3
+    assert _versions_in(patch) == [3]
+
+
+# -- What the subscriber is sent ---------------------------------------------
+#
+# ``wrap_func`` is driven directly here rather than ``update_packet``, because
+# the empty patch is only half the fix: the handler also has to decline to
+# broadcast it. A ``window_update`` carrying the version the client already
+# holds fails the frontend's check just as a stale one does.
+
+
+def _serve(handler, pane, win="win_0", eid="main"):
+    """Put ``pane`` in the handler's state and return its window id."""
+    pane["id"] = win
+    handler.state[eid] = {"jsons": {win: pane}, "reload": {}}
+    return win
+
+
+def _update(handler, win, data, eid="main"):
+    UpdateHandler.wrap_func(handler, {"win": win, "eid": eid, "data": data})
+
+
+def test_a_rejected_update_is_not_broadcast(handler):
+    sub = handler.add_sub()
+    pane, args = _table()
+    win = _serve(handler, pane)
+
+    _update(handler, win, args["data"])
+
+    assert sub.sent == []
+    assert handler.dirtied == []
+    assert handler.written == [win]
+
+
+def test_an_unknown_embeddings_update_is_not_broadcast(handler):
+    """The empty patch used to go out anyway, announcing an unmoved version."""
+    sub = handler.add_sub()
+    win = _serve(handler, _embeddings_pane())
+
+    _update(handler, win, {"update_type": "Nonsense"})
+
+    assert sub.sent == []
+    assert handler.dirtied == []
+    assert handler.written == [win]
+
+
+def test_an_applied_embeddings_update_is_still_broadcast(handler):
+    sub = handler.add_sub()
+    win = _serve(handler, _embeddings_pane())
+
+    _update(handler, win, {"update_type": "EntitySelected", "selected": 1})
+
+    packet = sub.last("window_update")
+    assert packet["version"] == 2
+    assert {"op": "add", "path": "/version", "value": 2} in packet["content"]
+    assert handler.dirtied == ["main"]
+
+
+def test_a_refused_embeddings_update_leaves_no_gap(handler):
+    """The versions a subscriber sees stay dense across a refusal."""
+    sub = handler.add_sub()
+    win = _serve(handler, _embeddings_pane())
+
+    _update(handler, win, {"update_type": "EntitySelected", "selected": 1})
+    _update(handler, win, {"update_type": "Nonsense"})
+    _update(handler, win, {"update_type": "RegionSelected", "points": [[5, 6]]})
+
+    versions = [
+        msg["version"] for msg in sub.sent if msg.get("command") == "window_update"
+    ]
+    assert versions == [2, 3]

--- a/py/tests/unit/window_builder.py
+++ b/py/tests/unit/window_builder.py
@@ -286,16 +286,16 @@ def test_caption_is_skipped_when_content_is_not_a_dict():
     assert text_pane["content"] == "hello"
 
 
-def test_version_is_bumped_once_per_update(titled_pane):
+def test_version_is_left_to_the_caller(titled_pane):
+    """``update_window`` used to own the version bump, and could not.
+
+    Only plot panes reach it: ``UpdateHandler.update`` returns ahead of it for
+    text, image and plot history and tables, so those types never got a bump
+    at all. The increment now sits in ``UpdateHandler.update_packet``, which
+    runs once for every type -- see ``py/tests/unit/pane_versioning.py``.
+    """
     update_window(titled_pane, {"opts": {"title": "a"}})
-    assert titled_pane["version"] == 2
-    update_window(titled_pane, {"opts": {"title": "b"}})
-    assert titled_pane["version"] == 3
-
-
-def test_version_is_bumped_even_for_an_empty_update(titled_pane):
-    update_window(titled_pane, {})
-    assert titled_pane["version"] == 2
+    assert titled_pane["version"] == 1
 
 
 def test_returns_the_same_pane_object(titled_pane):

--- a/py/visdom/server/handlers/web_handlers.py
+++ b/py/visdom/server/handlers/web_handlers.py
@@ -144,6 +144,16 @@ class UpdateHandler(BaseHandler):
             max_plot_history,
         )
         p["contentID"] = get_rand_id()
+        # Bump here, not in ``update_window()``. Every pane type that carries
+        # content rather than traces -- text, image_history, plot_history and
+        # table -- returns from ``update()`` before ``update_window()`` is ever
+        # reached, so those panes stayed pinned at version 1 while the server
+        # went on broadcasting ``window_update`` for them. The frontend only
+        # applies a patch whose version is exactly one ahead of the pane it
+        # holds, so with both sides stuck at 1 every update fell through to a
+        # full environment reload. Bumping once per accepted update, ahead of
+        # the diff, puts the new version in the patch for every type.
+        p["version"] = p.get("version", 1) + 1
 
         patch = jsonpatch.make_patch(old_p, p)
         return p, patch.patch
@@ -156,11 +166,13 @@ class UpdateHandler(BaseHandler):
             selected = args["data"]["selected"]
             p["content"]["selected"] = selected
             p["contentID"] = content_id
+            p["version"] = p.get("version", 1) + 1
             # `selected` may not exist yet on the first selection, so use "add"
             # (which also overwrites when the key is already present).
             return [
                 {"op": "add", "path": "/content/selected", "value": selected},
                 {"op": "replace", "path": "/contentID", "value": content_id},
+                {"op": "replace", "path": "/version", "value": p["version"]},
             ]
         if update_type == "RegionSelected":
             old_data = p["content"]["data"]
@@ -173,11 +185,13 @@ class UpdateHandler(BaseHandler):
             p["content"]["has_previous"] = True
             p["content"]["selected"] = None
             p["contentID"] = content_id
+            p["version"] = p.get("version", 1) + 1
             return [
                 {"op": "replace", "path": "/content/data", "value": new_data},
                 {"op": "add", "path": "/content/has_previous", "value": True},
                 {"op": "add", "path": "/content/selected", "value": None},
                 {"op": "replace", "path": "/contentID", "value": content_id},
+                {"op": "replace", "path": "/version", "value": p["version"]},
             ]
         return []
 

--- a/py/visdom/server/handlers/web_handlers.py
+++ b/py/visdom/server/handlers/web_handlers.py
@@ -143,10 +143,22 @@ class UpdateHandler(BaseHandler):
             max_image_history,
             max_plot_history,
         )
+        # ``update()`` hands the pane straight back when it turns an update
+        # down: a ``/update`` aimed at a table, an image slider move on a pane
+        # holding no frames, a heatmap append whose shape does not line up with
+        # the plot it is aimed at. ``old_p`` deep-copied everything ``update()``
+        # mutates in place, so an unchanged pane here means nothing was applied.
+        # A rejected update has no revision to announce: bumping for one spends
+        # a version on a patch that carries no change and rerolls ``contentID``
+        # to make the frontend redraw the pane it already has. Leave both alone
+        # and hand back an empty patch, which ``wrap_func`` declines to send.
+        if p == old_p:
+            return p, []
+
         p["contentID"] = get_rand_id()
         # Bump here, not in ``update_window()``. Every pane type that carries
-        # content rather than traces -- text, image_history, plot_history and
-        # table -- returns from ``update()`` before ``update_window()`` is ever
+        # content rather than traces -- text, image_history and plot_history --
+        # returns from ``update()`` before ``update_window()`` is ever
         # reached, so those panes stayed pinned at version 1 while the server
         # went on broadcasting ``window_update`` for them. The frontend only
         # applies a patch whose version is exactly one ahead of the pane it
@@ -172,7 +184,7 @@ class UpdateHandler(BaseHandler):
             return [
                 {"op": "add", "path": "/content/selected", "value": selected},
                 {"op": "replace", "path": "/contentID", "value": content_id},
-                {"op": "replace", "path": "/version", "value": p["version"]},
+                {"op": "add", "path": "/version", "value": p["version"]},
             ]
         if update_type == "RegionSelected":
             old_data = p["content"]["data"]
@@ -191,7 +203,7 @@ class UpdateHandler(BaseHandler):
                 {"op": "add", "path": "/content/has_previous", "value": True},
                 {"op": "add", "path": "/content/selected", "value": None},
                 {"op": "replace", "path": "/contentID", "value": content_id},
-                {"op": "replace", "path": "/version", "value": p["version"]},
+                {"op": "add", "path": "/version", "value": p["version"]},
             ]
         return []
 
@@ -482,8 +494,17 @@ class UpdateHandler(BaseHandler):
             diff_packet = UpdateHandler.update_embeddings_packet(
                 p, args, handler.max_old_content
             )
-            UpdateHandler.broadcast_window_update(handler, args, eid, p, diff_packet)
-            handler.mark_dirty(eid)
+            # An unrecognised ``update_type`` applies nothing and returns an
+            # empty patch. Announcing it would repeat the version the client
+            # already holds, which fails the frontend's "exactly one ahead"
+            # check and reloads the whole environment -- the reload the bump
+            # exists to prevent. Nothing changed, so nothing needs saving
+            # either.
+            if diff_packet:
+                UpdateHandler.broadcast_window_update(
+                    handler, args, eid, p, diff_packet
+                )
+                handler.mark_dirty(eid)
             handler.write(p["id"])
             return
 
@@ -502,6 +523,16 @@ class UpdateHandler(BaseHandler):
                 handler.write(str(exc))
                 return
             raise
+        if not diff_packet:
+            # ``update_packet`` refused the update and left the pane on the
+            # version the browser already holds. A ``window_update`` repeating
+            # that version fails the frontend's "exactly one ahead" check and
+            # sends it back for the whole environment, so say nothing at all --
+            # there is no change to save either. The pane id is still returned
+            # as the ack, as it is for an update that did land.
+            handler.write(p["id"])
+            return
+
         # send the smaller of the patch and the updated pane
         if len(stringify(p)) <= len(stringify(diff_packet)):
             broadcast_msg = dict(p)

--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -430,7 +430,6 @@ def update_window(p, args):
             for i, d in enumerate(pdata):
                 if i < len(legend):
                     d["name"] = legend[i]
-    p["version"] += 1
     return p
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The incremental update protocol is gated on a version number. The server broadcasts `window_update` carrying the pane's new version, and `main.js` applies the patch only when that version is exactly one ahead of the pane it already holds:

```javascript
cmd.version == storeData.panes[cmd.win].version + 1
```

Anything else falls through to `sendEnvQuery()` and reloads the whole environment.

The version bump lived in `update_window()`, which only plot panes reach. `UpdateHandler.update()` dispatches on `p["type"]` and returns early for `text`, `image_history`, `plot_history`, and `table`, all before `update_window()` is called. Embeddings never go through `update()` at all, since `update_embeddings_packet()` builds their packet by hand and did not touch the version either.

As a result, five of the six updatable pane types remained at version `1` for their entire lifetime while the server continued broadcasting updates for them.

With both sides pinned at `1`, the frontend's check effectively becomes:

```text
1 == 2
```

which can never be true. Every update therefore took the full-environment reload branch.

The incremental update protocol was effectively disabled for the most commonly used pane types in the library, particularly `text` and `image_history`.

After four updates, the server-side versions were:

```text
text          version = 1
image_history version = 1
plot_history  version = 1
table         version = 1
embeddings    version = 1
scatter       version = 5   <- the only type that worked
```

A broadcast captured from a subscribed socket showed:

```text
command=window_update  version=1
command=window_update  version=1
command=window_update  version=1
```

This change moves the version increment out of `update_window()` and into `update_packet()`, which runs once per accepted update regardless of pane type.

The increment is performed before the `jsonpatch` diff so that the new version is included in the generated patch. If the version is bumped after creating the diff, the patch would not contain the new version and could still leave the client desynchronized.

`update_embeddings_packet()` now bumps the version and appends the `/version` operation itself, matching the behavior already used by the socket handlers for `update_comment` and `update_plot_layout`.

The version is updated using:

```python
p["version"] = p.get("version", 1) + 1
```

rather than:

```python
p["version"] += 1
```

This allows environments saved before panes carried a version field to be repaired instead of raising a `KeyError`.

`update_window()` has no other production caller, so no other code path loses the version bump. The plot path reaches `update_packet()` on exactly the same updates it did before, so its version sequence remains unchanged.

## Motivation and Context

The incremental update protocol depends on the client receiving a version exactly one greater than the version it currently holds.

Previously, only the plot path incremented the pane version. The other pane types continued broadcasting updates with version `1`, causing the frontend's sequential-version check to fail on every update.

This meant the server was broadcasting incremental updates, but the client could not apply them and instead reloaded the entire environment.

Moving the version bump into the common `update_packet()` path ensures that every accepted pane update advances the version consistently and that the new version is included in the broadcast patch.

The embeddings path is handled separately because `update_embeddings_packet()` constructs its packet manually.

## How Has This Been Tested?

Unit coverage verifies that:

* All six pane types increment their version once per update.
* Versions continue incrementing correctly across multiple updates.
* The new version is included in the generated patch.
* Panes without an existing `version` field are handled correctly.
* An unrecognised embeddings update type remains a no-op.
* No broadcast is produced for an unrecognised embeddings update type.

Integration coverage reads the versions from a real subscriber socket over an HTTP round trip. This verifies the version actually announced to the client, rather than only checking the server-side stored value, since the announced version is what the frontend uses for its incremental-update gate.

The expected announced sequence is:

```text
2, 3, 4
```

with no gaps.

## Screenshots (if appropriate):

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:

* [ ] I adapted the version number under `py/visdom/VERSION` according to [[Semantic Versioning](https://semver.org/)](https://semver.org/)
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.

## Summary by Sourcery

Restore reliable incremental pane updates by advancing versions in the common accepted-update path and synchronizing the embeddings path.

Bug Fixes:
- Ensure every accepted pane update advances and broadcasts a consecutive version, restoring incremental client updates for text, image history, plot history, table, embeddings, and plot panes.
- Prevent rejected or unrecognized updates from changing versions or producing window-update broadcasts.

Enhancements:
- Handle panes from older saved environments that do not yet contain a version field.
- Keep embeddings patches synchronized by including their version changes explicitly.

Tests:
- Add unit and integration coverage for version progression, patch contents, legacy panes, rejected updates, and versions observed by subscribed clients.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Pane version numbers now increment consistently for accepted updates across supported pane types.
  - Browser update notifications now include the latest pane version without gaps.
  - Rejected or unchanged updates no longer trigger unnecessary notifications or version changes.
  - Embeddings updates correctly apply the announced version to the client.
  - Panes saved without a version now receive one automatically.
- **Tests**
  - Expanded coverage for version updates, rejected changes, and browser notifications across supported pane types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->