### PR TITLE
fix: answer opts-only /update requests instead of raising KeyError

### DIFF
--- a/py/tests/unit/update_opts_only.py
+++ b/py/tests/unit/update_opts_only.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+
+# Copyright 2017-present, The Visdom Authors
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""``/update`` requests that carry ``opts``/``layout`` but no ``data``.
+
+This is the shape ``Visdom.update_window_opts()`` sends. Only plot panes ever
+handled it; text, image_history, plot_history, table and embeddings panes
+indexed ``args["data"]`` unconditionally and answered HTTP 500.
+"""
+
+import copy
+
+import pytest
+import tornado.web
+
+from visdom.server.handlers.web_handlers import UpdateHandler
+from visdom.utils.shared_utils import get_rand_id
+
+from testutils.fakes import FakeHandler
+
+pytestmark = pytest.mark.unit
+
+
+def _pane(ptype, **extra):
+    pane = {
+        "command": "window",
+        "version": 1,
+        "id": "win_{}".format(ptype),
+        "title": ptype,
+        "contentID": get_rand_id(),
+        "type": ptype,
+    }
+    pane.update(extra)
+    return pane
+
+
+def _plot_pane():
+    return _pane(
+        "plot",
+        content={
+            "data": [{"type": "scatter", "x": [1], "y": [1], "name": "a"}],
+            "layout": {},
+        },
+    )
+
+
+def _text_pane():
+    return _pane("text", content="line0")
+
+
+def _image_history_pane():
+    return _pane("image_history", content=[{"src": "img0"}], selected=0)
+
+
+def _plot_history_pane():
+    return _pane("plot_history", content=[{"data": [], "layout": {}}], selected=0)
+
+
+def _table_pane():
+    return _pane("table", content=[["a", "b"]], editable=True)
+
+
+def _embeddings_pane():
+    return _pane(
+        "embeddings",
+        content={"data": [[1, 2]], "selected": None, "has_previous": False},
+        old_content=[],
+    )
+
+
+def _image_pane():
+    return _pane("image", content={"src": "img0", "caption": None})
+
+
+PANE_CASES = [
+    ("plot", _plot_pane),
+    ("text", _text_pane),
+    ("image_history", _image_history_pane),
+    ("plot_history", _plot_history_pane),
+    ("table", _table_pane),
+    ("embeddings", _embeddings_pane),
+]
+
+CONTENT_PRESERVING_CASES = [case for case in PANE_CASES if case[0] != "plot"]
+
+OPTS = {"title": "renamed", "width": 400}
+LAYOUT = {"title": {"text": "renamed"}, "margin": {"l": 60, "r": 60}}
+
+
+def _opts_only(pane, **extra):
+    handler = FakeHandler(state={"main": {"jsons": {pane["id"]: pane}, "reload": {}}})
+    sub = handler.add_sub(eid="main")
+    args = {"win": pane["id"], "eid": "main"}
+    args.update(extra)
+    UpdateHandler.wrap_func(handler, args)
+    return handler, sub
+
+
+@pytest.mark.parametrize("name, build", PANE_CASES, ids=[c[0] for c in PANE_CASES])
+def test_opts_reach_the_pane(name, build):
+    pane = build()
+    _opts_only(pane, layout=copy.deepcopy(LAYOUT), opts=dict(OPTS))
+    assert pane["title"] == "renamed"
+    assert pane["width"] == 400
+
+
+@pytest.mark.parametrize("name, build", PANE_CASES, ids=[c[0] for c in PANE_CASES])
+def test_the_update_is_broadcast_with_the_next_version(name, build):
+    pane = build()
+    handler, sub = _opts_only(pane, layout=copy.deepcopy(LAYOUT), opts=dict(OPTS))
+    assert pane["version"] == 2
+    assert [msg["version"] for msg in sub.sent] == [2]
+    assert handler.dirtied == ["main"]
+
+
+@pytest.mark.parametrize(
+    "name, build",
+    CONTENT_PRESERVING_CASES,
+    ids=[c[0] for c in CONTENT_PRESERVING_CASES],
+)
+def test_the_content_is_left_alone(name, build):
+    pane = build()
+    before = copy.deepcopy(pane["content"])
+    _opts_only(pane, layout=copy.deepcopy(LAYOUT), opts=dict(OPTS))
+    assert pane["content"] == before
+
+
+def test_a_plot_pane_still_takes_the_layout():
+    pane = _plot_pane()
+    _opts_only(pane, layout=copy.deepcopy(LAYOUT), opts=dict(OPTS))
+    assert pane["content"]["layout"]["title"] == {"text": "renamed"}
+    assert pane["content"]["data"] == [
+        {"type": "scatter", "x": [1], "y": [1], "name": "a"}
+    ]
+
+
+def test_a_legend_opt_does_not_reach_a_pane_without_traces():
+    pane = _text_pane()
+    _opts_only(pane, opts={"title": "renamed", "legend": ["a", "b"]})
+    assert pane["title"] == "renamed"
+    assert pane["content"] == "line0"
+
+
+def test_a_legend_opt_still_renames_plot_traces():
+    pane = _plot_pane()
+    _opts_only(pane, opts={"legend": ["b"]})
+    assert pane["content"]["data"][0]["name"] == "b"
+
+
+def test_an_empty_data_list_is_treated_as_opts_only():
+    pane = _text_pane()
+    _opts_only(pane, data=[], opts=dict(OPTS))
+    assert pane["title"] == "renamed"
+    assert pane["content"] == "line0"
+
+
+def test_a_pane_type_that_cannot_be_updated_is_reported():
+    pane = _image_pane()
+    handler, sub = _opts_only(pane, layout=copy.deepcopy(LAYOUT), opts=dict(OPTS))
+    assert "win is not scatter" in handler.body
+    assert "was image" in handler.body
+    assert sub.sent == []
+    assert handler.dirtied == []
+
+
+def test_a_bar_pane_still_reports_its_trace_type():
+    pane = _pane(
+        "plot",
+        content={"data": [{"type": "bar", "x": ["a"], "y": [1]}], "layout": {}},
+    )
+    handler, _ = _opts_only(pane, opts=dict(OPTS))
+    assert "was bar" in handler.body
+
+
+def test_a_named_update_without_data_is_a_client_error():
+    pane = _plot_pane()
+    with pytest.raises(tornado.web.HTTPError) as excinfo:
+        _opts_only(pane, name="a", opts=dict(OPTS))
+    assert excinfo.value.status_code == 400

--- a/py/tests/unit/update_opts_only.py
+++ b/py/tests/unit/update_opts_only.py
@@ -168,13 +168,54 @@ def test_a_pane_type_that_cannot_be_updated_is_reported():
     assert handler.dirtied == []
 
 
-def test_a_bar_pane_still_reports_its_trace_type():
+OTHER_TRACE_TYPES = [
+    ("bar", {"type": "bar", "x": ["a"], "y": [1]}),
+    ("boxplot", {"type": "box", "y": [1, 2, 3]}),
+    ("pie", {"type": "pie", "values": [1, 2], "labels": ["a", "b"]}),
+    ("histogram", {"type": "histogram", "x": [1, 2, 3]}),
+]
+
+OTHER_TRACE_IDS = [case[0] for case in OTHER_TRACE_TYPES]
+
+
+def _trace_pane(trace):
+    return _pane("plot", content={"data": [dict(trace)], "layout": {}})
+
+
+@pytest.mark.parametrize("name, trace", OTHER_TRACE_TYPES, ids=OTHER_TRACE_IDS)
+def test_opts_reach_a_pane_whose_traces_are_not_scatter(name, trace):
+    pane = _trace_pane(trace)
+    handler, sub = _opts_only(pane, layout=copy.deepcopy(LAYOUT), opts=dict(OPTS))
+    assert "win is not" not in handler.body
+    assert pane["title"] == "renamed"
+    assert pane["content"]["layout"]["title"] == {"text": "renamed"}
+    assert [msg["version"] for msg in sub.sent] == [2]
+
+
+@pytest.mark.parametrize("name, trace", OTHER_TRACE_TYPES, ids=OTHER_TRACE_IDS)
+def test_a_data_update_on_those_panes_is_still_refused(name, trace):
+    # only the opts path is opened up. update() reads x and y straight off a
+    # trace, which a pie or a y-only boxplot has not got.
+    pane = _trace_pane(trace)
+    handler, sub = _opts_only(pane, data=[dict(trace)], append=True, opts=dict(OPTS))
+    assert "win is not scatter" in handler.body
+    assert sub.sent == []
+    assert handler.dirtied == []
+
+
+def test_a_plot_built_without_a_layout_still_takes_one():
+    pane = _pane("plot", content={"data": [{"type": "scatter", "x": [1], "y": [1]}]})
+    _opts_only(pane, layout=copy.deepcopy(LAYOUT), opts=dict(OPTS))
+    assert pane["content"]["layout"] == copy.deepcopy(LAYOUT)
+
+
+def test_a_layout_that_is_not_a_dict_is_replaced_on_a_plot():
     pane = _pane(
         "plot",
-        content={"data": [{"type": "bar", "x": ["a"], "y": [1]}], "layout": {}},
+        content={"data": [{"type": "scatter", "x": [1], "y": [1]}], "layout": None},
     )
-    handler, _ = _opts_only(pane, opts=dict(OPTS))
-    assert "was bar" in handler.body
+    _opts_only(pane, layout={"showlegend": True}, opts=dict(OPTS))
+    assert pane["content"]["layout"] == {"showlegend": True}
 
 
 def test_a_named_update_without_data_is_a_client_error():

--- a/py/visdom/server/handlers/web_handlers.py
+++ b/py/visdom/server/handlers/web_handlers.py
@@ -187,6 +187,9 @@ class UpdateHandler(BaseHandler):
     def update(
         p, args, max_text_lines, max_old_content, max_image_history, max_plot_history
     ):
+        if not args.get("data") and p["type"] != "plot":
+            return update_window(p, args)
+
         # Update text in window, separated by a line break
         if p["type"] == "text":
             p["content"] += "<br>" + args["data"][0]["content"]
@@ -250,7 +253,7 @@ class UpdateHandler(BaseHandler):
         idxs = list(range(len(pdata)))
 
         if name is not None:
-            if not delete and len(new_data) != 1:
+            if not delete and (not new_data or len(new_data) != 1):
                 raise tornado.web.HTTPError(
                     400, reason="a named trace update takes exactly one data entry"
                 )
@@ -444,29 +447,30 @@ class UpdateHandler(BaseHandler):
             handler.write("win is not image_history; was {}".format(p["type"]))
             return
 
+        content = p.get("content")
+        traces = content.get("data") if isinstance(content, dict) else None
+        first = traces[0] if isinstance(traces, list) and traces else None
+        trace_type = first.get("type") if isinstance(first, dict) else None
+        is_plot = isinstance(traces, list) and (
+            not traces
+            or trace_type in ["scatter", "scatter3d", "scattergl", "custom", "heatmap"]
+        )
+
         if not (
             p["type"] == "text"
             or p["type"] == "image_history"
             or p["type"] == "plot_history"
             or p["type"] == "embeddings"
             or p["type"] == "table"
-            or (
-                len(p["content"]["data"]) == 0
-                or p["content"]["data"][0]["type"]
-                in ["scatter", "scatter3d", "scattergl", "custom", "heatmap"]
-            )
+            or is_plot
         ):
             handler.write(
                 "win is not scatter, heatmap, custom, image_history, plot_history, embeddings, or text; "
-                "was {}".format(
-                    p["content"]["data"][0]["type"]
-                    if len(p["content"]["data"]) > 0
-                    else "empty"
-                )
+                "was {}".format(trace_type or p["type"])
             )
             return
 
-        if p["type"] == "embeddings":
+        if p["type"] == "embeddings" and args.get("data"):
             diff_packet = UpdateHandler.update_embeddings_packet(
                 p, args, handler.max_old_content
             )

--- a/py/visdom/server/handlers/web_handlers.py
+++ b/py/visdom/server/handlers/web_handlers.py
@@ -451,8 +451,12 @@ class UpdateHandler(BaseHandler):
         traces = content.get("data") if isinstance(content, dict) else None
         first = traces[0] if isinstance(traces, list) and traces else None
         trace_type = first.get("type") if isinstance(first, dict) else None
+        # opts and layout apply to every plot pane. Only a data update cares
+        # about the trace type, because update() reads x/y straight off it.
+        opts_only = not args.get("data")
         is_plot = isinstance(traces, list) and (
             not traces
+            or opts_only
             or trace_type in ["scatter", "scatter3d", "scattergl", "custom", "heatmap"]
         )
 

--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -414,10 +414,12 @@ def extract_eid(args):
 def update_window(p, args):
     """Adds new args to a window if they exist"""
     content = p["content"]
+    pdata = content.get("data") if isinstance(content, dict) else None
     layout_update = args.get("layout", {})
-    for layout_name, layout_val in layout_update.items():
-        if layout_val is not None:
-            content["layout"][layout_name] = layout_val
+    if isinstance(content, dict) and isinstance(content.get("layout"), dict):
+        for layout_name, layout_val in layout_update.items():
+            if layout_val is not None:
+                content["layout"][layout_name] = layout_val
     opts = args.get("opts", {})
     for opt_name, opt_val in opts.items():
         if opt_val is not None:
@@ -427,14 +429,13 @@ def update_window(p, args):
             else:
                 p[opt_name] = opt_val
 
-    if "legend" in opts:
+    if "legend" in opts and isinstance(pdata, list):
         legend = opts["legend"]
-        pdata = p["content"]["data"]
         name = args.get("name")
         if name is not None:
             if len(legend) > 0:
                 for d in pdata:
-                    if d.get("name") == name:
+                    if isinstance(d, dict) and d.get("name") == name:
                         d["name"] = legend[0]
         else:
             if len(legend) < len(pdata):
@@ -445,7 +446,7 @@ def update_window(p, args):
                     len(pdata),
                 )
             for i, d in enumerate(pdata):
-                if i < len(legend):
+                if i < len(legend) and isinstance(d, dict):
                     d["name"] = legend[i]
     p["version"] += 1
     return p

--- a/py/visdom/utils/server_utils.py
+++ b/py/visdom/utils/server_utils.py
@@ -415,11 +415,17 @@ def update_window(p, args):
     """Adds new args to a window if they exist"""
     content = p["content"]
     pdata = content.get("data") if isinstance(content, dict) else None
-    layout_update = args.get("layout", {})
-    if isinstance(content, dict) and isinstance(content.get("layout"), dict):
-        for layout_name, layout_val in layout_update.items():
-            if layout_val is not None:
-                content["layout"][layout_name] = layout_val
+    layout_update = args.get("layout") or {}
+    if layout_update and isinstance(content, dict):
+        layout = content.get("layout")
+        if not isinstance(layout, dict) and p.get("type") == "plot":
+            # a plot built without a layout still has to accept one; the other
+            # pane types have no layout and must not grow one
+            layout = content["layout"] = {}
+        if isinstance(layout, dict):
+            for layout_name, layout_val in layout_update.items():
+                if layout_val is not None:
+                    layout[layout_name] = layout_val
     opts = args.get("opts", {})
     for opt_name, opt_val in opts.items():
         if opt_val is not None:


### PR DESCRIPTION
## Description

`update_window_opts()` returns a 500 on text, image_history, plot_history and
embeddings panes. Plot panes are the only ones it works on.

The payload that method sends is `{win, eid, layout, opts}`, with no `data` keyat all. `wrap_func` is happy with that, it only rejects a request when `data`,`layout` and `opts` are all missing (the check from #1480). The trouble is
`update()`, which switches on the pane type before it reaches the opts/layout merge, and the text, image_history and plot_history branches read `args["data"][0]` immediately. Embeddings does the same with `args["data"]["update_type"]`. That's a `KeyError`, and `wrap_func` only catches `TypeError` and `ValueError`, so it goes all the way up as a 500:

```
File "py/visdom/server/handlers/web_handlers.py", line 192, in update
  p["content"] += "<br>" + args["data"][0]["content"]
KeyError: 'data'
```

What this changes:

`update()` hands a data-less request to `update_window()` unless it's a plot pane, which is what plot panes were already doing anyway.
`update_window()` needed some work to cope with being called for these types.Text content is a plain string and image/plot history content is a list, so `content["layout"]` and `p["content"]["data"]` can't be read blindly any more.
A pane with no traces in it now just skips the legend rename.

While in there I noticed the pane type check right above has the same problem. It reads `p["content"]["data"]` to work out whether the pane is a plot, so an `/update` aimed at an image, properties or network pane blows up with a
`KeyError` before it can even write out the "win is not scatter..." rejection. That's fixed too, it now reports the type it turned down ("was image") instead of crashing. Plot panes still say "was bar" like before.

Two small ones that fell out of the same code: an empty `data` list no longerraises `IndexError` on a text pane, and a named update with no data comes back as a 400 instead of a `TypeError` out of `len(None)`.

## Motivation and Context

`update_window_opts()` is the only way to change a window's title or size after creating it, and it didn't work on four of the six pane types `/update` accepts. Two of those, image_history and plot_history, are plot windows, which is what the method's docstring says it's for in the first place.

Follow-up to #1479. #1480 fixed the case where the request carries no useful fields at all, but the `layout`/`opts`-only path still lands on the same `KeyError`. It's easier to hit than the original report as well, that one needed a hand-written HTTP request while this is one line of ordinary API use:

```python
viz = visdom.Visdom()
win = viz.text("hello world")
viz.update_window_opts(win, {"title": "New title"})   # 500 on dev
```

## How Has This Been Tested?

Ran two servers side by side, one on `dev` and one on this branch, and sent them the same request:

```
dev      viz.update_window_opts(win, {'title': 'after'})  ->  HTTP 500
PR       viz.update_window_opts(win, {'title': 'after'})  ->  HTTP 200  my_text_pane

--- dev server log ---
KeyError: 'data'
ERROR:tornado.access:500 POST /update (::1) 2.91ms
```

On this branch the saved pane afterwards reads `title = after` and
`version = 2`, with `content = hello world` left alone.

New tests live in `py/tests/unit/update_opts_only.py`. They push the exact payload `update_window_opts` sends through `wrap_func` for all six pane types that accept `/update`, and cover the rejection path and the two edge cases as well. 18 of the 24 fail on `dev`, all 24 pass here.

Rest of the suite on Python 3.12 / macOS, nothing else moved: `pytest -m unit` 1378 passed, `pytest py/tests/integration` 584 passed, `black` reports nochanges. I skipped `keras_logger`, `sklearn_logger` and `test_xgboost_logger` locally because xgboost can't load libomp on this machine, unrelated to any of this.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:

- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Summary by Sourcery

Fix opts-only window updates so pane options and layouts are applied safely without requiring trace data.

Bug Fixes:
- Fix `/update` requests containing only layout or option changes so they succeed across supported pane types instead of raising `KeyError` and returning HTTP 500.
- Return clear client errors for invalid named updates and safely handle empty data updates.
- Prevent unsupported pane types and panes without traces from crashing during update validation.

Enhancements:
- Preserve non-plot pane content while applying window options and layouts, and support missing or invalid plot layouts.
- Apply legend updates only when trace data is present.

Tests:
- Add unit coverage for opts-only updates across pane types, rejected updates, content preservation, layout handling, legend behavior, and edge cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed options- and layout-only updates without replacing existing window content.
  * Preserved non-plot content during options-only updates.
  * Improved layout and legend handling across supported chart types.
  * Prevented malformed plot content, layouts, and trace data from causing errors.
  * Rejected invalid named trace updates before changing window state.
  * Corrected update handling for embeddings and unsupported window types.
  * Ensured delete requests with empty data still clear plot traces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->