### PR TITLE
 perf: build the append patch instead of diffing the whole pane

### DIFF
--- a/py/tests/unit/update_append_patch.py
+++ b/py/tests/unit/update_append_patch.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+
+# Copyright 2017-present, The Visdom Authors
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Append updates, which build their patch instead of diffing the pane.
+
+A wrong patch here wouldn't raise anything -- the frontend just applies it and
+the pane drifts from the data. So rather than assert on the patch contents,
+these check against the diff implementation that used to do this: same
+resulting pane, and applying the patch to the old pane gives the new one.
+"""
+
+import copy
+import json
+
+import jsonpatch
+import pytest
+
+from visdom.server.handlers.web_handlers import (
+    UpdateHandler,
+    _planned_extensions,
+    pane_fits_in,
+)
+
+pytestmark = pytest.mark.unit
+
+
+MAXES = (100, 10, 10, 10)
+
+# what the client actually sends for a bare vis.line(..., update='append') --
+# opts is never empty, the defaults get filled in
+CLIENT_OPTS = {
+    "markers": False,
+    "fillarea": False,
+    "mode": "lines",
+    "markersymbol": "dot",
+    "markersize": 10,
+    "markerborderwidth": 0.5,
+}
+
+
+def reference_update_packet(p, args):
+    """update_packet() as it was before the append fast path."""
+    old_p = p.copy()
+    if "content" in p:
+        old_p["content"] = copy.deepcopy(p["content"])
+    if "old_content" in p:
+        old_p["old_content"] = copy.deepcopy(p["old_content"])
+    p = UpdateHandler.update(p, args, *MAXES)
+    p["contentID"] = "fixed-content-id"
+    return p, jsonpatch.make_patch(old_p, p).patch
+
+
+def plot_pane(points=3, traces=1, trace_type="scatter", marker_color=False):
+    data = []
+    for index in range(traces):
+        trace = {
+            "x": [float(i) for i in range(points)],
+            "y": [i * 0.1 for i in range(points)],
+            "name": str(index + 1),
+            "type": trace_type,
+            "mode": "lines",
+            "marker": {"size": 10, "symbol": "dot"},
+        }
+        if trace_type == "scatter3d":
+            trace["z"] = [i * 0.2 for i in range(points)]
+        if marker_color:
+            trace["marker"]["color"] = ["#ff0000"] * points
+        data.append(trace)
+    return {
+        "id": "w",
+        "type": "plot",
+        "contentID": "before",
+        "version": 1,
+        "title": "loss",
+        "content": {"data": data, "layout": {"title": "loss"}, "caption": None},
+        "layout": {},
+    }
+
+
+def sample(name="1", trace_type="scatter", count=1, marker_color=False, x=None):
+    trace = {
+        "x": [99.0] * count if x is None else x,
+        "y": [0.5] * count,
+        "name": name,
+        "type": trace_type,
+        "mode": "lines",
+        "marker": {"size": 10, "symbol": "dot"},
+    }
+    if trace_type == "scatter3d":
+        trace["z"] = [0.7] * count
+    if marker_color:
+        trace["marker"]["color"] = ["#0000ff"] * count
+    return trace
+
+
+def append_args(data, **extra):
+    args = {
+        "win": "w",
+        "append": True,
+        "name": None,
+        "layout": {},
+        "opts": dict(CLIENT_OPTS),
+        "data": data,
+    }
+    args.update(extra)
+    return args
+
+
+# handled by the fast path
+FAST_CASES = {
+    "plain append": (plot_pane(), append_args([sample()])),
+    "several samples at once": (plot_pane(), append_args([sample(count=4)])),
+    "an opt changes too": (
+        plot_pane(),
+        append_args([sample()], opts=dict(CLIENT_OPTS, title="new title")),
+    ),
+    "a caption changes too": (
+        plot_pane(),
+        append_args([sample()], opts=dict(CLIENT_OPTS, caption="cap")),
+    ),
+    "the layout changes too": (
+        plot_pane(),
+        append_args([sample()], layout={"showlegend": True}),
+    ),
+    "two traces": (
+        plot_pane(traces=2),
+        append_args([sample("1"), sample("2")]),
+    ),
+    "one named trace": (
+        plot_pane(traces=2),
+        append_args([sample("2")], name="2"),
+    ),
+    "a 3d trace": (
+        plot_pane(trace_type="scatter3d"),
+        append_args([sample(trace_type="scatter3d")]),
+    ),
+    "per-point marker colours": (
+        plot_pane(marker_color=True),
+        append_args([sample(marker_color=True)]),
+    ),
+    "a masked (all-NaN) sample": (
+        plot_pane(),
+        append_args([sample(x=[float("nan")])]),
+    ),
+    "fewer entries than the pane has traces": (
+        plot_pane(traces=3),
+        append_args([sample("1")]),
+    ),
+}
+
+# not plain appends -- these have to reach the differ untouched
+FALLBACK_CASES = {
+    "a replace rather than an append": (
+        plot_pane(),
+        append_args([sample()], append=False),
+    ),
+    "a trace deletion": (
+        plot_pane(traces=2),
+        append_args([sample("2")], delete=True, name="2"),
+    ),
+    "a named trace that does not exist yet": (
+        plot_pane(),
+        append_args([sample("new")], name="new"),
+    ),
+    "a legend rename": (
+        plot_pane(traces=2),
+        append_args(
+            [sample("1"), sample("2")],
+            opts=dict(CLIENT_OPTS, legend=["a", "b"]),
+        ),
+    ),
+    "a heatmap": (
+        {
+            "id": "w",
+            "type": "plot",
+            "contentID": "before",
+            "version": 1,
+            "content": {
+                "data": [
+                    {"type": "heatmap", "z": [[1, 2], [3, 4]], "x": None, "y": None}
+                ],
+                "layout": {},
+            },
+            "layout": {},
+        },
+        append_args(
+            [{"type": "heatmap", "z": [[5, 6]], "x": None, "y": None}],
+            updateDir="appendRow",
+        ),
+    ),
+    "a text pane": (
+        {
+            "id": "w",
+            "type": "text",
+            "contentID": "before",
+            "version": 1,
+            "content": "hello",
+            "layout": {},
+        },
+        append_args([{"content": "world", "type": "text"}]),
+    ),
+}
+
+ALL_CASES = dict(FAST_CASES, **FALLBACK_CASES)
+
+
+def normalized(pane):
+    """Pin the random content id so two runs compare equal."""
+    pane = dict(pane)
+    pane["contentID"] = "fixed-content-id"
+    return json.loads(json.dumps(pane, default=str))
+
+
+@pytest.mark.parametrize("label", sorted(FAST_CASES))
+def test_fast_path_is_taken_for_appends(label):
+    pane, args = FAST_CASES[label]
+    assert _planned_extensions(copy.deepcopy(pane), copy.deepcopy(args)) is not None
+
+
+@pytest.mark.parametrize("label", sorted(FALLBACK_CASES))
+def test_other_updates_fall_back_to_the_differ(label):
+    pane, args = FALLBACK_CASES[label]
+    assert _planned_extensions(copy.deepcopy(pane), copy.deepcopy(args)) is None
+
+
+@pytest.mark.parametrize("label", sorted(ALL_CASES))
+def test_pane_matches_the_implementation_it_replaced(label):
+    pane, args = ALL_CASES[label]
+    fast, _ = UpdateHandler.update_packet(
+        copy.deepcopy(pane), copy.deepcopy(args), *MAXES
+    )
+    slow, _ = reference_update_packet(copy.deepcopy(pane), copy.deepcopy(args))
+    assert normalized(fast) == normalized(slow)
+
+
+@pytest.mark.parametrize("label", sorted(ALL_CASES))
+def test_patch_rebuilds_the_updated_pane(label):
+    """Subscribers get the patch instead of the pane, so it has to carry the
+    same update."""
+    pane, args = ALL_CASES[label]
+    updated, ops = UpdateHandler.update_packet(
+        copy.deepcopy(pane), copy.deepcopy(args), *MAXES
+    )
+    rebuilt = jsonpatch.JsonPatch(ops).apply(copy.deepcopy(pane))
+    assert normalized(rebuilt) == normalized(updated)
+
+
+def test_appending_does_not_diff_the_samples(monkeypatch):
+    """Regression guard for the quadratic.
+
+    Timing this would be flaky, so check the cause instead: whatever reaches
+    make_patch has to be the same size at 10 points and at 10k, which only
+    holds if the sample arrays never get there.
+    """
+    seen = []
+    real_make_patch = jsonpatch.make_patch
+
+    def recording_make_patch(src, dst):
+        seen.append(len(json.dumps(src, default=str)))
+        return real_make_patch(src, dst)
+
+    monkeypatch.setattr(jsonpatch, "make_patch", recording_make_patch)
+
+    sizes = []
+    for points in (10, 10000):
+        seen.clear()
+        UpdateHandler.update_packet(
+            plot_pane(points=points), append_args([sample()]), *MAXES
+        )
+        sizes.append(sum(seen))
+
+    assert sizes[0] == sizes[1]
+
+
+def test_patch_size_does_not_grow_with_the_plot():
+    counts = []
+    for points in (10, 10000):
+        _, ops = UpdateHandler.update_packet(
+            plot_pane(points=points), append_args([sample()]), *MAXES
+        )
+        counts.append(len(ops))
+    assert counts[0] == counts[1]
+
+
+def test_appended_samples_land_at_the_end():
+    pane = plot_pane(points=3)
+    updated, _ = UpdateHandler.update_packet(
+        pane, append_args([sample(count=2)]), *MAXES
+    )
+    trace = updated["content"]["data"][0]
+    assert trace["x"] == [0.0, 1.0, 2.0, 99.0, 99.0]
+    assert trace["y"] == [0.0, 0.1, 0.2, 0.5, 0.5]
+
+
+def test_pane_fits_in_answers_the_size_question():
+    small = {"a": 1}
+    assert pane_fits_in(small, 10_000) is True
+    assert pane_fits_in({"a": "x" * 100}, 10) is False
+
+
+def test_pane_fits_in_stops_once_the_limit_is_passed():
+    """A pane far past the limit shouldn't be serialized in full to find out."""
+    big = {"data": ["x" * 1000 for _ in range(1000)]}
+    encoded = len(json.dumps(big, separators=(",", ":")))
+    assert encoded > 1_000_000
+    assert pane_fits_in(big, 50) is False

--- a/py/visdom/server/handlers/web_handlers.py
+++ b/py/visdom/server/handlers/web_handlers.py
@@ -123,11 +123,202 @@ class ExistsHandler(BaseHandler):
         self.wrap_func(self, args)
 
 
+# ---- Fast path for append updates ---- #
+#
+# update_packet() normally deep-copies the pane and diffs the copy to get its
+# JSON Patch, which costs the whole pane on every call. An append is the one
+# update where the patch is known up front (new samples go on the end of the
+# arrays), so we build it directly and skip the copy and the diff.
+#
+# Anything that isn't a plain append returns None and falls back to the diff.
+# Worth keeping that net wide: a bad patch doesn't raise, the frontend just
+# applies it and the pane silently goes out of sync with the data.
+
+# Panes whose content isn't a list of traces.
+_NON_TRACE_PANE_TYPES = frozenset(
+    {"text", "image_history", "plot_history", "embeddings", "table"}
+)
+
+
+def _pane_head(p):
+    """Copy of the pane without `content`, which is the only part that grows."""
+    return {key: copy.deepcopy(value) for key, value in p.items() if key != "content"}
+
+
+def _content_head(content):
+    """Copy of `content` without `data`, same idea."""
+    return {
+        key: copy.deepcopy(value) for key, value in content.items() if key != "data"
+    }
+
+
+def _reroot(ops, prefix):
+    """Move ops built against a sub-document to `prefix`."""
+    for op in ops:
+        op["path"] = prefix + op["path"]
+    return ops
+
+
+def _planned_extensions(p, args):
+    """Arrays this append will extend, or None if it isn't a plain append.
+
+    Runs before anything is mutated, so a rejected update reaches the diff path
+    with the pane untouched. Each entry is (json pointer, the live list, values).
+    """
+    if not args.get("append") or args.get("delete"):
+        return None
+    if p.get("type") in _NON_TRACE_PANE_TYPES or "old_content" in p:
+        return None
+
+    content = p.get("content")
+    if not isinstance(content, dict):
+        return None
+    pdata = content.get("data")
+    if not isinstance(pdata, list) or not pdata:
+        return None
+
+    new_data = args.get("data")
+    if not isinstance(new_data, list) or not new_data:
+        return None
+    # legend renames traces rather than extending them
+    if "legend" in (args.get("opts") or {}):
+        return None
+
+    name = args.get("name")
+    if name is None:
+        idxs = range(len(pdata))
+    else:
+        idxs = [
+            i
+            for i, trace in enumerate(pdata)
+            if isinstance(trace, dict) and trace.get("name") == name
+        ]
+        # a missing named trace gets injected by update(), and a named update
+        # carrying more than one entry is rejected there
+        if len(idxs) != 1 or len(new_data) != 1:
+            return None
+
+    extensions = []
+    for idx, new_trace in zip(idxs, new_data):
+        trace = pdata[idx]
+        if not isinstance(trace, dict) or not isinstance(new_trace, dict):
+            return None
+        # heatmaps rewrite the z grid by direction instead of appending
+        if "heatmap" in (trace.get("type"), new_trace.get("type")):
+            return None
+
+        xs = new_trace.get("x")
+        if not isinstance(xs, list):
+            return None
+        # all-missing x is a masked update, which update() skips
+        if all(_is_missing_value(value) for value in xs):
+            continue
+
+        axes = ["x", "y"]
+        if trace.get("type") == "scatter3d":
+            axes.append("z")
+        for axis in axes:
+            current, added = trace.get(axis), new_trace.get(axis)
+            if not isinstance(current, list) or not isinstance(added, list):
+                return None
+            extensions.append(
+                ("/content/data/{0}/{1}".format(idx, axis), current, added)
+            )
+
+        marker = new_trace.get("marker")
+        if isinstance(marker, dict) and "color" in marker:
+            current_marker = trace.get("marker")
+            if not isinstance(current_marker, dict):
+                return None
+            current, added = current_marker.get("color"), marker["color"]
+            if not isinstance(current, list) or not isinstance(added, list):
+                return None
+            extensions.append(
+                ("/content/data/{0}/marker/color".format(idx), current, added)
+            )
+
+    return extensions
+
+
+def append_patch(p, args):
+    """Apply an append to `p` in place and return (p, ops), or None.
+
+    None means it wasn't a plain append; the caller should fall back to
+    update() plus a diff.
+
+    Only the sample arrays are handled by hand. The opts/layout/caption that
+    update_window() touches are still diffed, just against copies with the
+    sample data left out, so this can't drift from what the slow path reports.
+    """
+    extensions = _planned_extensions(p, args)
+    if extensions is None:
+        return None
+
+    content = p["content"]
+    old_pane_head = _pane_head(p)
+    old_content_head = _content_head(content)
+
+    ops = []
+    for path, current, added in extensions:
+        # update() does `trace[axis] + new[axis]`, rebuilding the array every
+        # time; extending in place is what keeps this O(samples added)
+        start = len(current)
+        current.extend(added)
+        for offset, value in enumerate(added):
+            ops.append(
+                {
+                    "op": "add",
+                    "path": "{0}/{1}".format(path, start + offset),
+                    "value": value,
+                }
+            )
+
+    # opts have to be applied before we diff for them. Op order doesn't matter
+    # to the client, every path here is distinct.
+    p = update_window(p, args)
+    p["contentID"] = get_rand_id()
+
+    head_ops = jsonpatch.make_patch(old_pane_head, _pane_head(p)).patch
+    content_ops = _reroot(
+        jsonpatch.make_patch(old_content_head, _content_head(content)).patch,
+        "/content",
+    )
+    return p, head_ops + content_ops + ops
+
+
+_COMPACT_ENCODER = json.JSONEncoder(separators=(",", ":"))
+
+
+def pane_fits_in(p, limit):
+    """Whether the serialized pane is at most `limit` bytes.
+
+    Encodes incrementally and bails at the first chunk past `limit`, so we stop
+    paying for a full serialization we only wanted a length from.
+
+    Measures the pane raw rather than through stringify(), which would have to
+    build the ordered structure first. That ordering only ever shortens things
+    (integral floats render as ints, sorting keys doesn't change length), so
+    anything that fits here fits there too. The reverse can miss by a few bytes
+    and we send the patch instead of the pane, which is fine.
+    """
+    total = 0
+    for chunk in _COMPACT_ENCODER.iterencode(p):
+        total += len(chunk)
+        if total > limit:
+            return False
+    return True
+
+
 class UpdateHandler(BaseHandler):
     @staticmethod
     def update_packet(
         p, args, max_text_lines, max_old_content, max_image_history, max_plot_history
     ):
+        # appends build their own patch; everything else falls through
+        appended = append_patch(p, args)
+        if appended is not None:
+            return appended
+
         # Shallow copy the packet to dynamically capture changes to top-level keys.
         old_p = p.copy()
 
@@ -491,7 +682,7 @@ class UpdateHandler(BaseHandler):
                 return
             raise
         # send the smaller of the patch and the updated pane
-        if len(stringify(p)) <= len(stringify(diff_packet)):
+        if pane_fits_in(p, len(stringify(diff_packet))):
             broadcast_msg = dict(p)
             broadcast_msg["eid"] = eid
             broadcast(handler, json.dumps(broadcast_msg, cls=NanSafeEncoder), eid)


### PR DESCRIPTION
## Description
#1805 

This PR fixes the performance issue described in #1805.

The main problem was that `update_packet()` was deep-copying the whole pane and then using `jsonpatch.make_patch()` to find the change for every append. On top of that, `wrap_func()` was serializing the whole pane again just to compare its size with the generated patch.

For a line plot that keeps getting new points, both operations get more expensive as the plot grows. So appending one point ends up doing work on all the points already in the pane.

Since an append is predictable, there is no need to diff the whole pane. The new samples are always added at the end of their respective arrays, so the patch can be built directly.

### What changed

- Added `append_patch()` to build the JSON Patch directly for append updates.
- `update_window()` still handles changes to `opts`, `layout`, and `caption`, but those parts are diffed separately so the append fast path only deals with the sample data.
- Added `pane_fits_in()` to replace the full `stringify(p)` call. It checks the encoded size incrementally instead of serializing the entire pane first.
- If an update is not safe to handle as an append, it falls back to the existing diff implementation.

Both changes are needed here. Removing only the `stringify(p)` call makes the update faster, but the deepcopy + `make_patch()` still scans the whole pane on every append, so the overall behaviour is still O(n²).

### Benchmark

I measured appending one point at a time to the same line plot before and after the change:

```
500 appends ->  0.185s  (0.37 ms/update)
1000 appends ->  0.685s  (0.68 ms/update)
2000 appends ->  2.687s  (1.34 ms/update)
4000 appends ->  9.965s  (2.49 ms/update)
```


## How Has This Been Tested?

Unit tests verify that:

- Append updates generate the expected patch without diffing the sample data.
- The fast path produces the same final pane as the existing diff-based implementation.
- Applying the generated patch to the old pane produces the same result as the updated pane.
- Supported append updates work correctly across the different line plot update shapes.
- Unsupported update types fall back to the existing diff implementation.
- The existing behaviour is preserved for updates that cannot safely use the append fast path.

The performance regression test does not rely on elapsed time, since timing-based tests can be flaky. Instead, it verifies that the sample data is not passed to `make_patch()` as the number of points grows from 10 to 10k.

The benchmark was also run before and after the change using the same line plot update pattern.

## Screenshots (if appropriate):

Not applicable.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactor or cleanup (changes to existing code for improved performance)

## Checklist:

- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Summary

### Bug Fixes

- Avoid deep-copying and diffing the entire pane for append-only line plot updates.
- Build append patches directly from the existing sample array lengths.
- Avoid serializing the entire pane when checking whether the patch fits within the configured size limit.
- Keep unsupported update types on the existing diff-based path.

### Performance

- Reduce append update complexity from O(n²) to O(n) over a sequence of n appends.
- Benchmark shows the new implementation is about 60x faster at 8000 points.
- The performance gap increases as the plot grows.

### Tests

- Add coverage for append patch generation across supported update shapes.
- Compare the fast path against the existing diff implementation.
- Verify generated patches reconstruct the expected updated pane.
- Add a regression guard to ensure large sample arrays are not passed to `make_patch()`.
- Full test suite passes: 2177 tests.
- `black --check` passes.

## Summary by Sourcery

Optimize append updates by generating sample patches directly and avoiding full-pane serialization during size checks.

Bug Fixes:
- Avoid full-pane copying and diffing for safe append-only plot updates while preserving the existing fallback behavior for unsupported updates.

Enhancements:
- Build JSON patches directly for appended trace samples and check pane size incrementally to improve performance as plots grow.

Tests:
- Add comprehensive coverage comparing fast-path results and patches with the existing diff-based implementation, including supported appends, fallbacks, and size-check behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved incremental plot updates by reducing the size and generation time of append-only updates.
  * Added automatic fallback handling for updates that require full recalculation.
* **Bug Fixes**
  * Improved payload-size checks when choosing between sending an update or a complete pane.
  * Preserved existing trace styling when appending new data.
* **Tests**
  * Added coverage for append updates, fallback scenarios, patch reconstruction, payload growth, and pane size checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->