### PR TITLE
fix: keep numbers ahead of other types when ranking experiments descending

### DIFF
--- a/py/tests/unit/experiment_store.py
+++ b/py/tests/unit/experiment_store.py
@@ -499,6 +499,26 @@ def test_a_string_never_outranks_the_highest_number(experiments):
     assert _ranked(experiments, descending=False) == ["run_five", "run_ten", "run_str"]
 
 
+def test_a_bounded_page_is_not_filled_by_a_string(experiments):
+    """The heap path ranks like the sort path, so a page keeps the numbers.
+
+    ``search_page`` selects through ``heapq`` rather than sorting, on the same
+    key. Ranking a string first there does not merely misorder the page: it
+    takes a slot, evicting a run that belongs on it.
+    """
+    experiments.log_experiment("run_five", params={"acc": 5})
+    experiments.log_experiment("run_ten", params={"acc": 10})
+    experiments.log_experiment("run_str", params={"acc": "pending"})
+
+    page, total = experiments.search_page(sort_by="acc", descending=True, limit=2)
+    assert [experiment.env_id for experiment in page] == ["run_ten", "run_five"]
+    assert total == 3
+
+    page, total = experiments.search_page(sort_by="acc", descending=False, limit=2)
+    assert [experiment.env_id for experiment in page] == ["run_five", "run_ten"]
+    assert total == 3
+
+
 def test_equal_values_keep_their_scan_order_in_both_directions(experiments):
     """Reversing the comparison must not reverse ties."""
     for env_id in ("first", "second", "third"):

--- a/py/tests/unit/experiment_store.py
+++ b/py/tests/unit/experiment_store.py
@@ -473,3 +473,36 @@ def test_log_returns_experiment_but_read_is_empty():
     assert isinstance(store.log_experiment("main", params={"lr": 0.01}), Experiment)
     assert store.get_experiment("main") is None
     assert store.list_experiments() == []
+
+
+# -- ranking a field that holds mixed types -----------------------------------
+
+
+def _ranked(experiments, descending):
+    result = experiments.search(sort_by="acc", descending=descending)
+    found = result["experiments"] if isinstance(result, dict) else result
+    return [experiment.env_id for experiment in found]
+
+
+def test_a_string_never_outranks_the_highest_number(experiments):
+    """Numbers lead in both directions, so a string cannot top the ranking.
+
+    ``_order_key`` tags numbers ahead of everything else; reversing the whole
+    key for a descending sort used to reverse that tag too, putting the run
+    whose value is a string above the run holding the largest number.
+    """
+    experiments.log_experiment("run_five", params={"acc": 5})
+    experiments.log_experiment("run_ten", params={"acc": 10})
+    experiments.log_experiment("run_str", params={"acc": "pending"})
+
+    assert _ranked(experiments, descending=True) == ["run_ten", "run_five", "run_str"]
+    assert _ranked(experiments, descending=False) == ["run_five", "run_ten", "run_str"]
+
+
+def test_equal_values_keep_their_scan_order_in_both_directions(experiments):
+    """Reversing the comparison must not reverse ties."""
+    for env_id in ("first", "second", "third"):
+        experiments.log_experiment(env_id, params={"acc": 7})
+
+    assert _ranked(experiments, descending=True) == ["first", "second", "third"]
+    assert _ranked(experiments, descending=False) == ["first", "second", "third"]

--- a/py/visdom/experiments/store.py
+++ b/py/visdom/experiments/store.py
@@ -124,9 +124,17 @@ def _rank_key(entry, descending):
     scoring the same keep the order they were scanned in, whichever direction
     the sort runs — the property a stable ``list.sort`` used to provide, which
     selecting through a heap does not.
+
+    The type tag from :func:`_order_key` is negated for the same reason: it
+    groups numbers ahead of everything else, and reversing the comparison would
+    otherwise reverse that grouping too, ranking a run whose value is a string
+    above the run holding the highest number.
     """
     seq, value, _ = entry
-    return (_order_key(value), -seq if descending else seq)
+    kind, number, text = _order_key(value)
+    if descending:
+        return (-kind, number, text, -seq)
+    return (kind, number, text, seq)
 
 
 def _rank(entries, descending, keep=None):


### PR DESCRIPTION
## Description

ISSUE:- #1819

`_rank_key` returned `_order_key(value)` as the leading element of the sort key and `_rank` applied `reverse=descending` to the whole key. `_order_key`'s first element is a type tag — `0` for numbers, `1` for everything else — so reversing the comparison reversed the grouping too, ranking a run whose value is text above the run holding the highest number.

The tag is now negated for a descending sort, the same technique the function already used for the `seq` tie-breaker. Fixed in `_rank_key` rather than `_rank` because `_rank` has two paths — `sorted(reverse=)` and `heapq.nlargest` — and both were affected.

## Motivation and Context

A field can be numeric on some runs and text on others — a crashed run logged as `"failed"`, a pending one as `"n/a"`. "Show my best runs" then puts a run with no score at the top:

```python
store.log_experiment("baseline", params={"accuracy": 0.72})
store.log_experiment("tuned",    params={"accuracy": 0.91})
store.log_experiment("crashed",  params={"accuracy": "failed"})

store.search(sort_by="accuracy", descending=True)
# actual:   ['crashed', 'tuned', 'baseline']
# expected: ['tuned', 'baseline', 'crashed']
```

With paging it is worse: the heap selects on the same key and evicts real numeric results.

```python
store.search_page(sort_by="accuracy", descending=True, limit=2)
# → ['crashed', 'tuned']   — 'baseline' dropped for a run with no score
```

Ascending is correct; only descending is affected, and nothing warns.

## How Has This Been Tested?

- 28 ranking scenarios: numbers only, mixed number/text, several strings, ties in both directions, booleans, empty and single-entry lists, negatives and floats, `keep` larger than the list, and end-to-end through `search()`
- Confirmed both `_rank` paths were affected before the fix and both are correct after
- Tie stability preserved in both directions
- Two regression tests added to `py/tests/unit/experiment_store.py`, verified to fail against the pre-fix code (`'run_str' != 'run_ten'`) and pass with it
- `pytest -m "not server"` and `black --check` clean. The remaining failures on my machine are pre-existing Windows `MAX_PATH` ones in `data_model.py` and friends, which also fail on a clean `dev` checkout here and pass on the Linux runners.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor or cleanup (changes to existing code for improved readability or performance)

## Checklist:

- [ ] I adapted the version number under `py/visdom/VERSION` according to [Semantic Versioning](https://semver.org/)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Summary by Sourcery

Preserve numeric-first ranking semantics for descending experiment searches and pagination.

Bug Fixes:
- Keep numeric experiment values ranked ahead of non-numeric values when sorting in descending order, including bounded search pages.

Tests:
- Add regression coverage for mixed-type rankings, bounded pages, and stable ordering of equal values in both sort directions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Corrected experiment sorting by accuracy so numeric values consistently rank ahead of string values in ascending and descending results.
- Fixed paginated experiment results so non-numeric values do not displace higher-ranked numeric results.
- Preserved scan order when experiments have equal accuracy values, ensuring stable results in both sorting directions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->